### PR TITLE
feat: Add Kubernetes manifests for Umbraco deployment

### DIFF
--- a/.github/workflows/publish-syncroot-main.yaml
+++ b/.github/workflows/publish-syncroot-main.yaml
@@ -1,0 +1,64 @@
+name: Publish Syncroot artifacts
+run-name: Deploy ${{ inputs.image-tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Select environment"
+        type: choice
+        options:
+          - tt02
+          - prod
+      image-tag:
+        description: "Umbraco image tag to deploy"
+        required: true
+      database:
+        type: choice
+        description: "Select database"
+        options:
+          - Sqlite
+          - AzureSQL
+        required: true
+
+env:
+  SYNCROOT_ARTIFACT_NAME: kinorgeportal/syncroot
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-flux-artifacts-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-syncroot:
+    name: Publish syncroot artifact
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Update image tag
+        run: yq -i '(.images[] | select(.name == "umbraco")).newTag = "${{ inputs.image-tag }}"' ./syncroot/${{ inputs.environment }}/kustomization.yaml
+
+      - name: Update db connection string
+        if: inputs.database == 'AzureSQL'
+        run: yq -i '(.spec.template.spec.containers[0].env[] | select(.name == "ConnectionStrings__umbracoDbDSN")).value = "Server=tcp:${UMBRACO_SQL_CONN_FQDN},1433;Initial Catalog=umbraco;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=\"Active Directory Default\""' ./syncroot/base/umbraco/deployment.yaml
+
+      - name: Update db provider
+        if: inputs.database == 'AzureSQL'
+        run: yq -i '(.spec.template.spec.containers[0].env[] | select(.name == "ConnectionStrings__umbracoDbDSN_ProviderName")).value = "Microsoft.Data.SqlClient"' ./syncroot/base/umbraco/deployment.yaml
+
+      - name: Build and push syncroot artifact
+        uses: Altinn/altinn-platform/actions/flux/build-push-image@8d4e42eae11efbc3a159aa62fe15ed49954d9df9 # main
+        with:
+          image_name: ${{ env.SYNCROOT_ARTIFACT_NAME }}
+          tag: ${{ inputs.environment }}
+          workdir: ./syncroot
+          azure_subscription_id: ${{ secrets.DIS_SYNCROOT_AZURE_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.DIS_SYNCROOT_AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.DIS_SYNCROOT_AZURE_TENANT_ID }}
+

--- a/syncroot/README.md
+++ b/syncroot/README.md
@@ -1,0 +1,63 @@
+# Info Portalen (Umbraco) Infrastructure
+
+This directory contains the Kubernetes manifests for the Umbraco CMS implementation of the Info Portalen project.
+
+## TODO
+There are still things that needs to be done before this can be deployed.
+In `syncroot/at22/kustomization.yaml` the team need to define the image name (container registry + repository) and a valid image tag. The current setup is just a dumme value that will not work.
+
+There are still some questions regarding storage and backup. This setup should get you going once you have a public available docker image of umbraco that can be deployed.
+
+I have disbaled the push trigger for the pipeline so it shouldn't publish an deployment before the docker image todos are done.
+
+## Folder Structure
+
+- **base/**: Contains the base Kubernetes resources for the Umbraco stack.
+  - **umbraco/**:
+    - `deployment.yaml`: Defines the Umbraco pod with single replica and `Recreate` strategy.
+    - `service.yaml`: ClusterIP service for internal routing.
+    - `httproute.yaml`: Gateway API routing for external access.
+    - `storage.yaml`: Persistent Volume Claims for data and media.
+    - `serviceaccount.yaml`: Dedicated service account for the Umbraco pod.
+    - `kustomization.yaml`: Orchestrates the resources and applies common labels.
+- **at22/**: Kustomize overlay for the AT22 environment.
+  - `kustomization.yaml`: Applies environment-specific patches (e.g., hostnames, image tags).
+- **tt02/**: Kustomize overlay for the TT02 environment.
+- **prod/**: Kustomize overlay for the Production environment.
+
+## Resources Created
+
+### Deployment
+- **Name**: `umbraco`
+- **Namespace**: `product-infoportal` (inherited from base kustomization)
+- **Replicas**: 1
+- **Strategy**: `Recreate` (required for RWO storage)
+- **Port**: 8080 (named `http`)
+
+### Storage (PVCs)
+1. **umbraco-data**: 
+   - **Size**: 10Gi
+   - **StorageClass**: `managed-csi-premium` (Azure Disk)
+   - **Mount Path**: `/app/umbraco/Data`
+   - **Access Mode**: `ReadWriteOnce`
+2. **umbraco-media**:
+   - **Size**: 50Gi
+   - **StorageClass**: `azurefile-csi-premium` (Azure Files)
+   - **Mount Path**: `/app/umbraco/wwwroot/media`
+   - **Access Mode**: `ReadWriteMany`
+3. **Logs**:
+   - **Type**: `emptyDir`
+   - **Mount Path**: `/app/umbraco/Logs`
+
+### Networking
+- **Service**: ClusterIP on port 80 (targets container port 8080).
+- **HTTPRoute**: Routes traffic via `traefik-gateway` in the `traefik` namespace.
+  - **AT22 Hostname**: `infoportal.at22.dis-core.altinn.cloud`
+
+### Identity
+- **ServiceAccount**: `umbraco` (no additional permissions assigned).
+
+## Labels
+Resources are consistently labeled using Kustomize `commonLabels`:
+- `app.kubernetes.io/name: umbraco`
+- `app.kubernetes.io/part-of: infoportal`

--- a/syncroot/base/kustomization.yaml
+++ b/syncroot/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: product-kinorgeportal
+resources:
+  - umbraco

--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: umbraco
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: umbraco
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: umbraco
+        azure.workload.identity/use: "true"
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        linkerd.io/inject: enabled
+    spec:
+      serviceAccountName: umbraco
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: umbraco
+          image: umbraco:1
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+          env:
+            - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+              value: "true"
+            - name: KeyVault__AkvUri
+              valueFrom:
+                configMapKeyRef:
+                  name: umbraco-dis-vault
+                  key: AkvUri
+            - name: ConnectionStrings__umbracoDbDSN
+              value: "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True"
+            - name: ConnectionStrings__umbracoDbDSN_ProviderName
+              value: "Microsoft.Data.Sqlite"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: umbraco-data
+              mountPath: /app/umbraco/Data
+            - name: umbraco-media
+              mountPath: /app/wwwroot/media
+            - name: umbraco-logs
+              mountPath: /app/umbraco/Logs
+      volumes:
+        - name: umbraco-data
+          persistentVolumeClaim:
+            claimName: umbraco-data
+        - name: umbraco-media
+          persistentVolumeClaim:
+            claimName: umbraco-media
+        - name: umbraco-logs
+          emptyDir: {}

--- a/syncroot/base/umbraco/httproute.yaml
+++ b/syncroot/base/umbraco/httproute.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: umbraco
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: umbraco
+          port: 80

--- a/syncroot/base/umbraco/kustomization.yaml
+++ b/syncroot/base/umbraco/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/part-of: ki-norge-portal
+  app.kubernetes.io/name: umbraco
+
+resources:
+  - storage.yaml
+  - serviceaccount.yaml
+  - vault.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - network-policies.yaml

--- a/syncroot/base/umbraco/kustomization.yaml
+++ b/syncroot/base/umbraco/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 commonLabels:
-  app.kubernetes.io/part-of: ki-norge-portal
+  app.kubernetes.io/part-of: kinorgeportal
   app.kubernetes.io/name: umbraco
 
 resources:

--- a/syncroot/base/umbraco/network-policies.yaml
+++ b/syncroot/base/umbraco/network-policies.yaml
@@ -1,0 +1,49 @@
+apiVersion: policy.linkerd.io/v1beta3
+kind: Server
+metadata:
+  name: umbraco-http-server
+  labels:
+    app.kubernetes.io/name: umbraco
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: umbraco
+  port: http
+  proxyProtocol: HTTP/2
+---
+apiVersion: policy.linkerd.io/v1beta2
+kind: HTTPRoute
+metadata:
+  name: umbraco-http-route
+spec:
+  parentRefs:
+    - name: umbraco-http-server
+      kind: Server
+      group: policy.linkerd.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: umbraco-http-auth
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: HTTPRoute
+    name: umbraco-http-route
+  requiredAuthenticationRefs:
+    - name: traefik
+      kind: MeshTLSAuthentication
+      group: policy.linkerd.io
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  name: traefik
+spec:
+  identities:
+    - "altinn-traefik.traefik.serviceaccount.identity.linkerd.cluster.local"

--- a/syncroot/base/umbraco/service.yaml
+++ b/syncroot/base/umbraco/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: umbraco
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: umbraco
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/syncroot/base/umbraco/serviceaccount.yaml
+++ b/syncroot/base/umbraco/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: umbraco
+  annotations:
+    azure.workload.identity/client-id: ${UMBRACO_CLIENT_ID}
+    azure.workload.identity/tenant-id: cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c
+    dis.altinn.cloud/principal-id: ${UMBRACO_PRINCIPAL_ID}

--- a/syncroot/base/umbraco/storage.yaml
+++ b/syncroot/base/umbraco/storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: umbraco-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: managed-csi-premium
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: umbraco-media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile-csi-premium
+  resources:
+    requests:
+      storage: 50Gi

--- a/syncroot/base/umbraco/vault.yaml
+++ b/syncroot/base/umbraco/vault.yaml
@@ -7,4 +7,4 @@ spec:
     name: umbraco
   groupObjectId: b5949ea9-f3dc-4fd8-9dca-37e997b60c63 # DIS AKS Admin Dev KIN
   tags:
-    app: ki-norge-portal
+    app: kinorgeportal

--- a/syncroot/base/umbraco/vault.yaml
+++ b/syncroot/base/umbraco/vault.yaml
@@ -1,0 +1,10 @@
+apiVersion: vault.dis.altinn.cloud/v1alpha1
+kind: Vault
+metadata:
+  name: umbraco
+spec:
+  serviceAccountRef:
+    name: umbraco
+  groupObjectId: ${KINORGE_VAULT_GROUP_OBJECT_ID}
+  tags:
+    app: ki-norge-portal

--- a/syncroot/base/umbraco/vault.yaml
+++ b/syncroot/base/umbraco/vault.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   serviceAccountRef:
     name: umbraco
-  groupObjectId: ${KINORGE_VAULT_GROUP_OBJECT_ID}
+  groupObjectId: b5949ea9-f3dc-4fd8-9dca-37e997b60c63 # DIS AKS Admin Dev KIN
   tags:
     app: ki-norge-portal

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms.ki.norge.no
+          value: https://cms.prod.ki.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
@@ -49,4 +49,4 @@ patches:
         path: /spec/hostnames
         value:
           - kinorgeportal.prod.dis-core.altinn.cloud
-          - cms.ki.norge.no
+          - cms.prod.ki.norge.no

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -1,0 +1,52 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: product-kinorgeportal
+resources:
+  - ../base
+
+images:
+- name: umbraco
+  newName: altinncr.azurecr.io/product-kinorgeportal/umbraco
+  newTag: will-be-replaced
+
+patches:
+  - target:
+      kind: Vault
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/tags/env
+        value: prod
+  - target:
+      kind: Deployment
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://kinorgeportal.prod.dis-core.altinn.cloud
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__Security__BackOfficeHost
+          value: https://cms.ki.norge.no
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__Storage__AzureBlob__Media__ConnectionString
+          value: ${KINORGE_MEDIA_STORAGE_PROD_URL}
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__Storage__AzureBlob__Media__ContainerName
+          value: umbraco
+  - target:
+      kind: HTTPRoute
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/hostnames
+        value:
+          - kinorgeportal.prod.dis-core.altinn.cloud
+          - cms.ki.norge.no

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms.prod.ki.norge.no
+          value: https://cms.ki.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
@@ -49,4 +49,4 @@ patches:
         path: /spec/hostnames
         value:
           - kinorgeportal.prod.dis-core.altinn.cloud
-          - cms.prod.ki.norge.no
+          - cms.ki.norge.no

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -35,7 +35,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__Storage__AzureBlob__Media__ConnectionString
-          value: ${KINORGE_MEDIA_STORAGE_PROD_URL}
+          value: https://kinorgemediaprodbzrw.blob.core.windows.net
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms.tt02.ki.norge.no
+          value: https://cms.test.ki.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
@@ -49,4 +49,4 @@ patches:
         path: /spec/hostnames
         value:
           - kinorgeportal.tt02.dis-core.altinn.cloud
-          - cms.tt02.ki.norge.no
+          - cms.test.ki.norge.no

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms.test.ki.norge.no
+          value: https://cms.ki.test.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
@@ -49,4 +49,4 @@ patches:
         path: /spec/hostnames
         value:
           - kinorgeportal.tt02.dis-core.altinn.cloud
-          - cms.test.ki.norge.no
+          - cms.ki.test.norge.no

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -1,0 +1,52 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: product-kinorgeportal
+resources:
+  - ../base
+
+images:
+  - name: umbraco
+    newName: altinncr.azurecr.io/product-kinorgeportal/umbraco
+    newTag: will-be-replaced
+
+patches:
+  - target:
+      kind: Vault
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/tags/env
+        value: tt02
+  - target:
+      kind: Deployment
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://kinorgeportal.tt02.dis-core.altinn.cloud
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__Security__BackOfficeHost
+          value: https://cms.tt02.ki.norge.no
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__Storage__AzureBlob__Media__ConnectionString
+          value: ${KINORGE_MEDIA_STORAGE_TT02_URL}
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__Storage__AzureBlob__Media__ContainerName
+          value: umbraco
+  - target:
+      kind: HTTPRoute
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/hostnames
+        value:
+          - kinorgeportal.tt02.dis-core.altinn.cloud
+          - cms.tt02.ki.norge.no

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -35,7 +35,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__Storage__AzureBlob__Media__ConnectionString
-          value: ${KINORGE_MEDIA_STORAGE_TT02_URL}
+          value: https://kinorgemediatt0240c8.blob.core.windows.net
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:


### PR DESCRIPTION
Syncroot infrastructure with Kustomize overlays for TT02 and production environments. Includes base deployment, storage, networking, and GitHub Actions workflow for publishing artifacts with configurable database (SQLite or Azure SQL) and environment selection.

<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
