### PR TITLE
Drop stale /sandkasse/prosjekter from llm.txt

### DIFF
--- a/apps/frontend/public/llm.txt
+++ b/apps/frontend/public/llm.txt
@@ -46,16 +46,6 @@ Mange sider henter innhold fra Strapi CMS. Hvis CMS ikke er tilgjengelig eller i
 - Forventet (uten CMS):
   - H1: "Siden er ikke tilgjengelig"
 
-### /sandkasse/prosjekter
-- Forventet (med CMS):
-  - H1: Tittel fra CMS
-- Forventet (uten CMS):
-  - H1: "Prosjekter kommer snart"
-
-### /sandkasse/prosjekter/[slug]
-- Type: Dynamisk generert fra Strapi CMS
-- Krever publisert innhold i CMS for å fungere
-
 ### /eksempler
 - Forventet:
   - H1: "Gode eksempler"


### PR DESCRIPTION
Route was removed during the Sandkasse redesign — `src/pages/sandkasse/` only has `index.astro`, and prod returns 404. The dynamic `[slug]` entry also referenced "Strapi CMS" (we use Umbraco).

Fixes the routes.spec.ts smoke test failure surfaced while verifying the Astro 6 bump (#215).

🤖 Generated with [Claude Code](https://claude.com/claude-code)