### PR TITLE
CMS: add EnkelVeiledning content type (article-style guide)

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -1500,10 +1500,6 @@ public class ContentTypeComponent : IAsyncComponent
         return ct;
     }
 
-    // Enkel veiledningsmal: artikkel-lignende veiledning uten understeg eller
-    // flerstegsstruktur. Brukes når veiledningen er én sammenhengende side.
-    // Lever under veiledninger-containeren ved siden av veiledningGuide.
-    // URL: /veiledning/<slug>.
     private IContentType CreateEnkelVeiledning()
     {
         var ct = new ContentType(_shortStringHelper, -1)
@@ -2141,7 +2137,6 @@ public class ContentTypeComponent : IAsyncComponent
             changed = true;
         }
 
-        // Allowed children: oversikt + guide + enkelVeiledning (steg lever under guide).
         var oversiktType = _contentTypeService.Get("veiledningOversikt");
         var guideType = _contentTypeService.Get("veiledningGuide");
         var enkelType = _contentTypeService.Get("enkelVeiledning");

--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -175,6 +175,8 @@ public class ContentTypeComponent : IAsyncComponent
             if (_contentTypeService.Get("veiledningSteg") == null)
                 CreateVeiledningSteg();
             MigrateVeiledningSteg();
+            if (_contentTypeService.Get("enkelVeiledning") == null)
+                CreateEnkelVeiledning();
             if (_contentTypeService.Get("faq") == null)
                 CreateFAQ();
             if (_contentTypeService.Get("forside") == null)
@@ -1498,6 +1500,33 @@ public class ContentTypeComponent : IAsyncComponent
         return ct;
     }
 
+    // Enkel veiledningsmal: artikkel-lignende veiledning uten understeg eller
+    // flerstegsstruktur. Brukes når veiledningen er én sammenhengende side.
+    // Lever under veiledninger-containeren ved siden av veiledningGuide.
+    // URL: /veiledning/<slug>.
+    private IContentType CreateEnkelVeiledning()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        {
+            Alias = "enkelVeiledning",
+            Name = "Enkel veiledningsmal",
+            Description = "Veiledning som artikkel — uten understeg eller flersides struktur. Bruk denne når veiledningen er én side med løpende innhold.",
+            Icon = "icon-readonly",
+            AllowedAsRoot = false,
+        };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        AddArtikkelhodeFields(ct);
+        ct.AddPropertyType(Prop("innhold", "Innhold", _blockListArtikkelDt, description: "Hovedinnhold — samme moduler som artikler.", sortOrder: 5), "innhold");
+
+        ct.AddPropertyGroup("seo", "SEO");
+        ct.AddPropertyType(Prop("seoTittel", "SEO-tittel", _textStringDt, description: "Overstyr tittel i søkeresultater og sosiale medier"), "seo");
+        ct.AddPropertyType(Prop("seoBeskrivelse", "SEO-beskrivelse", _textAreaDt, description: "Overstyr beskrivelse i søkeresultater og sosiale medier"), "seo");
+        ct.AddPropertyType(Prop("seoBilde", "SEO-bilde", _mediaPickerDt, description: "Bilde som vises ved deling på sosiale medier"), "seo");
+        SetStandardGroupSortOrders(ct);
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
     private IContentType CreateFAQ()
     {
         var ct = new ContentType(_shortStringHelper, -1)
@@ -2111,16 +2140,21 @@ public class ContentTypeComponent : IAsyncComponent
             changed = true;
         }
 
-        // Update allowed children: oversikt + guide (steg goes under guide, not in container)
+        // Allowed children: oversikt + guide + enkelVeiledning (steg lever under guide).
         var oversiktType = _contentTypeService.Get("veiledningOversikt");
         var guideType = _contentTypeService.Get("veiledningGuide");
+        var enkelType = _contentTypeService.Get("enkelVeiledning");
         if (oversiktType != null && guideType != null)
         {
-            var desired = new[]
+            var list = new List<ContentTypeSort>
             {
-                new ContentTypeSort(oversiktType.Key, 0, oversiktType.Alias),
-                new ContentTypeSort(guideType.Key, 1, guideType.Alias)
+                new(oversiktType.Key, 0, oversiktType.Alias),
+                new(guideType.Key, 1, guideType.Alias),
             };
+            if (enkelType != null)
+                list.Add(new(enkelType.Key, 2, enkelType.Alias));
+
+            var desired = list.ToArray();
             var current = ct.AllowedContentTypes?.OrderBy(a => a.Alias).Select(a => a.Alias).ToArray() ?? Array.Empty<string>();
             var want = desired.OrderBy(a => a.Alias).Select(a => a.Alias).ToArray();
             if (!current.SequenceEqual(want))

--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -2096,6 +2096,7 @@ public class ContentTypeComponent : IAsyncComponent
             "ordbokOppslag",   // child of ordbokSamling
             "veiledningGuide", // child of veiledninger
             "veiledningSteg",  // child of veiledningGuide
+            "enkelVeiledning", // child of veiledninger
             "faq",             // child of faqSamling
             "forside",         // always at root
             // Containers themselves (sider can't contain other containers)

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -151,6 +151,14 @@ export interface Artikkel {
   publishedAt: string;
 }
 
+/**
+ * Enkel veiledningsmal — artikkel-lignende veiledning uten understeg.
+ * Lever på /veiledning/<slug> ved siden av flersteg-guider (VeiledningGuide).
+ * Samme shape som Artikkel; egen type så frontend kan skille content types
+ * uten property-sniffing.
+ */
+export interface EnkelVeiledning extends Artikkel {}
+
 export interface Side {
   id: string;
   documentId: string;
@@ -644,7 +652,8 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
 
     case 'artikkel':
     case 'case':
-      // Case has identical shape to Artikkel (mirror content type)
+    case 'enkelVeiledning':
+      // Case og EnkelVeiledning har samme shape som Artikkel (mirror content type).
       return {
         ...base,
         tittel: props.tittel as string || item.name,
@@ -1280,6 +1289,10 @@ export async function getVeiledningSteg(guideSlug: string, options: FetchOptions
 export async function getVeiledningStegBySlug(guideSlug: string, stepSlug: string, options: FetchOptions = {}) {
   const steps = await getVeiledningSteg(guideSlug, options);
   return steps.find(s => s.slug === stepSlug) || null;
+}
+
+export async function getEnkelVeiledning(slug: string, options: FetchOptions = {}) {
+  return fetchBySlug<EnkelVeiledning>('enkelVeiledning', slug, options);
 }
 
 // ── FAQ API functions ───────────────────────────────────────────

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -151,12 +151,6 @@ export interface Artikkel {
   publishedAt: string;
 }
 
-/**
- * Enkel veiledningsmal — artikkel-lignende veiledning uten understeg.
- * Lever på /veiledning/<slug> ved siden av flersteg-guider (VeiledningGuide).
- * Samme shape som Artikkel; egen type så frontend kan skille content types
- * uten property-sniffing.
- */
 export interface EnkelVeiledning extends Artikkel {}
 
 export interface Side {
@@ -653,7 +647,6 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
     case 'artikkel':
     case 'case':
     case 'enkelVeiledning':
-      // Case og EnkelVeiledning har samme shape som Artikkel (mirror content type).
       return {
         ...base,
         tittel: props.tittel as string || item.name,

--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -1,58 +1,164 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
 import BlocksRenderer from '../../components/shared/BlocksRenderer.astro';
+import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import StepNavigator from '../../components/guide/StepNavigator.astro';
 import InfoBanner from '../../components/guide/InfoBanner.astro';
-import { getVeiledningGuide, getVeiledningSteg, getPlainText } from '../../lib/umbraco';
+import {
+  getVeiledningGuide,
+  getVeiledningSteg,
+  getEnkelVeiledning,
+  getPlainText,
+  getMediaUrl,
+} from '../../lib/umbraco';
+import { articleSchema, breadcrumbSchema } from '../../lib/seo';
 
-const { guide: guideSlug } = Astro.params;
-const guideData = await getVeiledningGuide(guideSlug!);
-if (!guideData) return Astro.redirect('/veiledning');
+const { guide: slug } = Astro.params;
+const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
-const allSteps = await getVeiledningSteg(guideSlug!);
+// Try enkelVeiledning first (artikkel-stil, én side). Hvis ikke funnet,
+// fall tilbake til flersteg-guide. Slugs er unike per parent i CMS,
+// så maks ett av to oppslag returnerer et treff.
+const enkel = await getEnkelVeiledning(slug!, { preview: isPreview });
+const guideData = enkel ? null : await getVeiledningGuide(slug!, { preview: isPreview });
+if (!enkel && !guideData) return Astro.redirect('/veiledning');
 
-// Group steps by steg number
-const stepMap = new Map<number, { title: string; substeps: { title: string; slug: string }[] }>();
-for (const step of allSteps) {
-  if (!stepMap.has(step.steg)) {
-    // Use first sub-step's parent step title (the step group title comes from overview design)
-    stepMap.set(step.steg, { title: '', substeps: [] });
-  }
-  stepMap.get(step.steg)!.substeps.push({ title: step.tittel, slug: step.slug });
+// ── Enkel veiledningsmal: render som artikkel ────────────────────
+let enkelCtx: {
+  seoTitle: string;
+  seoDesc: string;
+  seoImage?: string;
+  heroImage?: ReturnType<typeof getMediaUrl> | undefined;
+  isLightBlueBg: boolean;
+  articleJsonLd: unknown;
+  breadcrumbJsonLd: unknown;
+} | null = null;
+
+if (enkel) {
+  const seoTitle = enkel.seoTittel || enkel.tittel;
+  const seoDesc = enkel.seoBeskrivelse || enkel.ingress || getPlainText(enkel.innhold, 200);
+  const heroImage = enkel.artikkelBilde || enkel.seoBilde;
+  const seoImage = enkel.seoBilde?.url || enkel.artikkelBilde?.url;
+  enkelCtx = {
+    seoTitle,
+    seoDesc,
+    seoImage,
+    heroImage: heroImage?.url ? getMediaUrl(heroImage) : undefined,
+    isLightBlueBg: (enkel.bakgrunn || 'hvit') === 'lyseblaa',
+    articleJsonLd: articleSchema({
+      headline: seoTitle,
+      description: seoDesc,
+      slug: slug!,
+      datePublished: enkel.publishedAt,
+      dateModified: enkel.updatedAt || enkel.publishedAt,
+    }),
+    breadcrumbJsonLd: breadcrumbSchema([
+      { name: 'Forside', url: '/' },
+      { name: 'Veiledning', url: '/veiledning' },
+      { name: enkel.tittel, url: `/veiledning/${slug}` },
+    ]),
+  };
 }
 
-// The step group titles from the overview design
-const stepGroupTitles: Record<number, string> = {
-  1: 'Finn ut hvilke data du trenger',
-  2: 'Samle inn data',
-  3: 'Forberede data til bruk',
-  4: 'Gjøre data tilgjengelig for KI-systemet',
-  5: 'Slette data',
-};
+// ── Flersteg-guide: behold eksisterende oppførsel ────────────────
+let guideCtx: {
+  seoTitle: string;
+  seoDesc: string;
+  steps: { number: number; title: string; substeps: { title: string; slug: string }[] }[];
+} | null = null;
 
-const steps = Array.from(stepMap.entries()).map(([num, data]) => ({
-  number: num,
-  title: stepGroupTitles[num] || `Steg ${num}`,
-  substeps: data.substeps,
-}));
+if (guideData) {
+  const allSteps = await getVeiledningSteg(slug!);
 
-const seoTitle = guideData.seoTittel || guideData.tittel;
-const seoDesc = guideData.seoBeskrivelse || getPlainText(guideData.introTekst, 200);
+  const stepMap = new Map<number, { title: string; substeps: { title: string; slug: string }[] }>();
+  for (const step of allSteps) {
+    if (!stepMap.has(step.steg)) {
+      stepMap.set(step.steg, { title: '', substeps: [] });
+    }
+    stepMap.get(step.steg)!.substeps.push({ title: step.tittel, slug: step.slug });
+  }
+
+  const stepGroupTitles: Record<number, string> = {
+    1: 'Finn ut hvilke data du trenger',
+    2: 'Samle inn data',
+    3: 'Forberede data til bruk',
+    4: 'Gjøre data tilgjengelig for KI-systemet',
+    5: 'Slette data',
+  };
+
+  guideCtx = {
+    seoTitle: guideData.seoTittel || guideData.tittel,
+    seoDesc: guideData.seoBeskrivelse || getPlainText(guideData.introTekst, 200),
+    steps: Array.from(stepMap.entries()).map(([num, data]) => ({
+      number: num,
+      title: stepGroupTitles[num] || `Steg ${num}`,
+      substeps: data.substeps,
+    })),
+  };
+}
 ---
-<Layout title={seoTitle} description={seoDesc}>
-  <div class="guide-overview">
-    <h1 class="guide-title">{guideData.tittel}</h1>
+{ enkel && enkelCtx ? (
+  <Layout
+    title={enkelCtx.seoTitle}
+    description={enkelCtx.seoDesc}
+    ogType="article"
+    publishedAt={enkel.publishedAt}
+    ogImage={enkelCtx.seoImage}
+  >
+    <script type="application/ld+json" set:html={JSON.stringify(enkelCtx.articleJsonLd).replace(/</g, '\\u003c')} />
+    <script type="application/ld+json" set:html={JSON.stringify(enkelCtx.breadcrumbJsonLd).replace(/</g, '\\u003c')} />
+    <div class="article-page grid">
+      <section class={`article-hero ${enkelCtx.isLightBlueBg ? 'col-all article-hero--bg-lyseblaa' : 'col-center-10'}`}>
+        {enkelCtx.isLightBlueBg ? (
+          <div class="grid article-hero-bg-grid">
+            <div class="article-hero-inner col-center-10">
+              <div class="article-hero-text">
+                <h1 class="article-title">{enkel.tittel}</h1>
+                {enkel.ingress && <p class="article-ingress">{enkel.ingress}</p>}
+              </div>
+              {enkelCtx.heroImage && (
+                <div class="article-hero-image">
+                  <img src={enkelCtx.heroImage} alt={enkel.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div class="article-hero-inner">
+            <div class="article-hero-text">
+              <h1 class="article-title">{enkel.tittel}</h1>
+              {enkel.ingress && <p class="article-ingress">{enkel.ingress}</p>}
+            </div>
+            {enkelCtx.heroImage && (
+              <div class="article-hero-image">
+                <img src={enkelCtx.heroImage} alt={enkel.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+              </div>
+            )}
+          </div>
+        )}
+      </section>
 
-    {guideData.introTekst && (
-      <InfoBanner>
-        <BlocksRenderer blocks={guideData.introTekst} />
-      </InfoBanner>
-    )}
+      <ArticleBlocksRenderer blocks={enkel.innhold} defaultDate={enkel.publishedAt} />
+    </div>
+  </Layout>
+) : guideData && guideCtx ? (
+  <Layout title={guideCtx.seoTitle} description={guideCtx.seoDesc}>
+    <div class="guide-overview">
+      <h1 class="guide-title">{guideData.tittel}</h1>
 
-    <StepNavigator steps={steps} guideSlug={guideSlug!} />
-  </div>
-</Layout>
+      {guideData.introTekst && (
+        <InfoBanner>
+          <BlocksRenderer blocks={guideData.introTekst} />
+        </InfoBanner>
+      )}
+
+      <StepNavigator steps={guideCtx.steps} guideSlug={slug!} />
+    </div>
+  </Layout>
+) : null }
+
 <style>
+  /* Flersteg-guide */
   .guide-overview {
     max-width: 800px;
     margin: 0 auto;
@@ -63,5 +169,81 @@ const seoDesc = guideData.seoBeskrivelse || getPlainText(guideData.introTekst, 2
     font-weight: 700;
     margin: 0 0 32px;
     color: #000;
+  }
+
+  /* Enkel veiledningsmal — duplisert fra apps/frontend/src/pages/artikler/[slug].astro.
+     TODO: konsoliderer i shared ArticleHero-komponent (task #72). */
+  .article-page {
+    padding-top: 0;
+    row-gap: 48px;
+  }
+
+  .article-hero {
+    padding: 100px 0;
+  }
+
+  .article-hero--bg-lyseblaa {
+    background: #e5f2f7;
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-top: calc(-1 * var(--header-height, 72px));
+    padding-top: calc(140px + var(--header-height, 72px));
+    padding-bottom: 80px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .article-hero-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-inner {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  .article-hero-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .article-title {
+    font-size: clamp(2rem, 4vw, 3rem);
+    font-weight: 700;
+    line-height: 1.15;
+    margin: 0;
+    color: var(--ds-color-text-default, #000);
+  }
+
+  .article-ingress {
+    font-size: 1.25rem;
+    line-height: 1.5;
+    margin: 0;
+    color: var(--ds-color-text-default, #000);
+  }
+
+  .article-hero-image {
+    flex: 1;
+    min-width: 0;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-image {
+      max-width: 50%;
+    }
+  }
+
+  .article-hero-img {
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    display: block;
   }
 </style>

--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -16,14 +16,10 @@ import { articleSchema, breadcrumbSchema } from '../../lib/seo';
 const { guide: slug } = Astro.params;
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
-// Try enkelVeiledning first (artikkel-stil, én side). Hvis ikke funnet,
-// fall tilbake til flersteg-guide. Slugs er unike per parent i CMS,
-// så maks ett av to oppslag returnerer et treff.
 const enkel = await getEnkelVeiledning(slug!, { preview: isPreview });
 const guideData = enkel ? null : await getVeiledningGuide(slug!, { preview: isPreview });
 if (!enkel && !guideData) return Astro.redirect('/veiledning');
 
-// ── Enkel veiledningsmal: render som artikkel ────────────────────
 let enkelCtx: {
   seoTitle: string;
   seoDesc: string;
@@ -60,7 +56,6 @@ if (enkel) {
   };
 }
 
-// ── Flersteg-guide: behold eksisterende oppførsel ────────────────
 let guideCtx: {
   seoTitle: string;
   seoDesc: string;
@@ -158,7 +153,6 @@ if (guideData) {
 ) : null }
 
 <style>
-  /* Flersteg-guide */
   .guide-overview {
     max-width: 800px;
     margin: 0 auto;
@@ -171,8 +165,6 @@ if (guideData) {
     color: #000;
   }
 
-  /* Enkel veiledningsmal — duplisert fra apps/frontend/src/pages/artikler/[slug].astro.
-     TODO: konsoliderer i shared ArticleHero-komponent (task #72). */
   .article-page {
     padding-top: 0;
     row-gap: 48px;


### PR DESCRIPTION
Editors asked for a guide format that's just an article — no substeps, no multi-page wizard. Currently only `VeiledningGuide` exists, which forces the stepped UI (`/veiledning/bruk-data-rett` etc.).

**CMS**
- New content type `enkelVeiledning` reusing `AddArtikkelhodeFields` + `_blockListArtikkelDt`
- Allowed as child of `veiledninger` container alongside `veiledningGuide`

**Frontend**
- `EnkelVeiledning` interface (extends `Artikkel`), `mapItem` entry, `getEnkelVeiledning(slug)`
- `/veiledning/[guide].astro` tries `getEnkelVeiledning` first, falls back to stepped guide. Slugs are unique sibling nodes in CMS so the two cannot collide.
- Article-style hero rendered inline with the same classes as `/artikler/[slug]` (CSS duplicated — consolidation tracked in task #72: extract `ArticleHero` shared component).

Base: #222 (editor field reordering). `AddArtikkelhodeFields` is reused for the new content type, so this needs that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)