### PR TITLE
CMS-editable step group titles on VeiledningGuide

### DIFF
--- a/apps/cms-umbraco/Composers/ContentSeeder.cs
+++ b/apps/cms-umbraco/Composers/ContentSeeder.cs
@@ -153,7 +153,52 @@ public class ContentSeeder : IAsyncComponent
         FlattenOmOssSeksjonerToBlocks();
         MigrateEksempelToCase();
         FixBakgrunnDropdownValues();
+        BackfillBrukDataRettStegtitler();
         EnsureSandkasseExistsForDev();
+    }
+
+    /// <summary>
+    /// One-time backfill: the bruk-data-rett guide used to render with hardcoded
+    /// step group titles in the frontend route. Now that veiledningGuide has a
+    /// stegGruppeTittler field, copy the previous defaults onto the existing node
+    /// so the page keeps rendering with the same labels. Idempotent — skips if
+    /// the field already has a value, or if no such guide exists.
+    /// </summary>
+    private void BackfillBrukDataRettStegtitler()
+    {
+        var ct = _contentTypeService.Get("veiledningGuide");
+        if (ct == null) return;
+        if (!ct.PropertyTypeExists("stegGruppeTittler")) return;
+
+        IContent? guide = null;
+        foreach (var root in _contentService.GetRootContent())
+        {
+            if (root.ContentType.Alias == "veiledningGuide" && root.GetValue<string>("slug") == "bruk-data-rett")
+            {
+                guide = root;
+                break;
+            }
+            var descendants = _contentService.GetPagedDescendants(root.Id, 0, int.MaxValue, out _);
+            guide = descendants.FirstOrDefault(d =>
+                d.ContentType.Alias == "veiledningGuide" && d.GetValue<string>("slug") == "bruk-data-rett");
+            if (guide != null) break;
+        }
+        if (guide == null) return;
+
+        var existing = guide.GetValue<string>("stegGruppeTittler");
+        if (!string.IsNullOrWhiteSpace(existing)) return;
+
+        guide.SetValue("stegGruppeTittler", string.Join("\n", new[]
+        {
+            "Finn ut hvilke data du trenger",
+            "Samle inn data",
+            "Forberede data til bruk",
+            "Gjøre data tilgjengelig for KI-systemet",
+            "Slette data",
+        }));
+        _contentService.Save(guide);
+        if (guide.Published) _contentService.Publish(guide, new[] { "*" });
+        Console.WriteLine("ContentSeeder: Backfilled stegGruppeTittler on bruk-data-rett");
     }
 
     /// <summary>

--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -170,6 +170,7 @@ public class ContentTypeComponent : IAsyncComponent
 
             if (_contentTypeService.Get("veiledningGuide") == null)
                 CreateVeiledningGuide();
+            MigrateVeiledningGuideStegtitler();
             if (_contentTypeService.Get("veiledningSteg") == null)
                 CreateVeiledningSteg();
             if (_contentTypeService.Get("faq") == null)
@@ -1325,6 +1326,7 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, mandatory: true), "innhold");
         ct.AddPropertyType(Prop("slug", "Slug", _textStringDt, mandatory: true), "innhold");
         ct.AddPropertyType(Prop("introTekst", "Intro-tekst", _richTextDt), "innhold");
+        ct.AddPropertyType(Prop("stegGruppeTittler", "Stegtitler", _textAreaDt, description: "Tittel per steg-gruppe, én per linje. Tom linje = bruk standard 'Steg N'. Rekkefølgen følger steg-nummeret (linje 1 = steg 1, osv.)."), "innhold");
 
         ct.AddPropertyGroup("seo", "SEO");
         ct.AddPropertyType(Prop("seoTittel", "SEO-tittel", _textStringDt), "seo");
@@ -1332,6 +1334,17 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("seoBilde", "SEO-bilde", _mediaPickerDt), "seo");
         _contentTypeService.Save(ct);
         return ct;
+    }
+
+    private void MigrateVeiledningGuideStegtitler()
+    {
+        var ct = _contentTypeService.Get("veiledningGuide");
+        if (ct == null) return;
+        if (ct.PropertyTypeExists("stegGruppeTittler")) return;
+
+        ct.AddPropertyType(Prop("stegGruppeTittler", "Stegtitler", _textAreaDt, description: "Tittel per steg-gruppe, én per linje. Tom linje = bruk standard 'Steg N'. Rekkefølgen følger steg-nummeret (linje 1 = steg 1, osv.)."), "innhold");
+        _contentTypeService.Save(ct);
+        Console.WriteLine("ContentTypeComposer: Added stegGruppeTittler to veiledningGuide");
     }
 
     private IContentType CreateVeiledningSteg()

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -195,6 +195,7 @@ export interface VeiledningGuide {
   tittel: string;
   slug: string;
   introTekst?: UmbracoBlock[];
+  stegGruppeTittler?: string;
   seoTittel?: string;
   seoBeskrivelse?: string;
   seoBilde?: UmbracoMedia;
@@ -695,6 +696,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         tittel: props.tittel as string || item.name,
         slug: props.slug as string || '',
         introTekst: mapRichText(props.introTekst),
+        stegGruppeTittler: props.stegGruppeTittler as string || '',
         seoTittel: props.seoTittel as string || '',
         seoBeskrivelse: props.seoBeskrivelse as string || '',
         seoBilde: mapMedia(props.seoBilde),

--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -21,14 +21,11 @@ for (const step of allSteps) {
   stepMap.get(step.steg)!.substeps.push({ title: step.tittel, slug: step.slug });
 }
 
-// The step group titles from the overview design
-const stepGroupTitles: Record<number, string> = {
-  1: 'Finn ut hvilke data du trenger',
-  2: 'Samle inn data',
-  3: 'Forberede data til bruk',
-  4: 'Gjøre data tilgjengelig for KI-systemet',
-  5: 'Slette data',
-};
+const stepGroupTitles: Record<number, string> = {};
+(guideData.stegGruppeTittler || '').split('\n').forEach((line, i) => {
+  const trimmed = line.trim();
+  if (trimmed) stepGroupTitles[i + 1] = trimmed;
+});
 
 const steps = Array.from(stepMap.entries()).map(([num, data]) => ({
   number: num,


### PR DESCRIPTION
The /veiledning/<guide> route had a hardcoded map of step group titles ("Finn ut hvilke data du trenger", "Samle inn data", …) keyed by step number. Any new guide picked them up whether or not they applied. Reported by Dorte in Slack.

- New `stegGruppeTittler` textarea on VeiledningGuide (one title per line, line N = step N).
- Frontend parses it and falls back to `Steg N` when empty.
- One-time idempotent backfill on the existing `bruk-data-rett` guide so the visible page does not regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)