### PR TITLE
fix: Normalize request host for Traefik rewrites in Kubernetes

### DIFF
--- a/apps/cms-umbraco/Program.cs
+++ b/apps/cms-umbraco/Program.cs
@@ -62,6 +62,23 @@ WebApplication app = builder.Build();
 await app.BootUmbracoAsync();
 app.UseForwardedHeaders();
 
+// Traefik rewrites :authority to the internal Kubernetes service hostname before
+// forwarding to the pod. Normalize Request.Host back to the public hostname so
+// Umbraco builds correct OAuth redirect URLs and media URLs.
+string? configuredBackOfficeHost = app.Configuration["Umbraco:CMS:Security:BackOfficeHost"];
+if (!string.IsNullOrEmpty(configuredBackOfficeHost) &&
+    Uri.TryCreate(configuredBackOfficeHost, UriKind.Absolute, out Uri? backOfficeUri))
+{
+    app.Use(async (context, next) =>
+    {
+        if (!context.Request.Host.Host.Equals(backOfficeUri.Host, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Request.Host = new HostString(backOfficeUri.Host);
+        }
+        await next(context);
+    });
+}
+
 // ── Health endpoints (before Umbraco middleware so they always respond) ──
 // /api/health: liveness — process is alive, no DB check. Used for fast probes.
 // /api/health/ready: readiness — DB reachable, Umbraco initialized. Used for traffic decisions.


### PR DESCRIPTION
Traefik overwrites the :authority header to the internal service hostname before forwarding to the pod. This middleware restores the public hostname so Umbraco generates correct OAuth redirects and media URLs.

<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
