### PR TITLE
Media-URLer absolutte mot CMS (img + RichText + og:image)

### DIFF
--- a/apps/frontend/src/components/layout/Layout.astro
+++ b/apps/frontend/src/components/layout/Layout.astro
@@ -4,6 +4,7 @@ import Footer from './Footer.astro';
 import PreviewBanner from '../shared/PreviewBanner.astro';
 import BackToTop from '../shared/BackToTop.astro';
 import CookieNotice from '../shared/CookieNotice.astro';
+import { toAbsoluteMediaUrl } from '../../lib/umbraco';
 import '../../styles/global.css';
 import '../../styles/layout.css';
 import '../../styles/search-dialog.css';
@@ -35,7 +36,13 @@ const siteUrl = Astro.site?.href.replace(/\/$/, '') || 'https://ki.norge.no';
 const canonicalUrl = `${siteUrl}${currentPath}`;
 const fullTitle = `${title} | KI Norge`;
 const DEFAULT_OG_IMAGE = '/og-image.png';
-const ogImageUrl = `${siteUrl}${ogImage || DEFAULT_OG_IMAGE}`;
+// CMS-media (/media/...) gjores absolutt mot CMS-hosten; ellers prefikses
+// site-hosten. Uten dette ble og:image til ki.norge.no/media/... (feil host),
+// som ga utdatert/odelagt delingsbilde.
+const resolvedOg = toAbsoluteMediaUrl(ogImage);
+const ogImageUrl = resolvedOg
+  ? (resolvedOg.startsWith('http') ? resolvedOg : `${siteUrl}${resolvedOg}`)
+  : `${siteUrl}${DEFAULT_OG_IMAGE}`;
 ---
 
 <!doctype html>

--- a/apps/frontend/src/lib/media-url.test.ts
+++ b/apps/frontend/src/lib/media-url.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test, beforeAll } from 'vitest';
+
+// Regresjonsvern for media-URL-helperne. Umbraco Delivery API gir relative
+// media-URLer (/media/...); på Cloudflare hentes de fra frontend-domenet i
+// stedet for CMS og gir 404. Helperne gjør dem absolutte mot CMS-hosten.
+//
+// umbraco.ts leser UMBRACO_PUBLIC_URL fra env ved import, så vi setter en kjent
+// host FØR dynamisk import. Da avhenger ikke assertions av .env-innhold.
+const CMS = 'https://cms.test.example';
+
+let lib: typeof import('./umbraco');
+
+beforeAll(async () => {
+  process.env.UMBRACO_URL = CMS;
+  process.env.UMBRACO_PUBLIC_URL = CMS;
+  lib = await import('./umbraco');
+});
+
+describe('toAbsoluteMediaUrl', () => {
+  test('prefikser relativ /media med CMS-host', () => {
+    expect(lib.toAbsoluteMediaUrl('/media/x/foo.jpg')).toBe(`${CMS}/media/x/foo.jpg`);
+  });
+  test('lar allerede-absolutt URL passere', () => {
+    expect(lib.toAbsoluteMediaUrl('https://cdn.example/x.jpg')).toBe('https://cdn.example/x.jpg');
+  });
+  test('rører ikke ikke-media relative URLer (f.eks. /og-image.png)', () => {
+    expect(lib.toAbsoluteMediaUrl('/og-image.png')).toBe('/og-image.png');
+  });
+  test('tom/undefined gir undefined', () => {
+    expect(lib.toAbsoluteMediaUrl(undefined)).toBeUndefined();
+    expect(lib.toAbsoluteMediaUrl('')).toBeUndefined();
+  });
+});
+
+describe('getMediaUrl', () => {
+  test('gjør media-objektets url absolutt', () => {
+    expect(lib.getMediaUrl({ url: '/media/a/b.jpg' } as never)).toBe(`${CMS}/media/a/b.jpg`);
+  });
+  test('undefined media gir undefined', () => {
+    expect(lib.getMediaUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe('absolutizeMediaUrls (RichText-brødtekst)', () => {
+  test('absolutiserer img src', () => {
+    expect(lib.absolutizeMediaUrls('<img src="/media/a/b.jpg" alt="x" />'))
+      .toBe(`<img src="${CMS}/media/a/b.jpg" alt="x" />`);
+  });
+  test('absolutiserer a href (fil-lenke)', () => {
+    expect(lib.absolutizeMediaUrls('<a href="/media/a/doc.pdf">PDF</a>'))
+      .toBe(`<a href="${CMS}/media/a/doc.pdf">PDF</a>`);
+  });
+  test('rører ikke interne ruter', () => {
+    expect(lib.absolutizeMediaUrls('<a href="/artikler/x">lenke</a>'))
+      .toBe('<a href="/artikler/x">lenke</a>');
+  });
+  test('matcher ikke srcset (kun src/href)', () => {
+    const html = '<img srcset="/media/a.jpg 1x" />';
+    expect(lib.absolutizeMediaUrls(html)).toBe(html);
+  });
+  test('unngår dobbel-prefiks på allerede absolutt URL', () => {
+    const html = `<img src="${CMS}/media/a.jpg" />`;
+    expect(lib.absolutizeMediaUrls(html)).toBe(html);
+  });
+  test('håndterer flere bilder i samme html', () => {
+    expect(lib.absolutizeMediaUrls('<img src="/media/a.jpg"/><img src="/media/b.jpg"/>'))
+      .toBe(`<img src="${CMS}/media/a.jpg"/><img src="${CMS}/media/b.jpg"/>`);
+  });
+});

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -517,6 +517,16 @@ interface RichTextNode {
   elements?: RichTextNode[];
 }
 
+// Embeddede media-URLer i RichText (bilder, fil-lenker) kommer relativt som
+// /media/... og ville blitt hentet fra frontend-domenet (404 pa Cloudflare).
+// Prefiks CMS-hosten. Allerede-absolutte URLer (http) treffes ikke av regexen.
+function absolutizeMediaUrls(html: string): string {
+  return html.replace(
+    /\b(src|href)="(\/media\/[^"]*)"/g,
+    (_m, attr, value) => `${attr}="${UMBRACO_PUBLIC_URL}${value}"`,
+  );
+}
+
 function richTextToHtml(node: RichTextNode): string {
   // Text node
   if (node.tag === '#text') {
@@ -529,7 +539,7 @@ function richTextToHtml(node: RichTextNode): string {
   // RichText field, not recursively per node.
   if (node.tag === '#root') {
     const inner = (node.elements || []).map(richTextToHtml).join('');
-    return applyDsClasses(inner);
+    return absolutizeMediaUrls(applyDsClasses(inner));
   }
 
   // Comment node
@@ -1347,11 +1357,18 @@ function parseJsonArray(value: string | undefined): string[] {
   }
 }
 
+// Gjor en relativ Umbraco media-URL (/media/...) absolutt mot CMS-hosten.
+// Passerer allerede-absolutte (http) og ikke-media-URLer uendret.
+export function toAbsoluteMediaUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith('http')) return url;
+  if (url.startsWith('/media')) return `${UMBRACO_PUBLIC_URL}${url}`;
+  return url;
+}
+
 // Helper to get full media URL
 export function getMediaUrl(media?: UmbracoMedia): string | undefined {
-  if (!media?.url) return undefined;
-  if (media.url.startsWith('http')) return media.url;
-  return `${UMBRACO_PUBLIC_URL}${media.url}`;
+  return toAbsoluteMediaUrl(media?.url);
 }
 
 /**

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -520,7 +520,7 @@ interface RichTextNode {
 // Embeddede media-URLer i RichText (bilder, fil-lenker) kommer relativt som
 // /media/... og ville blitt hentet fra frontend-domenet (404 pa Cloudflare).
 // Prefiks CMS-hosten. Allerede-absolutte URLer (http) treffes ikke av regexen.
-function absolutizeMediaUrls(html: string): string {
+export function absolutizeMediaUrls(html: string): string {
   return html.replace(
     /\b(src|href)="(\/media\/[^"]*)"/g,
     (_m, attr, value) => `${attr}="${UMBRACO_PUBLIC_URL}${value}"`,

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -126,11 +126,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
         "script-src 'self' 'unsafe-inline' https://survey.skyra.no",
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://altinncdn.no https://survey.skyra.no",
         "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com https://altinncdn.no data:",
-        "img-src 'self' data: https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io https://cms.ki.norge.no https://survey.skyra.no",
-        "connect-src 'self' https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io https://cms.ki.norge.no https://survey.skyra.no https://*.skyra.no",
-        // Allow CMS to embed the frontend in the preview iframe. Both the prod CMS
-        // origin and the localhost CMS dev origin are listed so preview works in dev too.
-        "frame-ancestors 'self' https://cms.ki.norge.no https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io http://localhost:5000 https://localhost:44391",
+        "img-src 'self' data: https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud https://cms.ki.norge.no https://survey.skyra.no",
+        "connect-src 'self' https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud https://cms.ki.norge.no https://survey.skyra.no https://*.skyra.no",
+        // Allow CMS to embed the frontend in the preview iframe. Prod and tt02 CMS
+        // origins (dis-core) plus the localhost CMS dev origin are listed so preview
+        // works in dev too.
+        "frame-ancestors 'self' https://cms.ki.norge.no https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud http://localhost:5000 https://localhost:44391",
         "base-uri 'self'",
         "form-action 'self'",
       ].join('; '),

--- a/apps/frontend/src/pages/artikler/index.astro
+++ b/apps/frontend/src/pages/artikler/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
-import { getArtikler, getArtiklerOversikt, getPlainText, type Artikkel } from '../../lib/umbraco';
+import { getArtikler, getArtiklerOversikt, getPlainText, getMediaUrl, type Artikkel } from '../../lib/umbraco';
 
 let articles: Artikkel[] = [];
 let oversikt = null;
@@ -33,7 +33,10 @@ const bottomFeatured = rest[8];
 const remaining = rest.slice(9);
 
 function getImageUrl(article: Artikkel) {
-  return article.artikkelBilde?.url || undefined;
+  // Bruk getMediaUrl slik at media-URLen blir absolutt mot CMS-hosten.
+  // Ra artikkelBilde.url er relativ (/media/...) og ville blitt hentet fra
+  // frontend-domenet, ikke CMS, og gitt 404.
+  return getMediaUrl(article.artikkelBilde);
 }
 
 function getTag(article: Artikkel) {


### PR DESCRIPTION
Media-bilder ga 404 i prod (Cloudflare-frontend mot prod-CMS). Generell fiks, ikke bare artikler.

Umbraco Delivery API gir RELATIVE media-URLer (/media/...). På Cloudflare hentes de fra frontend-domenet i stedet for CMS og gir 404. 

Fiks:
- Ny toAbsoluteMediaUrl(url) i umbraco.ts, getMediaUrl delegerer til den.
- absolutizeMediaUrls(html) rewriter media-URLer i RichText (#root i richTextToHtml).
- artikler/index.astro bruker getMediaUrl.
- Layout gjør CMS-media absolutt; default og-bilde forblir site-relativt.