### PR TITLE
Rydd utdaterte Container Apps-URLer (dis-core + Cloudflare)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,10 +148,11 @@ Eller bruk /az-auth skillen.
 
 ## Produksjon
 
-- Frontend: https://ki-norge-frontend.greentree-c9e56a64.norwayeast.azurecontainerapps.io
-- CMS: https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io/umbraco
+- Frontend (prod): https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev (Cloudflare Workers)
+- CMS (prod): https://kinorgeportal.prod.dis-core.altinn.cloud/umbraco (Altinn dis-core)
+- CMS (tt02): https://kinorgeportal.tt02.dis-core.altinn.cloud/umbraco
 - Status: /status (krever ki_admin cookie)
-- Domene: ki.norge.no (DNS opprettet, Azure custom domain venter på TXT-record)
+- Domene: ki.norge.no (Cloudflare Partial-zone på norge.no, DNS ikke satt opp ennå)
 
 ## Teamet
 

--- a/apps/frontend/src/pages/api/health/ready.ts
+++ b/apps/frontend/src/pages/api/health/ready.ts
@@ -6,7 +6,7 @@ import type { APIRoute } from 'astro';
  * Returns 503 if CMS Delivery API isn't reachable.
  */
 
-const CMS_URL = import.meta.env.UMBRACO_PUBLIC_URL || import.meta.env.UMBRACO_URL || 'https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
+const CMS_URL = import.meta.env.UMBRACO_PUBLIC_URL || import.meta.env.UMBRACO_URL || 'https://kinorgeportal.prod.dis-core.altinn.cloud';
 
 export const GET: APIRoute = async () => {
   const ts = new Date().toISOString();

--- a/apps/frontend/src/pages/api/status-checks.ts
+++ b/apps/frontend/src/pages/api/status-checks.ts
@@ -6,8 +6,8 @@
  */
 import type { APIRoute } from 'astro';
 
-const FRONTEND_URL = 'https://ki-norge-frontend.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
-const CMS_URL = 'https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
+const FRONTEND_URL = 'https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev';
+const CMS_URL = 'https://kinorgeportal.prod.dis-core.altinn.cloud';
 
 interface CheckResult {
   name: string;

--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from 'astro';
 const PROD_HOSTS = new Set([
   'ki.norge.no',
   'www.ki.norge.no',
-  'ki-norge-frontend.greentree-c9e56a64.norwayeast.azurecontainerapps.io',
+  'ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev',
 ]);
 
 export const GET: APIRoute = ({ url }) => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "frontend:dev": "cd apps/frontend && pnpm run dev",
     "frontend:dev:mock": "node apps/frontend/tools/mock-cms/dev.mjs",
     "mock-cms": "node apps/frontend/tools/mock-cms/server.mjs",
-    "frontend:dev:prod": "cross-env UMBRACO_URL=https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io UMBRACO_PUBLIC_URL=https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io pnpm --dir apps/frontend run dev",
+    "frontend:dev:prod": "cross-env UMBRACO_URL=https://kinorgeportal.prod.dis-core.altinn.cloud UMBRACO_PUBLIC_URL=https://kinorgeportal.prod.dis-core.altinn.cloud pnpm --dir apps/frontend run dev",
     "frontend:build": "cd apps/frontend && pnpm run build",
     "frontend:build:tt02": "cd apps/frontend && pnpm run build:tt02",
     "frontend:build:prod": "cd apps/frontend && pnpm run build:prod",

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -14,8 +14,8 @@ if [ "$MODE" = "--local" ]; then
   FRONTEND="http://localhost:4321"
   CMS="http://localhost:5000"
 else
-  FRONTEND="https://ki-norge-frontend.greentree-c9e56a64.norwayeast.azurecontainerapps.io"
-  CMS="https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io"
+  FRONTEND="https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev"
+  CMS="https://kinorgeportal.prod.dis-core.altinn.cloud"
 fi
 
 API_KEY="ki-norge-delivery-key-2025"

--- a/tests/frontend/smoke.spec.ts
+++ b/tests/frontend/smoke.spec.ts
@@ -32,7 +32,7 @@ test('Artikkel detail page renders for first article', async ({ page, request })
   const apiKey = 'ki-norge-delivery-key-2025';
   const cms = process.env.TARGET === 'local'
     ? 'http://localhost:5000'
-    : 'https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
+    : 'https://kinorgeportal.prod.dis-core.altinn.cloud';
 
   const res = await request.get(`${cms}/umbraco/delivery/api/v2/content?filter=contentType:artikkel&take=1`, {
     headers: { 'Api-Key': apiKey },
@@ -50,7 +50,7 @@ test('Eksempel detail page renders for first eksempel', async ({ page, request }
   const apiKey = 'ki-norge-delivery-key-2025';
   const cms = process.env.TARGET === 'local'
     ? 'http://localhost:5000'
-    : 'https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
+    : 'https://kinorgeportal.prod.dis-core.altinn.cloud';
 
   const res = await request.get(`${cms}/umbraco/delivery/api/v2/content?filter=contentType:eksempel&take=1`, {
     headers: { 'Api-Key': apiKey },

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -14,11 +14,11 @@ const TARGET = process.env.TARGET || 'prod';
 
 const FRONTEND = TARGET === 'local'
   ? 'http://localhost:4321'
-  : 'https://ki-norge-frontend.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
+  : 'https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev';
 
 const CMS = TARGET === 'local'
   ? 'http://localhost:5000'
-  : 'https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io';
+  : 'https://kinorgeportal.prod.dis-core.altinn.cloud';
 
 export default defineConfig({
   testDir: '.',


### PR DESCRIPTION
Container Apps-stacken fases ut. Bytter mange stale URL-referanser til ny prod.

## Endret
- CMS-referanser -> `https://kinorgeportal.prod.dis-core.altinn.cloud` (fasit fra `apps/frontend/wrangler.jsonc`)
- Frontend-referanser -> `https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev`
- Filer: `package.json` (frontend:dev:prod), `health/ready.ts` (fallback-default), `status-checks.ts`, `robots.txt.ts` (PROD_HOSTS), `scripts/smoke-test.sh`, `tests/playwright.config.ts`, `tests/frontend/smoke.spec.ts`, `CLAUDE.md` (Produksjon)
