### PR TITLE
Preview-fiks: CSP-origins, type-mapping, FrontendUrl-env

### DIFF
--- a/apps/cms-umbraco/Composers/HeadlessPreviewUrlProvider.cs
+++ b/apps/cms-umbraco/Composers/HeadlessPreviewUrlProvider.cs
@@ -26,7 +26,8 @@ public class KiNorgePreviewService : IDocumentPreviewService
 
     public Task<DocumentPreviewUrlInfo> PreviewUrlInfoAsync(IContent content, string? culture, string? segment)
     {
-        var frontendUrl = _config["HeadlessPreview:FrontendUrl"] ?? "http://localhost:4321";
+        var frontendUrl = _config["HeadlessPreview:FrontendUrl"];
+        if (string.IsNullOrWhiteSpace(frontendUrl)) frontendUrl = "http://localhost:4321";
         var previewSecret = _config["HeadlessPreview:PreviewSecret"] ?? "";
         var contentType = content.ContentType.Alias;
         var slug = content.GetValue<string>("slug") ?? "";
@@ -37,15 +38,20 @@ public class KiNorgePreviewService : IDocumentPreviewService
             "artikkel" => $"/artikler/{slug}",
             "eksempel" => $"/eksempler/{slug}",
             "side" => $"/{slug}",
-            "faq" => "/faq",
             "forside" => "/",
             "omOss" => "/om-oss",
-            "omOssSeksjon" => "/om-oss",
             "sandkasse" => "/sandkasse",
-            "veiledningOversikt" => "/veiledning",
             "veiledningGuide" => $"/veiledning/{slug}",
+            "enkelVeiledning" => $"/veiledning/{slug}",
             "veiledningSteg" => $"/veiledning/{guideSlug}/{slug}",
-            "kiOrdbok" => "/ki-ordbok",
+            // Oversikts-/landingssider (redigerbare)
+            "artikler" => "/artikler",
+            "eksempler" => "/eksempler",
+            "kalender" => "/kalender",
+            "veiledninger" => "/veiledning",
+            // kalenderhendelse har ingen egen detaljrute, vis i oversikten
+            "kalenderhendelse" => "/kalender",
+            // stegartikkel trenger forelder-traversering, egen oppfølging
             _ => null
         };
 

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -130,7 +130,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
         "connect-src 'self' https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io https://cms.ki.norge.no https://survey.skyra.no https://*.skyra.no https://*.siteimproveanalytics.io",
         // Allow CMS to embed the frontend in the preview iframe. Both the prod CMS
         // origin and the localhost CMS dev origin are listed so preview works in dev too.
-        "frame-ancestors 'self' https://cms.ki.norge.no https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io http://localhost:5000 https://localhost:44391",
+        "frame-ancestors 'self' https://cms.ki.norge.no https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://kinorgeportal.tt02.dis-core.altinn.cloud https://ki-norge-cms.greentree-c9e56a64.norwayeast.azurecontainerapps.io http://localhost:5000 https://localhost:44391",
         "base-uri 'self'",
         "form-action 'self'",
       ].join('; '),

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
         value:
           name: Umbraco__Storage__AzureBlob__Media__ContainerName
           value: umbraco
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: HeadlessPreview__FrontendUrl
+          value: https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev
   - target:
       kind: HTTPRoute
       name: umbraco

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
         value:
           name: Umbraco__Storage__AzureBlob__Media__ContainerName
           value: umbraco
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: HeadlessPreview__FrontendUrl
+          value: https://ki-norge-frontend-tt02.digitaliseringsdirektoratet.workers.dev
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
Headless preview virket ikke i prod. Denne PR-en fikser tre ting i koden:

- **middleware.ts**: la til prod- og tt02-CMS-origins i CSP `frame-ancestors`, så backoffice kan embedde preview-iframen.
- **HeadlessPreviewUrlProvider.cs**: oppdatert content-type-mapping til gjeldende typer (la til enkelVeiledning, oversiktssidene og kalenderhendelse, fjernet stale faq/kiOrdbok/veiledningOversikt/omOssSeksjon). Faller tilbake til localhost når FrontendUrl er tom.
- **syncroot tt02/prod**: satte `HeadlessPreview__FrontendUrl` til frontend-workerens URL (var tom, så preview-URL-en ble bygd uten host).
