### PR TITLE
CMS: last hemmeligheter fra Azure Key Vault (dis-core)

### DIFF
--- a/apps/cms-umbraco/KiNorge.Cms.csproj
+++ b/apps/cms-umbraco/KiNorge.Cms.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Kjac.HeadlessPreview" Version="3.0.0" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Umbraco.Cms" Version="17.4.2" />

--- a/apps/cms-umbraco/Program.cs
+++ b/apps/cms-umbraco/Program.cs
@@ -39,6 +39,28 @@
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// ── Azure Key Vault config (prod/tt02 on dis-core) ──
+// dis-core provisions an Azure Key Vault per environment and gives the pod a workload
+// identity (AZURE_* env + federated token) with access to it, plus the vault URI as
+// KeyVault:AkvUri. Pull secrets into configuration so secret values (e.g.
+// Umbraco:CMS:DeliveryApi:ApiKey) live in the vault, not in git. Secret names use "--"
+// as the section separator (Foo--Bar -> Foo:Bar). Skipped locally where AkvUri is empty.
+var akvUri = builder.Configuration["KeyVault:AkvUri"];
+if (!string.IsNullOrWhiteSpace(akvUri))
+{
+    try
+    {
+        builder.Configuration.AddAzureKeyVault(new Uri(akvUri), new Azure.Identity.DefaultAzureCredential());
+    }
+    catch (Exception ex)
+    {
+        // A vault problem must never take down the CMS. Log and continue without it:
+        // secret config (e.g. the Delivery API preview key) just won't load until the
+        // vault is reachable again, but published content keeps serving.
+        Console.Error.WriteLine($"[KeyVault] Kunne ikke laste fra {akvUri}: {ex.Message}. Fortsetter uten.");
+    }
+}
+
 builder.CreateUmbracoBuilder()
     .AddBackOffice()
     .AddWebsite()


### PR DESCRIPTION
## Hva
Laster hemmeligheter fra Azure Key Vault ved oppstart, slik at secret-config kan ligge i vaulten i stedet for i git.

## Endring
- `Program.cs`: `AddAzureKeyVault(AkvUri, DefaultAzureCredential)` rett etter CreateBuilder, guardet på `KeyVault:AkvUri`. Bruker workload identity som allerede er koblet opp på dis-core. Secret-navn `Foo--Bar` blir config `Foo:Bar`. Vault-feil logges og hoppes over, så den tar aldri ned CMS-en.
- `KiNorge.Cms.csproj`: Azure.Identity 1.21.0 + Azure.Extensions.AspNetCore.Configuration.Secrets 1.5.1.

Lokal dev er urørt (AkvUri tom der). Gjelder miljøer med AkvUri satt (tt02/prod).