### PR TITLE
Ny app: cms-kinorgeportal proxy-worker for CMS på Cloudflare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ test-results/
 # Design files
 design/
 .venv/
+apps/cms-kinorgeportal/worker-configuration.d.ts
+apps/cms-kinorgeportal/.wrangler/tmp/

--- a/apps/cms-kinorgeportal/src/index.ts
+++ b/apps/cms-kinorgeportal/src/index.ts
@@ -1,0 +1,33 @@
+export interface Env {
+  ORIGIN: string;
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const targetBase = env.ORIGIN;
+    const url = new URL(request.url);
+    const targetUrl = targetBase + url.pathname + url.search;
+    const incomingUrl = new URL(request.url);
+
+    const headers = new Headers(request.headers);
+    headers.set("Host", incomingUrl.host);
+    headers.set("X-Forwarded-Host", incomingUrl.host);
+    headers.set("X-Forwarded-Proto", incomingUrl.protocol.replace(":", ""));
+
+    const originRequest: Request = new Request(targetUrl, request);
+
+    const proxyRequest = new Request(targetUrl.toString(), {
+      method: request.method,
+      headers,
+      body:
+        request.method !== "GET" && request.method !== "HEAD"
+          ? request.body
+          : undefined,
+      redirect: "manual",
+    });
+
+    const response: Response = await fetch(proxyRequest);
+
+    return response;
+  },
+} satisfies ExportedHandler<Env>;

--- a/apps/cms-kinorgeportal/wrangler.jsonc
+++ b/apps/cms-kinorgeportal/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "cms-kinorgeportal",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-07",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": false,
+  "env": {
+    "tt02": {
+      "name": "cms-kinorgeportal-tt02",
+      "vars": {
+        "ORIGIN": "https://kinorgeportal.tt02.dis-core.altinn.cloud",
+      },
+    },
+    "prod": {
+      "name": "cms-kinorgeportal-prod",
+      "vars": {
+        "ORIGIN": "https://kinorgeportal.prod.dis-core.altinn.cloud",
+      },
+    },
+  },
+}

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "@digdir/designsystemet": "^1.15.0",
     "cross-env": "^10.1.0"
+  },
+  "dependencies": {
+    "wrangler": "^4.95.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      wrangler:
+        specifier: ^4.95.0
+        version: 4.95.0
     devDependencies:
       '@digdir/designsystemet':
         specifier: ^1.15.0


### PR DESCRIPTION
Ny Cloudflare Worker (`apps/cms-kinorgeportal/`) som proxyer innkommende forespørsler videre til dis-core CMS-origin per miljø. Allerede i prod, mangler i main.

- `src/index.ts`: videresender request til `ORIGIN`, setter `Host` og `X-Forwarded-*`, `redirect: manual`.
- `wrangler.jsonc`: workers for tt02 (`cms-kinorgeportal-tt02`) og prod (`cms-kinorgeportal-prod`), `workers_dev: false`.
- Wiring i `package.json`, `pnpm-lock.yaml`, `.gitignore`.