### PR TITLE
CMS-feedback: redaktørstyrt rik-liste, modulnavn, fjern-formatering, font-SSOT

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -1285,11 +1285,13 @@ public class ContentTypeComponent : IAsyncComponent
     // Restricted: for highlight blocks (Fremheving) and process step descriptions.
     // No headings (block is itself a highlight, no nested sections), no source editor,
     // no alignment, no blockquote (handled by visAnforselstegn toggle).
+    // ClearFormatting ("fjern formatering") is included here too — ALL RichText
+    // editors must have a wash button so editors can strip pasted-in marks/styles.
     private static readonly List<List<List<string>>> RestrictedToolbar = new()
     {
         new()
         {
-            new() { "Umb.Tiptap.Toolbar.Bold", "Umb.Tiptap.Toolbar.Italic" },
+            new() { "Umb.Tiptap.Toolbar.Bold", "Umb.Tiptap.Toolbar.Italic", "Umb.Tiptap.Toolbar.ClearFormatting" },
             new() { "Umb.Tiptap.Toolbar.BulletList", "Umb.Tiptap.Toolbar.OrderedList" },
             new() { "Umb.Tiptap.Toolbar.Link", "Umb.Tiptap.Toolbar.Unlink" },
         }
@@ -2571,21 +2573,40 @@ public class ContentTypeComponent : IAsyncComponent
             ct.AddPropertyType(Prop("heroBilde", "Hero-bilde", _mediaPickerDt), "hero");
             changed = true;
         }
-        // Seksjon 1
+        // Seksjon 1 (vises som "Fremhevet veiledning og artikler" i backoffice)
         if (!ct.PropertyGroups.Any(g => g.Alias == "seksjon1"))
         {
-            ct.AddPropertyGroup("seksjon1", "Seksjon 1");
-            ct.AddPropertyType(Prop("seksjon1Tittel", "Seksjon 1 tittel", _textStringDt), "seksjon1");
-            ct.AddPropertyType(Prop("seksjon1Kort", "Seksjon 1 kort", _blockListVeiledningKortDt), "seksjon1");
+            ct.AddPropertyGroup("seksjon1", "Fremhevet veiledning og artikler");
+            ct.AddPropertyType(Prop("seksjon1Tittel", "Tittel", _textStringDt), "seksjon1");
+            ct.AddPropertyType(Prop("seksjon1Kort", "Kort", _blockListVeiledningKortDt), "seksjon1");
             changed = true;
         }
-        // Seksjon 2
+        // Seksjon 2 (vises som "Rik liste" i backoffice)
         if (!ct.PropertyGroups.Any(g => g.Alias == "seksjon2"))
         {
-            ct.AddPropertyGroup("seksjon2", "Seksjon 2");
-            ct.AddPropertyType(Prop("seksjon2Tittel", "Seksjon 2 tittel", _textStringDt), "seksjon2");
-            ct.AddPropertyType(Prop("seksjon2Kort", "Seksjon 2 kort", _blockListVeiledningKortDt), "seksjon2");
+            ct.AddPropertyGroup("seksjon2", "Rik liste");
+            ct.AddPropertyType(Prop("seksjon2Tittel", "Tittel", _textStringDt), "seksjon2");
+            ct.AddPropertyType(Prop("seksjon2Kort", "Kort", _blockListVeiledningKortDt), "seksjon2");
             changed = true;
+        }
+        // Re-label til beskrivende modulnavn (Dorte, Figma-tavle 2026-06-04). Aliasene
+        // beholdes, så ingen data flyttes. Kjorer hver oppstart slik at noder opprettet
+        // med de gamle "Seksjon 1/2"-navnene ogsaa oppdateres.
+        // TODO: "Enkel liste" (seksjon 3) mangler fortsatt — egen oppgave, henger sammen
+        // med planlagt sidetre-/modulkatalog-restrukturering.
+        foreach (var (alias, name) in new[] { ("seksjon1", "Fremhevet veiledning og artikler"), ("seksjon2", "Rik liste") })
+        {
+            var grp = ct.PropertyGroups.FirstOrDefault(g => g.Alias == alias);
+            if (grp != null && grp.Name != name) { grp.Name = name; changed = true; }
+        }
+        foreach (var (alias, name) in new[]
+        {
+            ("seksjon1Tittel", "Tittel"), ("seksjon1Kort", "Kort"),
+            ("seksjon2Tittel", "Tittel"), ("seksjon2Kort", "Kort"),
+        })
+        {
+            var pt = ct.PropertyTypes.FirstOrDefault(x => x.Alias == alias);
+            if (pt != null && pt.Name != name) { pt.Name = name; changed = true; }
         }
         // Verktøy-seksjonen er borte fra Figma — fjern fra eksisterende noder
         foreach (var alias in new[] { "verktoyTittel", "verktoyKort" })

--- a/apps/frontend/src/components/shared/EventCard.astro
+++ b/apps/frontend/src/components/shared/EventCard.astro
@@ -135,7 +135,7 @@ const isLink = !!href;
   }
 
   .event-card-day {
-    font-family: 'PT Serif', serif;
+    font-family: var(--ki-heading-font);
     font-size: var(--ds-heading-md-font-size);
     text-align: center;
     line-height: 1;

--- a/apps/frontend/src/components/shared/SimpleArticleLayout.astro
+++ b/apps/frontend/src/components/shared/SimpleArticleLayout.astro
@@ -77,7 +77,7 @@ const bylineAuthor = byline
   }
 
   .simple-article-layout__title {
-    font-family: 'PT Serif', serif;
+    font-family: var(--ki-heading-font);
     font-style: italic;
     font-size: clamp(2rem, 4vw, 3rem);
     font-weight: 400;
@@ -88,7 +88,7 @@ const bylineAuthor = byline
   }
 
   .simple-article-layout__ingress {
-    font-family: 'PT Serif', serif;
+    font-family: var(--ki-heading-font);
     font-size: 20px;
     line-height: 1.5;
     margin: 0 0 var(--ds-size-6);

--- a/apps/frontend/src/lib/richtext-classes.test.ts
+++ b/apps/frontend/src/lib/richtext-classes.test.ts
@@ -15,13 +15,26 @@ describe('applyDsClasses', () => {
     expect(twice).toBe(out);
   });
 
-  test('bevarer heading-id (TOC-anker)', () => {
+  test('bevarer heading-id (TOC-anker) og legger på ds-heading', () => {
     const out = applyDsClasses('<h2 id="seksjon">Tittel</h2>');
-    expect(out).toBe('<h2 id="seksjon">Tittel</h2>');
+    expect(out).toContain('id="seksjon"');
+    expect(out).toContain('ds-heading');
   });
 
   test('tom input', () => {
     expect(applyDsClasses('')).toBe('');
     expect(applyDsClasses(undefined as unknown as string)).toBe('');
+  });
+
+  test('fjerner fremmed font-family og font-size (f.eks. innliming fra Word)', () => {
+    const out = applyDsClasses('<p style="font-family: Calibri; font-size: 11pt">Hei</p>');
+    expect(out).not.toContain('font-family');
+    expect(out).not.toContain('font-size');
+  });
+
+  test('beholder andre inline-stiler (text-align, text-indent)', () => {
+    const out = applyDsClasses('<p style="text-align: center; font-family: Arial">Hei</p>');
+    expect(out).toContain('text-align: center');
+    expect(out).not.toContain('font-family');
   });
 });

--- a/apps/frontend/src/lib/richtext-classes.ts
+++ b/apps/frontend/src/lib/richtext-classes.ts
@@ -10,6 +10,26 @@ const RULES: Record<string, string> = {
   // 'hr':                   'ds-divider',
 };
 
+// Vi fjerner font-relaterte inline-stiler fra RTE-HTML uansett verdi. Sjekken
+// matcher CSS-egenskapen (font-family/font-size), ikke et bestemt font-navn, så
+// ingen font er hardkodet her: appens CSS er eneste kilde for hvilke fonter som
+// gjelder (--ds-font-family for brødtekst, --ki-heading-font for overskrift, se
+// global.css). Da kan ikke fremmede fonter fra innliming (Word o.l.) overstyre
+// dem. Overskrifter kommer inn som ekte h2–h4 og får overskriftsfonten via CSS.
+// Andre inline-stiler redaktøren bruker bevisst (text-align, text-indent) beholdes.
+const STRIP_STYLE_PROPS = /^(font-family|font-size)\s*:/i;
+
+function stripForeignFonts(el: Element): void {
+  const style = el.getAttribute('style');
+  if (!style) return;
+  const kept = style
+    .split(';')
+    .map(d => d.trim())
+    .filter(d => d && !STRIP_STYLE_PROPS.test(d));
+  if (kept.length) el.setAttribute('style', kept.join('; ') + ';');
+  else el.removeAttribute('style');
+}
+
 export function applyDsClasses(html: string): string {
   if (!html) return '';
   const { document } = parseHTML(`<div>${html}</div>`);
@@ -17,5 +37,6 @@ export function applyDsClasses(html: string): string {
   for (const [sel, cls] of Object.entries(RULES)) {
     root.querySelectorAll(sel).forEach(el => el.classList.add(cls));
   }
+  root.querySelectorAll('[style]').forEach(el => stripForeignFonts(el));
   return root.innerHTML;
 }

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -36,17 +36,20 @@ const featuredHref = cmsData?.seksjon1Kort?.[0]?.url || '/veiledning/kom-i-gang'
 const featuredLabel = cmsData?.seksjon1Tittel || 'Kom i gang';
 const featuredImage = heroImageUrl || '/woman-speaking.svg';
 
-// Rich link list — "Steg for steg" (guides with descriptions)
-const richLinks = guides.data.length > 0
-  ? guides.data.map(g => ({
-      title: g.tittel,
-      desc: g.ingress || '',
-      href: `/veiledning/${g.slug}`,
-    }))
-  : (cmsData?.seksjon2Kort || []).map(k => ({
+// Rich link list — "Steg for steg"
+// Redaktørstyrt: når redaktøren har fylt seksjon2-kortene brukes deres egen
+// beskrivelse (tilpasset tekst). Ellers auto-utledes lista fra guidene, der
+// beskrivelsen blir guidens ingress (fallback).
+const richLinks = (cmsData?.seksjon2Kort?.length ?? 0) > 0
+  ? cmsData!.seksjon2Kort!.map(k => ({
       title: k.tittel,
       desc: k.beskrivelse || '',
       href: k.url || '#',
+    }))
+  : guides.data.map(g => ({
+      title: g.tittel,
+      desc: g.ingress || '',
+      href: `/veiledning/${g.slug}`,
     }));
 
 // Simple link list — "Forstå regelverket"

--- a/apps/frontend/src/styles/article-blocks.css
+++ b/apps/frontend/src/styles/article-blocks.css
@@ -141,7 +141,7 @@
   border-radius: var(--ds-border-radius-full);
   background: var(--ds-color-text-default);
   color: var(--ds-color-surface-hover);
-  font-family: 'PT Serif', serif;
+  font-family: var(--ki-heading-font);
   font-size: var(--ds-font-size-8);
   line-height: 1;
 }
@@ -233,7 +233,7 @@
    collapses onto one running line of text and the marks naturally flow
    with the words. Italic body, 24px (= ds font size 6). */
 .article-fremheving-text--quote {
-  font-family: 'PT Serif', serif;
+  font-family: var(--ki-heading-font);
   font-style: italic;
   margin: 0;
   font-size: var(--ds-font-size-6);

--- a/apps/frontend/src/styles/article-layout.css
+++ b/apps/frontend/src/styles/article-layout.css
@@ -132,7 +132,7 @@ var(--article-layout-gutter);
   flex-direction: column;
   gap: var(--ds-size-1);
   color: var(--ds-color-text-default);
-  font-family: 'PT Serif', serif;
+  font-family: var(--ki-heading-font);
 }
 
 .article-layout__metadata-label {
@@ -149,7 +149,7 @@ var(--article-layout-gutter);
 
 /* ── Article ingress (shared) ── */
 .article-ingress {
-  font-family: 'PT Serif', serif;
+  font-family: var(--ki-heading-font);
   font-size: var(--ds-font-size-7);
   line-height: 1.5;
   margin: 0;

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -15,8 +15,11 @@
 }
 
 :root {
-  /* Font family */
+  /* Font family — single source of truth for sidens to fonter.
+     Brødtekst: --ds-font-family. Overskrift: --ki-heading-font.
+     Alt annet (inkl. RichText) skal referere disse, ikke gjenta navnene. */
   --ds-font-family: "Instrument Sans", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --ki-heading-font: "PT Serif", serif;
 
   /* Site chrome dimensions. Used by Layout.astro for <main> top padding AND
      by full-bleed hero sections that need to extend up behind the absolute
@@ -26,7 +29,7 @@
 }
 
 html {
-  font-family: "Instrument Sans";
+  font-family: var(--ds-font-family);
   scrollbar-gutter: stable;
 }
 
@@ -41,7 +44,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: "PT Serif", serif;
+  font-family: var(--ki-heading-font);
 }
 
 /* Utility classes */
@@ -112,7 +115,7 @@ main a:has(> img)::after {
   h1, h2, h3, h4 {
     page-break-after: avoid;
     color: black !important;
-    font-family: "PT Serif", serif;
+    font-family: var(--ki-heading-font);
   }
 
   p, li {

--- a/apps/frontend/src/styles/rich-text.css
+++ b/apps/frontend/src/styles/rich-text.css
@@ -50,7 +50,7 @@
     }
 
     & > h2 {
-      font-family: 'PT Serif', serif;
+      font-family: var(--ki-heading-font);
       font-style: italic;
       font-size: 24px;
       font-weight: 400;
@@ -112,7 +112,7 @@
 
     /* A <p> tag that comes directly after <h1> will be treated as an ingress */
     & > h1 + p {
-      font-family: 'PT Serif', serif;
+      font-family: var(--ki-heading-font);
       font-size: 30px;
       line-height: 1.5;
       margin-top: 0;


### PR DESCRIPTION
Feedback fra Dorte på CMS-en.

- **Rik-liste (veiledningsoversikt)**: bruker redaktørens egen kort-beskrivelse når den er fylt, ellers guidens ingress som før. Feltet fantes allerede på kortet, frontend ignorerte det.
- **Modulnavn på navigasjonsside veiledning**: gruppenavn "Seksjon 1/2" endret til "Fremhevet veiledning og artikler" / "Rik liste". Migrasjon re-labeler eksisterende noder, aliasene beholdes, ingen data flyttes.
- **Fjern-formatering på alle RichText-editorer**: Restricted-editoren manglet knappen. Innliming av bilde/video er sperret fra før (kun lenker).
- **Tving sidens to fonter**: frontend stripper inline `font-family`/`font-size` fra RichText-HTML så innliming (Word o.l.) ikke kan overstyre fontene. Sjekken matcher CSS-egenskapen, ikke et font-navn. Fontene er samlet til én kilde hver (`--ds-font-family`, `--ki-heading-font`).