### PR TITLE
fix: kladd-preview krever Preview-header mot Delivery API

### DIFF
--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -642,6 +642,8 @@ async function fetchCollection<T>(
 
   if (options.preview && API_KEY) {
     headers['Api-Key'] = API_KEY;
+    // Umbraco Delivery API leverer kladd kun med Preview-header (ikke ?preview-query).
+    headers['Preview'] = 'true';
   }
 
   const params = new URLSearchParams();
@@ -1572,6 +1574,8 @@ export async function searchContent(query: string, options: FetchOptions = {}): 
   const headers: HeadersInit = { 'Accept': 'application/json' };
   if (options.preview && API_KEY) {
     headers['Api-Key'] = API_KEY;
+    // Umbraco Delivery API leverer kladd kun med Preview-header (ikke ?preview-query).
+    headers['Preview'] = 'true';
   }
 
   const params = new URLSearchParams();


### PR DESCRIPTION
Umbraco Delivery API returnerer kladd kun når `Preview: true`-headeren er satt. Frontend sendte preview som query-param (`?preview=true`), som Umbraco ignorerer, så preview viste alltid publisert innhold (aldri kladd før publisering).

Legger `Preview: true`-headeren sammen med `Api-Key` i begge fetch-stiene (`fetchCollection` + `searchContent`).

Verifisert på tt02: upublisert kladde-artikkel vises kun med `?preview=true`, korrekt 302 i normal visning.