### PR TITLE
feat: update robots.txt to allow ONLY SiteimproveBot for pre-launch

### DIFF
--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -10,21 +10,14 @@ export const GET: APIRoute = ({ url }) => {
   const isProd = PROD_HOSTS.has(url.hostname);
 
   const body = isProd
-    ? `User-agent: *
+    ? `# Pre-launch: allow Siteimprove only
+User-agent: SiteimproveBot
 Allow: /
-Disallow: /admin-tilgang
-Disallow: /preview-tilgang
-Disallow: /status
-Disallow: /api/
-Disallow: /503
 
-Sitemap: https://ki.norge.no/sitemap-index.xml
-
-# Human/LLM-readable route expectations for automated testing:
-# See /llm.txt
-`
-    : `# Non-production environment — block all crawlers.
 User-agent: *
+Disallow: /
+`
+    : `User-agent: *
 Disallow: /
 `;
 

--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -28,13 +28,6 @@ Sitemap: https://ki.norge.no/sitemap-index.xml
 # See /llm.txt
 `
     : `# Non-production environment — allow only SiteimproveBot.
-User-agent: SiteimproveBot
-Allow: /
-Disallow: /admin-tilgang
-Disallow: /preview-tilgang
-Disallow: /status
-Disallow: /api/
-Disallow: /503
 
 User-agent: *
 Disallow: /

--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -10,7 +10,7 @@ export const GET: APIRoute = ({ url }) => {
   const isProd = PROD_HOSTS.has(url.hostname);
 
   const body = isProd
-    ? `# Pre-launch: allow Siteimprove only
+    ? `# Allows Siteimprove only (todo: allow at launch)
 User-agent: SiteimproveBot
 Allow: /
 Disallow: /admin-tilgang
@@ -27,7 +27,7 @@ Sitemap: https://ki.norge.no/sitemap-index.xml
 # Human/LLM-readable route expectations for automated testing:
 # See /llm.txt
 `
-    : `# Non-production environment — allow only SiteimproveBot.
+    : `# Non-production environment — disallow all (crawling on test would give bad content for Search Engines and give false results for Siteimprove)
 
 User-agent: *
 Disallow: /

--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -30,6 +30,11 @@ Sitemap: https://ki.norge.no/sitemap-index.xml
     : `# Non-production environment — allow only SiteimproveBot.
 User-agent: SiteimproveBot
 Allow: /
+Disallow: /admin-tilgang
+Disallow: /preview-tilgang
+Disallow: /status
+Disallow: /api/
+Disallow: /503
 
 User-agent: *
 Disallow: /

--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -13,11 +13,25 @@ export const GET: APIRoute = ({ url }) => {
     ? `# Pre-launch: allow Siteimprove only
 User-agent: SiteimproveBot
 Allow: /
+Disallow: /admin-tilgang
+Disallow: /preview-tilgang
+Disallow: /status
+Disallow: /api/
+Disallow: /503
 
 User-agent: *
 Disallow: /
+
+Sitemap: https://ki.norge.no/sitemap-index.xml
+
+# Human/LLM-readable route expectations for automated testing:
+# See /llm.txt
 `
-    : `User-agent: *
+    : `# Non-production environment — allow only SiteimproveBot.
+User-agent: SiteimproveBot
+Allow: /
+
+User-agent: *
 Disallow: /
 `;
 


### PR DESCRIPTION

## Summary

This pull request updates the `robots.txt` response logic to improve how search engine crawlers are managed, especially in the pre-launch phase. The main change is to allow only the Siteimprove bot to crawl the site in production environments before launch, while continuing to block all crawlers in non-production environments.

Crawling and indexing control:

* In production, the `robots.txt` now only allows the `SiteimproveBot` and blocks all other crawlers, removing previous disallow rules and the sitemap reference. This is intended for pre-launch, limiting indexing to Siteimprove for QA purposes.
* In non-production environments, the policy remains unchanged: all crawlers are blocked.<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
