### PR TITLE
tt02 CMS: backoffice-host = workers.dev (OAuth redirect)

### DIFF
--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -25,12 +25,12 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://kinorgeportal.tt02.dis-core.altinn.cloud
+          value: https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms.ki.test.norge.no
+          value: https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
@@ -55,3 +55,4 @@ patches:
         value:
           - kinorgeportal.tt02.dis-core.altinn.cloud
           - cms.ki.test.norge.no
+          - cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev


### PR DESCRIPTION
`/umbraco` på tt02 ga OpenIddict-feil (ID2043, ugyldig `redirect_uri`), mens `/umbraco/login` virket. cms-kinorgeportal-tt02-workeren proxer til dis-core med `Host` satt til workers.dev-vertsnavnet, men tt02 hadde `BackOfficeHost` = `cms.ki.test.norge.no` og `UmbracoApplicationUrl` = dis-core. Da bygger Umbraco en OAuth-redirect_uri som ikke matcher origin `/umbraco` besøkes fra.

Speiler prod-fiksen fra #320 til tt02:

- `UmbracoApplicationUrl` + `BackOfficeHost` peker nå på `cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev`
- Workers.dev-vertsnavnet lagt til i HTTPRoute slik at Traefik ruter det

Host-normaliseringen som gjør dette mulig ligger allerede i main (#323).