### PR TITLE
fix: prod media-URLer via offentlig proxy-host

### DIFF
--- a/apps/frontend/wrangler.jsonc
+++ b/apps/frontend/wrangler.jsonc
@@ -26,7 +26,9 @@
 		"prod": {
 			"vars": {
 				"UMBRACO_URL": "https://kinorgeportal.prod.dis-core.altinn.cloud",
-				"UMBRACO_PUBLIC_URL": "https://kinorgeportal.prod.dis-core.altinn.cloud",
+				// Media-URLer hentes av nettleseren, så de må peke på en offentlig host.
+				// Dis-core-hosten krever Altinn-nett; proxy-workeren (#350) er offentlig nåbar.
+				"UMBRACO_PUBLIC_URL": "https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev",
 				// Holding page on ki.norge.no until launch. Flip to "live" to go public.
 				"LAUNCH_MODE": "coming-soon",
 			},


### PR DESCRIPTION
`UMBRACO_PUBLIC_URL` brukes til media-URLer som nettleseren henter direkte. Prod pekte på `kinorgeportal.prod.dis-core.altinn.cloud`, som krever Altinn-nett, så bildene lastet ikke offentlig (HTTP 000).

Peker prod `UMBRACO_PUBLIC_URL` på proxy-workeren (#350), som er offentlig nåbar og videresender `/media` til dis-core. `UMBRACO_URL` (server-side API-fetch fra workeren) står på dis-core.

Verifisert på prod: media-URL er nå proxy-host og bildet laster (HTTP 200). tt02 urørt.