### PR TITLE
CMS: veiledningSteg.guideSlug settes automatisk fra guiden

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -1555,6 +1555,15 @@ public class ContentTypeComponent : IAsyncComponent
             }
         }
 
+        // guideSlug settes automatisk fra guiden (VeiledningStegGuideSlugHandler), så det er ikke lenger
+        // påkrevd. Relax eksisterende noder.
+        var guideSlugProp = ct.PropertyTypes.FirstOrDefault(p => p.Alias == "guideSlug");
+        if (guideSlugProp != null && guideSlugProp.Mandatory)
+        {
+            guideSlugProp.Mandatory = false;
+            changed = true;
+        }
+
         if (EnsureInnstillingerGroup(ct, "slug", "guideSlug", "steg", "understeg")) changed = true;
         if (SetPropertySortOrders(ct,
             ("tittel", 1), ("ingress", 2), ("innholdBlokker", 3),
@@ -1953,7 +1962,7 @@ public class ContentTypeComponent : IAsyncComponent
 
         ct.AddPropertyGroup("innstillinger", "Innstillinger");
         ct.AddPropertyType(Prop("slug", "Slug", _textStringDt, mandatory: true, description: "URL-vennlig identifikator.", sortOrder: 1), "innstillinger");
-        ct.AddPropertyType(Prop("guideSlug", "Guide-slug", _textStringDt, mandatory: true, description: "Slug til overordnet guide", sortOrder: 2), "innstillinger");
+        ct.AddPropertyType(Prop("guideSlug", "Guide-slug", _textStringDt, description: "Settes automatisk fra guiden ved lagring. Trenger ikke fylles ut.", sortOrder: 2), "innstillinger");
         ct.AddPropertyType(Prop("steg", "Steg", _numericDt, mandatory: true, description: "Stegnummer (1, 2, 3...)", sortOrder: 3), "innstillinger");
         ct.AddPropertyType(Prop("understeg", "Understeg", _numericDt, mandatory: true, description: "Understeg-nummer (1, 2, 3...)", sortOrder: 4), "innstillinger");
         SetStandardGroupSortOrders(ct);

--- a/apps/cms-umbraco/Composers/VeiledningStegGuideSlugHandler.cs
+++ b/apps/cms-umbraco/Composers/VeiledningStegGuideSlugHandler.cs
@@ -1,0 +1,47 @@
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Setter veiledningSteg.guideSlug automatisk fra den overordnede guiden sin slug ved lagring.
+/// Et steg ligger som barn av veiledningGuide i innholdstreet, så guideSlug trenger ikke fylles
+/// manuelt. Fritekst ga lett mismatch (casing/ø), og da fant frontend ingen steg å lenke til.
+/// Feltet overskrives hver lagring, så det matcher guiden by construction.
+/// </summary>
+public class VeiledningStegGuideSlugComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentSavingNotification, VeiledningStegGuideSlugHandler>();
+    }
+}
+
+public class VeiledningStegGuideSlugHandler : INotificationHandler<ContentSavingNotification>
+{
+    private readonly IContentService _contentService;
+
+    public VeiledningStegGuideSlugHandler(IContentService contentService)
+    {
+        _contentService = contentService;
+    }
+
+    public void Handle(ContentSavingNotification notification)
+    {
+        foreach (var content in notification.SavedEntities)
+        {
+            if (content.ContentType.Alias != "veiledningSteg") continue;
+
+            var parent = content.ParentId > 0 ? _contentService.GetById(content.ParentId) : null;
+            if (parent is null || parent.ContentType.Alias != "veiledningGuide") continue;
+
+            var guideSlug = parent.GetValue<string>("slug");
+            if (string.IsNullOrWhiteSpace(guideSlug)) continue;
+
+            content.SetValue("guideSlug", guideSlug);
+        }
+    }
+}


### PR DESCRIPTION
Gjør `guideSlug` på et veiledningssteg automatisk i stedet for manuelt fritekst.

- Ny `ContentSaving`-handler (`VeiledningStegGuideSlugHandler`, samme mønster som `MerkelappSlugHandler`) setter `guideSlug` = den overordnede guidens `slug` ved hver lagring. Et steg ligger som barn av `veiledningGuide` i treet, så feltet kan utledes fra forelderen.
- `guideSlug` er ikke lenger påkrevd (relax-migrasjon for eksisterende noder) og beskrivelsen sier at det settes automatisk.

Bakgrunn: fritekstfeltet ga lett mismatch (casing/`ø`), og da returnerte `getVeiledningSteg` tomt, så guide-sidene viste ingen steg-lenker. Nå matcher `guideSlug` guidens `slug` by construction.