### PR TITLE
Frontend tt02: preview-iframe (CSP) + hovedbilde i artikkelhodet

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -137,12 +137,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
         // CMS-hoster (union av alle reelle origins). Frontend henter media fra CMS,
         // sa img-src/connect-src ma tillate dem ellers blokkeres bildene. Den dode
         // Container Apps-hosten er fjernet.
-        "img-src 'self' data: https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://cms.ki.norge.no https://survey.skyra.no",
-        "connect-src 'self' https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://cms.ki.norge.no https://survey.skyra.no https://*.skyra.no https://*.siteimproveanalytics.io",
+        "img-src 'self' data: https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev https://cms.ki.norge.no https://survey.skyra.no",
+        "connect-src 'self' https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev https://cms.ki.norge.no https://survey.skyra.no https://*.skyra.no https://*.siteimproveanalytics.io",
         // Allow CMS to embed the frontend in the preview iframe. Prod og tt02 CMS
         // (dis-core + workers.dev) pluss localhost CMS dev-origin slik at preview
         // virker i dev ogsa.
-        "frame-ancestors 'self' https://cms.ki.norge.no https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud http://localhost:5000 https://localhost:44391",
+        "frame-ancestors 'self' https://cms.ki.norge.no https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev https://kinorgeportal.prod.dis-core.altinn.cloud https://kinorgeportal.tt02.dis-core.altinn.cloud http://localhost:5000 https://localhost:44391",
         "base-uri 'self'",
         "form-action 'self'",
       ].join('; '),

--- a/apps/frontend/src/pages/artikler/[slug].astro
+++ b/apps/frontend/src/pages/artikler/[slug].astro
@@ -4,7 +4,7 @@ import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
 
-import { getArtikkel, getArtikler, getPlainText } from '../../lib/umbraco';
+import { getArtikkel, getArtikler, getPlainText, getMediaUrl } from '../../lib/umbraco';
 import { articleSchema, breadcrumbSchema } from '../../lib/seo';
 
 const { slug } = Astro.params;
@@ -15,6 +15,7 @@ if (!article) return Astro.redirect('/artikler');
 const seoTitle = article.seoTittel || article.tittel;
 const seoDesc = article.seoBeskrivelse || article.ingress || getPlainText(article.innhold, 200);
 const seoImage = article.seoBilde?.url || article.artikkelBilde?.url;
+const heroImage = article.artikkelBilde || article.seoBilde;
 
 const articleJsonLd = articleSchema({
   headline: seoTitle,
@@ -46,7 +47,16 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')} />
 
   <section class="article-hero" data-layout-block="edge">
-    <h1 class="ds-heading article-title" data-size="xl">{article.tittel}</h1>
+    <div class="article-hero-inner">
+      <div class="article-hero-text">
+        <h1 class="ds-heading article-title" data-size="xl">{article.tittel}</h1>
+      </div>
+      {heroImage?.url && (
+        <div class="article-hero-image">
+          <img src={getMediaUrl(heroImage)} alt={article.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+        </div>
+      )}
+    </div>
   </section>
 
   <ArticleLayout publishedAt={article.publishedAt} byline={(bylineBlock?.content ?? null) as any}>
@@ -77,6 +87,46 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 </Layout>
 
 <style>
+  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  .article-hero-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-inner {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  .article-hero-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .article-hero-image {
+    flex-shrink: 0;
+    width: 100%;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-image { width: 407px; }
+  }
+
+  .article-hero-img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+    display: block;
+    object-fit: cover;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-img { height: 331px; }
+  }
+
   /* More articles */
   .more-articles {
     padding: 64px 0 120px;


### PR DESCRIPTION
To uavhengige tt02-frontend-fikser oppdaget under tt02-testing.

**Preview-iframe blokkert (CSP).** Frontend-CSP-en (`frame-ancestors`, og for konsistens `img-src` + `connect-src`) hadde prod sin workers.dev-CMS-host men ikke tt02 sin. Backoffice rammer inn frontend fra `cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev`, som ikke var i `frame-ancestors`, så preview ble blokkert (`Framing ... violates frame-ancestors`). La til tt02-hosten i alle tre listene ved siden av prod-hosten.

**Hovedbilde manglet på artikkelsiden.** `artikler/[slug]` rendret kun tittelen i hodet; bilde-rendringen forsvant i #340. `sandkasse` beholdt mønsteret. Gjenoppretter hovedbildet i artikkelhodet med samme `article-hero-inner`/`-image`-struktur (bilde ved siden av tittel, under på mobil).

Begge er uavhengige av #360/#362 og kan deployes nå.