### PR TITLE
Footer: redigerbar i globaleInnstillinger (flyttet fra forside)

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -2723,6 +2723,27 @@ public class ContentTypeComponent : IAsyncComponent
         }
     }
 
+    private void AddFooterFields(IContentType ct)
+    {
+        if (!ct.PropertyGroups.Any(g => g.Alias == "footer"))
+            ct.AddPropertyGroup("footer", "Footer");
+        ct.AddPropertyType(Prop("footerTittel", "Merkenavn", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerBeskrivelse", "Beskrivelse", _textAreaDt), "footer");
+        ct.AddPropertyType(Prop("footerSosialInstagram", "Instagram-URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerSosialLinkedin", "LinkedIn-URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerSosialX", "X-URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke1Tekst", "Lenke 1 tekst", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke1Url", "Lenke 1 URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke2Tekst", "Lenke 2 tekst", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke2Url", "Lenke 2 URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke3Tekst", "Lenke 3 tekst", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke3Url", "Lenke 3 URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke4Tekst", "Lenke 4 tekst", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke4Url", "Lenke 4 URL", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke5Tekst", "Lenke 5 tekst", _textStringDt), "footer");
+        ct.AddPropertyType(Prop("footerLenke5Url", "Lenke 5 URL", _textStringDt), "footer");
+    }
+
     private IContentType CreateGlobaleInnstillinger()
     {
         var ct = new ContentType(_shortStringHelper, -1)
@@ -2747,6 +2768,8 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("tittel503", "503 tittel", _textStringDt, description: "Vises som overskrift på vedlikeholdssiden."), "feilsider");
         ct.AddPropertyType(Prop("beskrivelse503", "503 beskrivelse", _textAreaDt, description: "Forklarende tekst på vedlikeholdssiden."), "feilsider");
         ct.AddPropertyType(Prop("vedlikeholdEpost", "Vedlikehold-e-post", _textStringDt, description: "Kontakt-e-post for hjelp under vedlikehold."), "feilsider");
+
+        AddFooterFields(ct);
 
         _contentTypeService.Save(ct);
         return ct;
@@ -2803,9 +2826,16 @@ public class ContentTypeComponent : IAsyncComponent
             changed = true;
         }
 
-        if (ct.Description != "Globale tekster brukt på tvers av sidene (cookie-melding, feilsider). Ett node på rot.")
+        // Footer flyttet hit fra forside (global, ikke forside-spesifikk).
+        if (!ct.PropertyTypes.Any(p => p.Alias == "footerTittel"))
         {
-            ct.Description = "Globale tekster brukt på tvers av sidene (cookie-melding, feilsider). Ett node på rot.";
+            AddFooterFields(ct);
+            changed = true;
+        }
+
+        if (ct.Description != "Globale tekster brukt på tvers av sidene (cookie-melding, footer, feilsider). Ett node på rot.")
+        {
+            ct.Description = "Globale tekster brukt på tvers av sidene (cookie-melding, footer, feilsider). Ett node på rot.";
             changed = true;
         }
 

--- a/apps/frontend/src/components/layout/Footer.astro
+++ b/apps/frontend/src/components/layout/Footer.astro
@@ -1,26 +1,26 @@
 ---
-// Footer — CMS-editable via forside singleton
-// NOTE: This fetches getForside() independently. On the frontpage, index.astro also
-// fetches it — resulting in a double call. Astro SSR may deduplicate within a request.
-// Future optimization: pass footer data as props through Layout.
-import { getForside } from '../../lib/umbraco';
+// Footer — CMS-redigerbar via globaleInnstillinger (footer flyttet dit fra forside).
+// Leser globaleInnstillinger først, faller tilbake til forside (overgangsperiode til
+// forside-footer-feltene fjernes), så hardkodet default. Ingen footer-innhold går tapt.
+import { getGlobaleInnstillinger, getForside } from '../../lib/umbraco';
 import Logo from './Logo';
+let global = null;
 let forside = null;
-try { forside = await getForside(); } catch (e) {}
+try { [global, forside] = await Promise.all([getGlobaleInnstillinger(), getForside()]); } catch (e) {}
 
-const brand = forside?.footerTittel || 'KI Norge';
-const desc = forside?.footerBeskrivelse || 'Et tverrsektorielt samarbeid for å fremme ansvarlig og sikker bruk av kunstig intelligens i den norske forvaltningen.';
-const igUrl = forside?.footerSosialInstagram || '#';
-const liUrl = forside?.footerSosialLinkedin || '#';
-const xUrl = forside?.footerSosialX || '#';
+const brand = global?.footerTittel || forside?.footerTittel || 'KI Norge';
+const desc = global?.footerBeskrivelse || forside?.footerBeskrivelse || 'Et tverrsektorielt samarbeid for å fremme ansvarlig og sikker bruk av kunstig intelligens i den norske forvaltningen.';
+const igUrl = global?.footerSosialInstagram || forside?.footerSosialInstagram || '#';
+const liUrl = global?.footerSosialLinkedin || forside?.footerSosialLinkedin || '#';
+const xUrl = global?.footerSosialX || forside?.footerSosialX || '#';
 
 const navCol1 = [
-  { text: forside?.footerLenke1Tekst || 'Om KI Norge', url: forside?.footerLenke1Url || '/om-oss' },
+  { text: global?.footerLenke1Tekst || forside?.footerLenke1Tekst || 'Om KI Norge', url: global?.footerLenke1Url || forside?.footerLenke1Url || '/om-oss' },
 ];
 const navCol2 = [
-  { text: forside?.footerLenke3Tekst || 'Personvern og informasjonskapsler', url: forside?.footerLenke3Url || '/personvern' },
-  { text: forside?.footerLenke4Tekst || 'Tilgjengelighet', url: forside?.footerLenke4Url || '/tilgjengelighet' },
-  { text: forside?.footerLenke5Tekst || 'Endre samtykke for informasjonskapsler', url: forside?.footerLenke5Url || '' },
+  { text: global?.footerLenke3Tekst || forside?.footerLenke3Tekst || 'Personvern og informasjonskapsler', url: global?.footerLenke3Url || forside?.footerLenke3Url || '/personvern' },
+  { text: global?.footerLenke4Tekst || forside?.footerLenke4Tekst || 'Tilgjengelighet', url: global?.footerLenke4Url || forside?.footerLenke4Url || '/tilgjengelighet' },
+  { text: global?.footerLenke5Tekst || forside?.footerLenke5Tekst || 'Endre samtykke for informasjonskapsler', url: global?.footerLenke5Url || forside?.footerLenke5Url || '' },
 ];
 ---
 

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -489,6 +489,21 @@ export interface GlobaleInnstillinger {
   tittel503?: string;
   beskrivelse503?: string;
   vedlikeholdEpost?: string;
+  footerTittel?: string;
+  footerBeskrivelse?: string;
+  footerSosialInstagram?: string;
+  footerSosialLinkedin?: string;
+  footerSosialX?: string;
+  footerLenke1Tekst?: string;
+  footerLenke1Url?: string;
+  footerLenke2Tekst?: string;
+  footerLenke2Url?: string;
+  footerLenke3Tekst?: string;
+  footerLenke3Url?: string;
+  footerLenke4Tekst?: string;
+  footerLenke4Url?: string;
+  footerLenke5Tekst?: string;
+  footerLenke5Url?: string;
 }
 
 export interface UmbracoMedia {
@@ -958,6 +973,21 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         tittel503: props.tittel503 as string || '',
         beskrivelse503: props.beskrivelse503 as string || '',
         vedlikeholdEpost: props.vedlikeholdEpost as string || '',
+        footerTittel: props.footerTittel as string || undefined,
+        footerBeskrivelse: props.footerBeskrivelse as string || undefined,
+        footerSosialInstagram: props.footerSosialInstagram as string || undefined,
+        footerSosialLinkedin: props.footerSosialLinkedin as string || undefined,
+        footerSosialX: props.footerSosialX as string || undefined,
+        footerLenke1Tekst: props.footerLenke1Tekst as string || undefined,
+        footerLenke1Url: props.footerLenke1Url as string || undefined,
+        footerLenke2Tekst: props.footerLenke2Tekst as string || undefined,
+        footerLenke2Url: props.footerLenke2Url as string || undefined,
+        footerLenke3Tekst: props.footerLenke3Tekst as string || undefined,
+        footerLenke3Url: props.footerLenke3Url as string || undefined,
+        footerLenke4Tekst: props.footerLenke4Tekst as string || undefined,
+        footerLenke4Url: props.footerLenke4Url as string || undefined,
+        footerLenke5Tekst: props.footerLenke5Tekst as string || undefined,
+        footerLenke5Url: props.footerLenke5Url as string || undefined,
       } as T;
 
     default:


### PR DESCRIPTION
Gjør footeren redigerbar i `globaleInnstillinger` i stedet for via forside-noden (footeren er global, ikke forside-spesifikk).

- Footer-felt lagt til på `globaleInnstillinger` i en egen **Footer**-gruppe, ved siden av Cookie-melding og Feilsider — alt det globale samlet i én node med tydelige faner.
- `Footer.astro` leser `globaleInnstillinger` først, med fallback til `forside` og deretter hardkodet default, så ingen footer-innhold går tapt.
- `forside` beholder footer-feltene foreløpig; frontend prioriterer `globaleInnstillinger`.