### PR TITLE
Frontend companion til #360 + #362: brand-farge + Om Oss rik artikkelmal

### DIFF
--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -403,14 +403,17 @@ export interface OmOssSeksjonBlokk {
   bildeAlt?: string;
 }
 
+// Om Oss bruker rik artikkelmal (#362): samme artikkelhode + modul-blokkliste som artikkel.
 export interface OmOss {
   id: string;
   documentId: string;
-  heroTittel?: string;
-  heroUndertittel?: string;
-  introTekst?: UmbracoBlock[];
-  misjonTekst?: UmbracoBlock[];
-  seksjoner?: OmOssSeksjonBlokk[];
+  tittel: string;
+  slug: string;
+  ingress: string;
+  artikkelBilde?: UmbracoMedia;
+  bildeAlt?: string;
+  bakgrunn?: string;
+  innhold?: UmbracoBlock[];
   seoTittel?: string;
   seoBeskrivelse?: string;
   seoBilde?: UmbracoMedia;
@@ -882,30 +885,18 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
       } as T;
 
     case 'omOss':
-      // Map seksjoner Block List to OmOssSeksjonBlokk[]
-      const seksjonerItems = (props.seksjoner as any)?.items || [];
-      const seksjoner: OmOssSeksjonBlokk[] = seksjonerItems.map((block: any) => {
-        const content = block.content || block;
-        const blockProps = content.properties || content;
-        const tekst = blockProps.tekst?.tag === '#root'
-          ? richTextToHtml(blockProps.tekst)
-          : (typeof blockProps.tekst === 'string' ? blockProps.tekst : '');
-        return {
-          tittel: blockProps.tittel || '',
-          tekst,
-          bilde: mapMedia(blockProps.bilde),
-          bildeAlt: blockProps.bildeAlt || '',
-        };
-      });
+      // Rik artikkelmal (#362): artikkelhode + innhold-blokkliste, som artikkel/sandkasse.
       return {
         ...base,
-        heroTittel: props.heroTittel as string || '',
-        heroUndertittel: props.heroUndertittel as string || '',
-        introTekst: mapRichText(props.introTekst),
-        misjonTekst: mapRichText(props.misjonTekst),
-        seksjoner,
-        seoTittel: props.seoTittel as string || '',
-        seoBeskrivelse: props.seoBeskrivelse as string || '',
+        tittel: props.tittel as string || item.name,
+        slug: props.slug as string || 'om-oss',
+        ingress: props.ingress as string || '',
+        artikkelBilde: mapMedia(props.artikkelBilde),
+        bildeAlt: props.bildeAlt as string || '',
+        bakgrunn: (props.bakgrunn as string) || 'ingen',
+        innhold: mapArtikkelBlocks(props.innhold),
+        seoTittel: props.seoTittel as string || undefined,
+        seoBeskrivelse: props.seoBeskrivelse as string || undefined,
         seoBilde: mapMedia(props.seoBilde),
       } as T;
 
@@ -1389,6 +1380,19 @@ export function toAbsoluteMediaUrl(url?: string): string | undefined {
 // Helper to get full media URL
 export function getMediaUrl(media?: UmbracoMedia): string | undefined {
   return toAbsoluteMediaUrl(media?.url);
+}
+
+/**
+ * Redaksjonell bakgrunnsfarge (#360) -> brand surface CSS-variabel for artikkelhodet.
+ * brand1/2/3 gir brand-flate; 'ingen'/ukjent/tom gir ingen brand-bakgrunn (undefined).
+ */
+export function bakgrunnSurface(bakgrunn?: string): string | undefined {
+  switch (bakgrunn) {
+    case 'brand1': return 'var(--ds-color-brand1-surface-default)';
+    case 'brand2': return 'var(--ds-color-brand2-surface-default)';
+    case 'brand3': return 'var(--ds-color-brand3-surface-default)';
+    default: return undefined;
+  }
 }
 
 /**

--- a/apps/frontend/src/pages/artikler/[slug].astro
+++ b/apps/frontend/src/pages/artikler/[slug].astro
@@ -4,7 +4,7 @@ import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
 
-import { getArtikkel, getArtikler, getPlainText, getMediaUrl } from '../../lib/umbraco';
+import { getArtikkel, getArtikler, getPlainText, getMediaUrl, bakgrunnSurface } from '../../lib/umbraco';
 import { articleSchema, breadcrumbSchema } from '../../lib/seo';
 
 const { slug } = Astro.params;
@@ -16,6 +16,7 @@ const seoTitle = article.seoTittel || article.tittel;
 const seoDesc = article.seoBeskrivelse || article.ingress || getPlainText(article.innhold, 200);
 const seoImage = article.seoBilde?.url || article.artikkelBilde?.url;
 const heroImage = article.artikkelBilde || article.seoBilde;
+const heroBg = bakgrunnSurface(article.bakgrunn);
 
 const articleJsonLd = articleSchema({
   headline: seoTitle,
@@ -46,7 +47,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <script type="application/ld+json" set:html={JSON.stringify(articleJsonLd).replace(/</g, '\\u003c')} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')} />
 
-  <section class="article-hero" data-layout-block="edge">
+  <section class="article-hero" data-layout-block="edge" style={heroBg ? `background-color: ${heroBg}` : undefined}>
     <div class="article-hero-inner">
       <div class="article-hero-text">
         <h1 class="ds-heading article-title" data-size="xl">{article.tittel}</h1>

--- a/apps/frontend/src/pages/eksempler/[slug].astro
+++ b/apps/frontend/src/pages/eksempler/[slug].astro
@@ -4,7 +4,7 @@ import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import ExampleCard from '../../components/shared/ExampleCard.astro';
 
-import { getEksempel, getEksempler, getPlainText, type Eksempel } from '../../lib/umbraco';
+import { getEksempel, getEksempler, getPlainText, getMediaUrl, bakgrunnSurface, type Eksempel } from '../../lib/umbraco';
 import { eksempelSchema, breadcrumbSchema } from '../../lib/seo';
 
 const { slug } = Astro.params;
@@ -15,6 +15,8 @@ if (!article) return Astro.redirect('/eksempler');
 const seoTitle = article.seoTittel || article.tittel;
 const seoDesc = article.seoBeskrivelse || article.ingress || getPlainText(article.innhold, 200);
 const seoImage = article.seoBilde?.url || article.artikkelBilde?.url;
+const heroImage = article.artikkelBilde || article.seoBilde;
+const heroBg = bakgrunnSurface(article.bakgrunn);
 
 const articleJsonLd = eksempelSchema({
   headline: seoTitle,
@@ -44,8 +46,17 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <script type="application/ld+json" set:html={JSON.stringify(articleJsonLd).replace(/</g, '\\u003c')} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')} />
 
-  <section class="article-hero" data-layout-block="edge">
-    <h1 class="ds-heading article-title" data-size="xl">{article.tittel}</h1>
+  <section class="article-hero" data-layout-block="edge" style={heroBg ? `background-color: ${heroBg}` : undefined}>
+    <div class="article-hero-inner">
+      <div class="article-hero-text">
+        <h1 class="ds-heading article-title" data-size="xl">{article.tittel}</h1>
+      </div>
+      {heroImage?.url && (
+        <div class="article-hero-image">
+          <img src={getMediaUrl(heroImage)} alt={article.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+        </div>
+      )}
+    </div>
   </section>
 
   <ArticleLayout publishedAt={article.publishedAt} byline={(bylineBlock?.content ?? null) as any}>
@@ -74,6 +85,40 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 </Layout>
 
 <style>
+  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  .article-hero-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-inner {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  .article-hero-text { flex: 1; min-width: 0; }
+
+  .article-hero-image { flex-shrink: 0; width: 100%; }
+
+  @media (min-width: 1024px) {
+    .article-hero-image { width: 407px; }
+  }
+
+  .article-hero-img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+    display: block;
+    object-fit: cover;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-img { height: 331px; }
+  }
+
   /* More articles */
   .more-articles {
     padding: 64px 0 120px;

--- a/apps/frontend/src/pages/om-oss.astro
+++ b/apps/frontend/src/pages/om-oss.astro
@@ -1,67 +1,63 @@
 ---
 import Layout from '../components/layout/Layout.astro';
 import ArticleLayout from '../components/shared/ArticleLayout.astro';
-import BlocksRenderer from '../components/shared/BlocksRenderer.astro';
+import ArticleBlocksRenderer from '../components/shared/ArticleBlocksRenderer.astro';
 import NewsCard from '../components/shared/NewsCard.astro';
-import { getOmOss, getOmOssSeksjoner, getArtikler, getPlainText } from '../lib/umbraco';
+import { getOmOss, getArtikler, getPlainText, getMediaUrl, bakgrunnSurface } from '../lib/umbraco';
+import { breadcrumbSchema } from '../lib/seo';
 
-let omOss: any = null;
-let seksjoner: any[] = [];
+// Om Oss er rik artikkelmal (#362): artikkelhode (tittel/ingress/hovedbilde) + innhold-blokkliste.
+const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
+const omOss = await getOmOss({ preview: isPreview });
+
 let latestArticles: any[] = [];
 try {
-  omOss = await getOmOss();
-  if (omOss?.seksjoner && Array.isArray(omOss.seksjoner) && omOss.seksjoner.length > 0) {
-    seksjoner = omOss.seksjoner;
-  } else {
-    const seksjonerRes = await getOmOssSeksjoner();
-    seksjoner = seksjonerRes.data;
-  }
   const artiklerRes = await getArtikler(3);
   latestArticles = artiklerRes.data;
 } catch (e) {
-  console.error('Failed to fetch om-oss CMS data:', e);
+  console.error('Failed to fetch om-oss articles:', e);
 }
 
-const heroTittel = omOss?.heroTittel || 'Om KI Norge';
-const heroUndertittel = omOss?.heroUndertittel || 'Mange virksomheter vil ta i bruk kunstig intelligens, men vet ikke helt hvor de skal begynne, eller om de gjør det riktig.';
+const tittel = omOss?.tittel || 'Om KI Norge';
 const seoTitle = omOss?.seoTittel || 'Om oss';
-const seoDesc = omOss?.seoBeskrivelse || 'Om KI Norge – en nasjonal satsing for ansvarlig bruk av kunstig intelligens.';
+const seoDesc = omOss?.seoBeskrivelse || omOss?.ingress || 'Om KI Norge – en nasjonal satsing for ansvarlig bruk av kunstig intelligens.';
+const seoImage = omOss?.seoBilde?.url || omOss?.artikkelBilde?.url;
+const heroImage = omOss?.artikkelBilde || omOss?.seoBilde;
+const heroBg = bakgrunnSurface(omOss?.bakgrunn);
+
+const breadcrumbJsonLd = breadcrumbSchema([
+  { name: 'Forside', url: '/' },
+  { name: tittel, url: '/om-oss' },
+]);
+
+const allBlocks = omOss?.innhold ?? [];
+const bylineBlock = allBlocks.find(b => b.contentType === 'artikkelByline');
+const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 ---
 
-<Layout title={seoTitle} description={seoDesc}>
-  <!-- Hero: title sits on the pink background, aligned to content column -->
-  <section class="article-hero" data-layout-block="edge">
-    <h1 class="ds-heading article-title" data-size="xl">{heroTittel}</h1>
+<Layout title={seoTitle} description={seoDesc} ogImage={seoImage}>
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')} />
+
+  <section class="article-hero" data-layout-block="edge" style={heroBg ? `background-color: ${heroBg}` : undefined}>
+    <div class="article-hero-inner">
+      <div class="article-hero-text">
+        <h1 class="ds-heading article-title" data-size="xl">{tittel}</h1>
+      </div>
+      {heroImage?.url && (
+        <div class="article-hero-image">
+          <img src={getMediaUrl(heroImage)} alt={omOss?.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+        </div>
+      )}
+    </div>
   </section>
 
-  <!-- Cream card with sidebar and main content -->
-  <ArticleLayout publishedAt={omOss?.publishedAt}>
-
-    <!-- Ingress -->
-    <p class="article-ingress ds-paragraph" data-size="lg">{heroUndertittel}</p>
-
-    <!-- Intro text blocks -->
-    {omOss?.introTekst && (
-      <div class="om-oss-intro">
-        <BlocksRenderer blocks={omOss.introTekst} />
-      </div>
+  <ArticleLayout publishedAt={omOss?.publishedAt} byline={(bylineBlock?.content ?? null) as any}>
+    {omOss?.ingress && (
+      <p class="article-ingress ds-paragraph" data-size="lg">{omOss.ingress}</p>
     )}
-
-    <!-- Sections (text-only, no images) -->
-    {seksjoner.map((seksjon: any) => (
-      <section class="om-oss-seksjon">
-        <h2 class="ds-heading om-oss-seksjon-tittel" data-size="sm">{seksjon.tittel}</h2>
-        <div class="om-oss-seksjon-tekst">
-          {typeof seksjon.tekst === 'string'
-            ? <div set:html={seksjon.tekst} />
-            : <BlocksRenderer blocks={seksjon.tekst} />
-          }
-        </div>
-      </section>
-    ))}
+    <ArticleBlocksRenderer blocks={contentBlocks} defaultDate={omOss?.publishedAt} />
   </ArticleLayout>
 
-  <!-- Aktuelt -->
   {latestArticles.length > 0 && (
     <section class="om-oss-aktuelt" data-layout-block="content">
       <h2 class="om-oss-aktuelt-heading">Aktuelt</h2>
@@ -81,15 +77,38 @@ const seoDesc = omOss?.seoBeskrivelse || 'Om KI Norge – en nasjonal satsing fo
 </Layout>
 
 <style>
-  /* Sections */
-  .om-oss-intro {
-    margin: 0;
-  }
-
-  .om-oss-seksjon {
+  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  .article-hero-inner {
     display: flex;
     flex-direction: column;
-    gap: var(--ds-size-3);
+    gap: 32px;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-inner {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  .article-hero-text { flex: 1; min-width: 0; }
+
+  .article-hero-image { flex-shrink: 0; width: 100%; }
+
+  @media (min-width: 1024px) {
+    .article-hero-image { width: 407px; }
+  }
+
+  .article-hero-img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+    display: block;
+    object-fit: cover;
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero-img { height: 331px; }
   }
 
   /* Aktuelt */
@@ -106,9 +125,7 @@ const seoDesc = omOss?.seoBeskrivelse || 'Om KI Norge – en nasjonal satsing fo
   }
 
   @media (min-width: 1024px) {
-    .om-oss-aktuelt-heading {
-      font-size: 40px;
-    }
+    .om-oss-aktuelt-heading { font-size: 40px; }
   }
 
   .om-oss-aktuelt-grid {
@@ -118,14 +135,10 @@ const seoDesc = omOss?.seoBeskrivelse || 'Om KI Norge – en nasjonal satsing fo
   }
 
   @media (min-width: 768px) {
-    .om-oss-aktuelt-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
+    .om-oss-aktuelt-grid { grid-template-columns: repeat(2, 1fr); }
   }
 
   @media (min-width: 1024px) {
-    .om-oss-aktuelt-grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
+    .om-oss-aktuelt-grid { grid-template-columns: repeat(3, 1fr); }
   }
 </style>

--- a/apps/frontend/src/pages/sandkasse/index.astro
+++ b/apps/frontend/src/pages/sandkasse/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
-import { getSandkasse, getMediaUrl, getPlainText } from '../../lib/umbraco';
+import { getSandkasse, getMediaUrl, getPlainText, bakgrunnSurface } from '../../lib/umbraco';
 import { breadcrumbSchema } from '../../lib/seo';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
@@ -21,40 +21,23 @@ const breadcrumbJsonLd = breadcrumbSchema([
   { name: sandkasse.tittel, url: '/sandkasse' },
 ]);
 
-const bakgrunn = sandkasse.bakgrunn || 'hvit';
-const isLightBlueBg = bakgrunn === 'lyseblaa';
+const heroBg = bakgrunnSurface(sandkasse.bakgrunn);
 ---
 
 <Layout title={seoTitle} description={seoDesc} ogImage={seoImage}>
   <div class="article-page grid" data-layout-block="content">
-    <section class={`article-hero ${isLightBlueBg ? 'col-all article-hero--bg-lyseblaa' : 'col-center-10'}`}>
-      {isLightBlueBg ? (
-        <div class={`grid article-hero-bg-grid`}>
-          <div class="article-hero-inner col-center-10">
-            <div class="article-hero-text">
-              <h1 class="article-title">{sandkasse.tittel}</h1>
-              {sandkasse.ingress && <p class="article-ingress">{sandkasse.ingress}</p>}
-            </div>
-            {heroImage?.url && (
-              <div class="article-hero-image">
-                <img src={getMediaUrl(heroImage)} alt={sandkasse.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
-              </div>
-            )}
-          </div>
+    <section class="article-hero col-center-10" style={heroBg ? `background-color: ${heroBg}` : undefined}>
+      <div class="article-hero-inner">
+        <div class="article-hero-text">
+          <h1 class="article-title">{sandkasse.tittel}</h1>
+          {sandkasse.ingress && <p class="article-ingress">{sandkasse.ingress}</p>}
         </div>
-      ) : (
-        <div class="article-hero-inner">
-          <div class="article-hero-text">
-            <h1 class="article-title">{sandkasse.tittel}</h1>
-            {sandkasse.ingress && <p class="article-ingress">{sandkasse.ingress}</p>}
+        {heroImage?.url && (
+          <div class="article-hero-image">
+            <img src={getMediaUrl(heroImage)} alt={sandkasse.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
           </div>
-          {heroImage?.url && (
-            <div class="article-hero-image">
-              <img src={getMediaUrl(heroImage)} alt={sandkasse.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
-            </div>
-          )}
-        </div>
-      )}
+        )}
+      </div>
     </section>
     
     <ArticleBlocksRenderer blocks={sandkasse.innhold} />


### PR DESCRIPTION
Frontend som matcher CMS-skjemaet etter at #360 + #362 er merget. Én PR, ingen bakoverkompat (pre-launch).

**#360 (bakgrunn brand-farge).** `bakgrunnSurface()`-helper mapper `brand1/2/3` → `--ds-color-brand{N}-surface-default` på artikkelhodet. Anvendt på artikkel, eksempel, sandkasse og om-oss. `ingen`/ukjent gir ingen brand-bakgrunn. Fjernet legacy `lyseblaa`-spesialcasing i sandkasse.

**#362 (Om Oss rik artikkelmal).** `om-oss` leser ny `innhold`-blokkliste via `ArticleBlocksRenderer` + rik artikkelhode (tittel/ingress/hovedbilde). Fjernet gamle felt (`heroTittel`/`heroUndertittel`/`introTekst`/`misjonTekst`/`seksjoner`) fra `OmOss`-typen og mappingen.

**Bonus.** Eksempel-detalj fikk hovedbilde i hodet (samme gap som artikkel, jf. #365).

Stacked på #365 (preview-CSP + hovedbilde). Bygger grønt. Retarget til main når #365 er merget.