### PR TITLE
Forside modularisert til reorderbar block-liste

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -54,6 +54,7 @@ public class ContentTypeComponent : IAsyncComponent
     private IDataType _blockListOmOssDt = null!;
     private IDataType _blockListVeiledningStegDt = null!;
     private IDataType _blockListVeiledningGuideDt = null!;
+    private IDataType _blockListForsideDt = null!;
 
     public ContentTypeComponent(
         IContentTypeService contentTypeService,
@@ -170,6 +171,20 @@ public class ContentTypeComponent : IAsyncComponent
             if (_contentTypeService.Get("eksempelKontakt") == null)
                 CreateEksempelKontaktElement();
 
+            // Forside-moduler (block list)
+            if (_contentTypeService.Get("forsideHero") == null)
+                CreateForsideHeroElement();
+            if (_contentTypeService.Get("forsideAktuelt") == null)
+                CreateForsideAktueltElement();
+            if (_contentTypeService.Get("forsideArrangementer") == null)
+                CreateForsideArrangementerElement();
+            if (_contentTypeService.Get("forsideVeiledning") == null)
+                CreateForsideVeiledningElement();
+            if (_contentTypeService.Get("forsideLaerAvAndre") == null)
+                CreateForsideLaerAvAndreElement();
+            if (_contentTypeService.Get("forsideSandkasse") == null)
+                CreateForsideSandkasseElement();
+
             CreateBlockListDataTypes();
 
             MigrateVeiledningElementNames();
@@ -189,6 +204,7 @@ public class ContentTypeComponent : IAsyncComponent
 
             RefreshMultiBlockListAllowedModules("Block List - Veiledning Steg", VeiledningStegModules);
             RefreshMultiBlockListAllowedModules("Block List - Veiledning Guide", VeiledningGuideModules);
+            RefreshMultiBlockListAllowedModules("Block List - Forside Seksjoner", ForsideModules);
 
             // One-shot removal of legacy CTs that are no longer part of the product
             // (FAQ, KI-ordbok, Merkelapper, veiledningOversikt). Runs early so containers
@@ -1066,6 +1082,9 @@ public class ContentTypeComponent : IAsyncComponent
         _blockListVeiledningGuideDt = CreateOrGetMultiBlockListDataType(
             "Block List - Veiledning Guide",
             VeiledningGuideModules);
+        _blockListForsideDt = CreateOrGetMultiBlockListDataType(
+            "Block List - Forside Seksjoner",
+            ForsideModules);
     }
 
     private IDataType CreateOrGetBlockListDataType(string name, string elementTypeAlias)
@@ -1266,6 +1285,17 @@ public class ContentTypeComponent : IAsyncComponent
         "veiledningTekst",
         "veiledningTrekkspill",
         "veiledningObs",
+    };
+
+    // Forside-moduler i Figma-rekkefølge (default når redaktør bygger siden).
+    private static readonly string[] ForsideModules =
+    {
+        "forsideHero",
+        "forsideAktuelt",
+        "forsideArrangementer",
+        "forsideVeiledning",
+        "forsideLaerAvAndre",
+        "forsideSandkasse",
     };
 
     // ── RichText configurations ────────────────────────────────────────
@@ -2423,70 +2453,9 @@ public class ContentTypeComponent : IAsyncComponent
             AllowedAsRoot = true,
         };
 
-        // Tab: Hero
-        ct.AddPropertyGroup("hero", "Hero");
-        ct.AddPropertyType(Prop("heroOverskrift", "Overskrift", _textStringDt), "hero");
-        ct.AddPropertyType(Prop("heroTekst", "Tekst", _richTextDt), "hero");
-        ct.AddPropertyType(Prop("heroBilde", "Bilde", _mediaPickerDt), "hero");
-
-        // Tab: Tre råd
-        ct.AddPropertyGroup("treRaad", "Tre råd");
-        ct.AddPropertyType(Prop("raadTittel", "Tittel", _textStringDt), "treRaad");
-        ct.AddPropertyType(Prop("tips", "Tips", _blockListTipsDt), "treRaad");
-
-        // Tab: Sandkassen
-        ct.AddPropertyGroup("sandkassen", "Sandkassen");
-        ct.AddPropertyType(Prop("sandkasseTittel", "Tittel", _textStringDt), "sandkassen");
-        ct.AddPropertyType(Prop("sandkasseTekst", "Tekst", _richTextDt), "sandkassen");
-        ct.AddPropertyType(Prop("sandkasseUrl", "URL", _textStringDt), "sandkassen");
-
-        // Tab: Veiledning
-        ct.AddPropertyGroup("veiledning", "Veiledning");
-        ct.AddPropertyType(Prop("veiledningOverskrift", "Overskrift", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning1Tittel", "Veiledning 1 Tittel", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning1Beskrivelse", "Veiledning 1 Beskrivelse", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning1Url", "Veiledning 1 URL", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning2Tittel", "Veiledning 2 Tittel", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning2Beskrivelse", "Veiledning 2 Beskrivelse", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning2Url", "Veiledning 2 URL", _textStringDt), "veiledning");
-
-        // Tab: Aktuelt
-        ct.AddPropertyGroup("aktuelt", "Aktuelt");
-        ct.AddPropertyType(Prop("aktueltOverskrift", "Overskrift", _textStringDt), "aktuelt");
-        ct.AddPropertyType(Prop("aktueltLenkeTekst", "Lenketekst", _textStringDt), "aktuelt");
-        ct.AddPropertyType(Prop("aktueltLenkeUrl", "Lenke-URL", _textStringDt), "aktuelt");
-
-        // Tab: Arrangement
-        ct.AddPropertyGroup("arrangement", "Arrangement");
-        ct.AddPropertyType(Prop("arrangementOverskrift", "Overskrift", _textStringDt), "arrangement");
-        ct.AddPropertyType(Prop("arrangementKommendeTekst", "Kommende tekst", _textStringDt), "arrangement");
-        ct.AddPropertyType(Prop("arrangementAvholdteTekst", "Avholdte tekst", _textStringDt), "arrangement");
-
-        // Tab: Bunn (Footer)
-        ct.AddPropertyGroup("bunn", "Bunn (Footer)");
-        ct.AddPropertyType(Prop("footerTittel", "Merkenavn", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerBeskrivelse", "Beskrivelse", _textAreaDt), "bunn");
-        ct.AddPropertyType(Prop("footerSosialInstagram", "Instagram", _textStringDt, description: "URL til Instagram-profil"), "bunn");
-        ct.AddPropertyType(Prop("footerSosialLinkedin", "LinkedIn", _textStringDt, description: "URL til LinkedIn-profil"), "bunn");
-        ct.AddPropertyType(Prop("footerSosialX", "X", _textStringDt, description: "URL til X-profil"), "bunn");
-        ct.AddPropertyType(Prop("footerLenke1Tekst", "Lenke 1 tekst", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke1Url", "Lenke 1 URL", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke2Tekst", "Lenke 2 tekst", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke2Url", "Lenke 2 URL", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke3Tekst", "Lenke 3 tekst", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke3Url", "Lenke 3 URL", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke4Tekst", "Lenke 4 tekst", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke4Url", "Lenke 4 URL", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke5Tekst", "Lenke 5 tekst", _textStringDt), "bunn");
-        ct.AddPropertyType(Prop("footerLenke5Url", "Lenke 5 URL", _textStringDt), "bunn");
-
-        // Tab: Rekkefølge (Order)
-        ct.AddPropertyGroup("rekkefolge", "Rekkefølge");
-        ct.AddPropertyType(Prop("rekkefolgeVeiledning", "Veiledning", _numericDt, description: "Rekkefølge for Veiledning-seksjonen (1-5)"), "rekkefolge");
-        ct.AddPropertyType(Prop("rekkefolgeAktuelt", "Aktuelt", _numericDt, description: "Rekkefølge for Aktuelt-seksjonen (1-5)"), "rekkefolge");
-        ct.AddPropertyType(Prop("rekkefolgeTreRaad", "Tre råd", _numericDt, description: "Rekkefølge for Tre råd-seksjonen (1-5)"), "rekkefolge");
-        ct.AddPropertyType(Prop("rekkefolgeSandkasse", "Sandkasse", _numericDt, description: "Rekkefølge for Sandkasse-seksjonen (1-5)"), "rekkefolge");
-        ct.AddPropertyType(Prop("rekkefolgeArrangement", "Arrangement", _numericDt, description: "Rekkefølge for Arrangement-seksjonen (1-5)"), "rekkefolge");
+        // Forsiden er modularisert: ett block-list-felt med moduler (reorderbart).
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("seksjoner", "Seksjoner", _blockListForsideDt, description: "Bygg opp forsiden ved å legge til moduler. Reorder ved drag og slipp."), "innhold");
 
         // Tab: SEO
         ct.AddPropertyGroup("seo", "SEO");
@@ -2494,6 +2463,81 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("seoBeskrivelse", "SEO-beskrivelse", _textAreaDt, description: "Overstyr beskrivelse i søkeresultater og sosiale medier"), "seo");
         ct.AddPropertyType(Prop("seoBilde", "SEO-bilde", _mediaPickerDt, description: "Bilde som vises ved deling på sosiale medier"), "seo");
 
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    // --- Forside-moduler (block list) ---
+
+    private IContentType CreateForsideHeroElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideHero", Name = "Forside Hero", Description = "Hero-seksjon øverst på forsiden", Icon = "icon-home", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("komIGangTekst", "Kom i gang-ledetekst", _textStringDt, description: "Liten ledetekst foran lenken, f.eks. \"Kom i gang\"."), "innhold");
+        ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt), "innhold");
+        ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+        ct.AddPropertyType(Prop("illustrasjon", "Illustrasjon", _mediaPickerDt), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideAktueltElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideAktuelt", Name = "Forside Aktuelt", Description = "Seksjon med siste artikler (innhold hentes automatisk)", Icon = "icon-newspaper-alt", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideArrangementerElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideArrangementer", Name = "Forside Arrangementer", Description = "Seksjon med kommende arrangement (innhold hentes automatisk)", Icon = "icon-calendar", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideVeiledningElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideVeiledning", Name = "Forside Veiledning", Description = "Fremhevet veiledning på forsiden", Icon = "icon-book-alt", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("label", "Label", _textStringDt, description: "Liten etikett over tittelen, f.eks. \"Veiledning\"."), "innhold");
+        ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("ingress", "Ingress", _textAreaDt), "innhold");
+        ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt), "innhold");
+        ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+        ct.AddPropertyType(Prop("illustrasjon", "Illustrasjon", _mediaPickerDt), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideLaerAvAndreElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideLaerAvAndre", Name = "Forside Lær av andre", Description = "Seksjon med eksempler (innhold hentes automatisk)", Icon = "icon-light-bulb", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideSandkasseElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideSandkasse", Name = "Forside Sandkasse", Description = "Sandkasse-CTA på forsiden", Icon = "icon-box", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("tekst", "Tekst", _richTextDt), "innhold");
+        ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt), "innhold");
+        ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+        ct.AddPropertyType(Prop("illustrasjon", "Illustrasjon", _mediaPickerDt), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -2780,64 +2824,63 @@ public class ContentTypeComponent : IAsyncComponent
     {
         var ct = _contentTypeService.Get("forside");
         if (ct == null) return;
-        if (ct.PropertyTypeExists("veiledningOverskrift")) return; // already migrated
+        // Ferdig migrert: har seksjoner-feltet og ingen gamle flate felt igjen.
+        if (ct.PropertyTypeExists("seksjoner") && !ct.PropertyTypeExists("heroOverskrift")) return;
 
-        // Tab: Veiledning
-        ct.AddPropertyGroup("veiledning", "Veiledning");
-        ct.AddPropertyType(Prop("veiledningOverskrift", "Overskrift", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning1Tittel", "Veiledning 1 Tittel", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning1Beskrivelse", "Veiledning 1 Beskrivelse", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning1Url", "Veiledning 1 URL", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning2Tittel", "Veiledning 2 Tittel", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning2Beskrivelse", "Veiledning 2 Beskrivelse", _textStringDt), "veiledning");
-        ct.AddPropertyType(Prop("veiledning2Url", "Veiledning 2 URL", _textStringDt), "veiledning");
+        bool changed = false;
 
-        // Tab: Aktuelt
-        ct.AddPropertyGroup("aktuelt", "Aktuelt");
-        ct.AddPropertyType(Prop("aktueltOverskrift", "Overskrift", _textStringDt), "aktuelt");
-        ct.AddPropertyType(Prop("aktueltLenkeTekst", "Lenketekst", _textStringDt), "aktuelt");
-        ct.AddPropertyType(Prop("aktueltLenkeUrl", "Lenke-URL", _textStringDt), "aktuelt");
-
-        // Tab: Arrangement
-        ct.AddPropertyGroup("arrangement", "Arrangement");
-        ct.AddPropertyType(Prop("arrangementOverskrift", "Overskrift", _textStringDt), "arrangement");
-        ct.AddPropertyType(Prop("arrangementKommendeTekst", "Kommende tekst", _textStringDt), "arrangement");
-        ct.AddPropertyType(Prop("arrangementAvholdteTekst", "Avholdte tekst", _textStringDt), "arrangement");
-
-        _contentTypeService.Save(ct);
-
-        // Migrate footer fields
-        if (!ct.PropertyTypeExists("footerTittel"))
+        // Forsiden er modularisert (block list). Fjern alle gamle flate felt: Hero, Tre råd,
+        // Sandkasse, Veiledning, Aktuelt, Arrangement, Footer (flyttet til globaleInnstillinger),
+        // Rekkefølge (erstattet av drag-og-slipp i block lista). Ingen innhold går tapt.
+        var legacyFields = new[]
         {
-            ct.AddPropertyGroup("bunn", "Bunn (Footer)");
-            ct.AddPropertyType(Prop("footerTittel", "Merkenavn", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerBeskrivelse", "Beskrivelse", _textAreaDt), "bunn");
-            ct.AddPropertyType(Prop("footerSosialInstagram", "Instagram", _textStringDt, description: "URL til Instagram-profil"), "bunn");
-            ct.AddPropertyType(Prop("footerSosialLinkedin", "LinkedIn", _textStringDt, description: "URL til LinkedIn-profil"), "bunn");
-            ct.AddPropertyType(Prop("footerSosialX", "X", _textStringDt, description: "URL til X-profil"), "bunn");
-            ct.AddPropertyType(Prop("footerLenke1Tekst", "Lenke 1 tekst", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke1Url", "Lenke 1 URL", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke2Tekst", "Lenke 2 tekst", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke2Url", "Lenke 2 URL", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke3Tekst", "Lenke 3 tekst", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke3Url", "Lenke 3 URL", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke4Tekst", "Lenke 4 tekst", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke4Url", "Lenke 4 URL", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke5Tekst", "Lenke 5 tekst", _textStringDt), "bunn");
-            ct.AddPropertyType(Prop("footerLenke5Url", "Lenke 5 URL", _textStringDt), "bunn");
-            _contentTypeService.Save(ct);
+            "heroOverskrift", "heroTekst", "heroBilde",
+            "raadTittel", "tips",
+            "sandkasseTittel", "sandkasseTekst", "sandkasseUrl",
+            "veiledningOverskrift",
+            "veiledning1Tittel", "veiledning1Beskrivelse", "veiledning1Url",
+            "veiledning2Tittel", "veiledning2Beskrivelse", "veiledning2Url",
+            "aktueltOverskrift", "aktueltLenkeTekst", "aktueltLenkeUrl",
+            "arrangementOverskrift", "arrangementKommendeTekst", "arrangementAvholdteTekst",
+            "footerTittel", "footerBeskrivelse", "footerSosialInstagram", "footerSosialLinkedin", "footerSosialX",
+            "footerLenke1Tekst", "footerLenke1Url", "footerLenke2Tekst", "footerLenke2Url",
+            "footerLenke3Tekst", "footerLenke3Url", "footerLenke4Tekst", "footerLenke4Url",
+            "footerLenke5Tekst", "footerLenke5Url",
+            "rekkefolgeVeiledning", "rekkefolgeAktuelt", "rekkefolgeTreRaad", "rekkefolgeSandkasse", "rekkefolgeArrangement",
+        };
+        foreach (var alias in legacyFields)
+        {
+            if (ct.PropertyTypeExists(alias))
+            {
+                ct.RemovePropertyType(alias);
+                changed = true;
+            }
         }
 
-        // Migrate reorder fields
-        if (!ct.PropertyTypeExists("rekkefolgeVeiledning"))
+        // Fjern de tomme gamle gruppene (samme mønster som MigrateGlobaleInnstillinger).
+        foreach (var groupAlias in new[] { "hero", "treRaad", "sandkassen", "veiledning", "aktuelt", "arrangement", "bunn", "rekkefolge" })
         {
-            ct.AddPropertyGroup("rekkefolge", "Rekkefølge");
-            ct.AddPropertyType(Prop("rekkefolgeVeiledning", "Veiledning", _numericDt, description: "Rekkefølge for Veiledning-seksjonen (1-5)"), "rekkefolge");
-            ct.AddPropertyType(Prop("rekkefolgeAktuelt", "Aktuelt", _numericDt, description: "Rekkefølge for Aktuelt-seksjonen (1-5)"), "rekkefolge");
-            ct.AddPropertyType(Prop("rekkefolgeTreRaad", "Tre råd", _numericDt, description: "Rekkefølge for Tre råd-seksjonen (1-5)"), "rekkefolge");
-            ct.AddPropertyType(Prop("rekkefolgeSandkasse", "Sandkasse", _numericDt, description: "Rekkefølge for Sandkasse-seksjonen (1-5)"), "rekkefolge");
-            ct.AddPropertyType(Prop("rekkefolgeArrangement", "Arrangement", _numericDt, description: "Rekkefølge for Arrangement-seksjonen (1-5)"), "rekkefolge");
+            var grp = ct.PropertyGroups.FirstOrDefault(g => g.Alias == groupAlias);
+            if (grp != null && !grp.PropertyTypes.Any())
+            {
+                ct.PropertyGroups.Remove(groupAlias);
+                changed = true;
+            }
+        }
+
+        // Legg til block-list-feltet hvis det mangler.
+        if (!ct.PropertyTypeExists("seksjoner"))
+        {
+            if (!ct.PropertyGroups.Any(g => g.Alias == "innhold"))
+                ct.AddPropertyGroup("innhold", "Innhold");
+            ct.AddPropertyType(Prop("seksjoner", "Seksjoner", _blockListForsideDt, description: "Bygg opp forsiden ved å legge til moduler. Reorder ved drag og slipp."), "innhold");
+            changed = true;
+        }
+
+        if (changed)
+        {
             _contentTypeService.Save(ct);
+            Console.WriteLine("ContentTypeComposer: Modulariserte forside (block list, fjernet gamle flate felt)");
         }
     }
 

--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -1,0 +1,195 @@
+---
+// Rendrer forsidens modul-blokker (forside.seksjoner) i redaktørens rekkefølge.
+// Komponenten gjør INGEN fetch — auto-data (artikler/arrangement/eksempler) sendes inn.
+// Hver modul faller tilbake til dagens hardkodede verdier når feltet er tomt.
+import Hero from './Hero.astro';
+import NewsCard from '../shared/NewsCard.astro';
+import CardGrid from '../shared/CardGrid.astro';
+import EventCard from '../shared/EventCard.astro';
+import ArrowLink from '../shared/ArrowLink.astro';
+import ExampleLinkCards from '../shared/ExampleLinkCards.astro';
+import TextWithImage from '../shared/TextWithImage.astro';
+import { getMediaUrl, type ForsideSeksjon, type Kalenderhendelse } from '../../lib/umbraco';
+
+interface Props {
+  seksjoner: ForsideSeksjon[];
+  latestArticles: any[];
+  nextEvent: Kalenderhendelse | null;
+  nextEventDate: { day: string; month: string; year: string } | null;
+  nextEventMultiDay?: boolean | string;
+  eksempelKort: { href: string; title: string; tag: string }[];
+}
+const { seksjoner, latestArticles, nextEvent, nextEventDate, nextEventMultiDay, eksempelKort } = Astro.props;
+const featuredArticle = latestArticles[0];
+---
+
+{seksjoner.map((block) => {
+  if (block.contentType === 'forsideHero') {
+    return (
+      <Hero
+        overskrift={block.overskrift}
+        komIGangTekst={block.komIGangTekst}
+        lenketekst={block.lenketekst}
+        lenkeUrl={block.lenkeUrl}
+        illustrasjon={block.illustrasjon ? getMediaUrl(block.illustrasjon) : undefined}
+      />
+    );
+  }
+
+  if (block.contentType === 'forsideAktuelt') {
+    return (
+      <section class="aktuelt" data-layout-block="edge">
+        <div data-layout-block="content">
+          <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Aktuelt'}</h2>
+          {featuredArticle && (
+            <NewsCard
+              href={`/artikler/${featuredArticle.slug}`}
+              title={featuredArticle.tittel}
+              tagColor="brand1"
+              lead={featuredArticle.lead || 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.'}
+              image={featuredArticle.image}
+              imageAlt=""
+              variant="featured"
+            />
+          )}
+          <CardGrid columns={3} divided>
+            {latestArticles.slice(1, 4).map((article) => (
+              <NewsCard
+                href={`/artikler/${article.slug}`}
+                title={article.tittel}
+                variant="image"
+                image={article.image}
+                date={article.publishedAt}
+              />
+            ))}
+          </CardGrid>
+          <ArrowLink href="/artikler" text="Se alle artikler" />
+        </div>
+      </section>
+    );
+  }
+
+  if (block.contentType === 'forsideArrangementer') {
+    return (
+      <section class="arrangementer-section" data-layout-block="content">
+        <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Kommende arrangementer'}</h2>
+        {nextEvent && nextEventDate && (
+          <EventCard
+            href={`/kalender/${nextEvent.slug}`}
+            title={nextEvent.tittel}
+            description={nextEvent.ingress || ''}
+            day={nextEventDate.day}
+            month={nextEventDate.month}
+            year={nextEventDate.year}
+            time={nextEvent.tid || ''}
+            timeNote={nextEventMultiDay ? 'Arrangement over flere dager' : undefined}
+            location={nextEvent.sted || ''}
+          />
+        )}
+        <ArrowLink href="/kalender" text="Se alle arrangementer" />
+      </section>
+    );
+  }
+
+  if (block.contentType === 'forsideVeiledning') {
+    return (
+      <section class="veiledning-section" data-layout-block="edge">
+        <div data-layout-block="content">
+          <TextWithImage
+            title={block.tittel || 'Gjør dataene KI-klare'}
+            href={block.lenkeUrl || '/veiledning'}
+            image={block.illustrasjon ? getMediaUrl(block.illustrasjon) : '/woman-speaking.svg'}
+            imageAlt="Illustrasjon"
+            label={block.label || 'Veiledning'}
+          >
+            <p slot="body">{block.ingress || 'Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.'}</p>
+          </TextWithImage>
+        </div>
+      </section>
+    );
+  }
+
+  if (block.contentType === 'forsideLaerAvAndre') {
+    return (
+      <section data-layout-block="content" class="examples-section">
+        <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Lær av andre'}</h2>
+        <ExampleLinkCards cards={eksempelKort} />
+        <ArrowLink href="/eksempler" text="Se alle eksempler" />
+      </section>
+    );
+  }
+
+  if (block.contentType === 'forsideSandkasse') {
+    return (
+      <section class="sandkasse-section" data-layout-block="edge">
+        <div data-layout-block="content">
+          <h2 class="sandkasse-title">{block.overskrift || 'Den regulatoriske sandkassen'}</h2>
+          {block.tekstHtml
+            ? <div class="sandkasse-desc" set:html={block.tekstHtml} />
+            : <p class="sandkasse-desc">Juridisk veiledning for deg som ønsker å utvikle et risikofylt KI-prosjekt.</p>}
+          {block.lenkeUrl && <ArrowLink href={block.lenkeUrl} text={block.lenketekst || 'Les mer'} />}
+        </div>
+      </section>
+    );
+  }
+
+  return null;
+})}
+
+<style>
+  :global(main) > * + * {
+    margin-top: var(--ds-size-6);
+  }
+
+  .section-heading {
+    margin: 0 0 var(--ds-size-8);
+  }
+
+  /* ── Aktuelt ─────────────────────────────────────────── */
+  .aktuelt {
+    background-color: var(--ds-color-brand2-surface-default);
+  }
+
+  .aktuelt :global(.card-grid) {
+    margin-bottom: var(--ds-size-6);
+  }
+
+  .aktuelt :global(.news-card--featured) {
+    margin-bottom: var(--ds-size-8);
+  }
+
+  /* ── Kommende arrangementer (egen seksjon, uten rosa strek) ── */
+  .arrangementer-section :global(.event-card) {
+    margin-bottom: var(--ds-size-6);
+  }
+
+  /* ── Lær av andre ────────────────────────────────────── */
+  .examples-section {
+    & :global(.arrow-link) {
+      margin-block-start: var(--ds-size-6);
+    }
+  }
+
+  /* ── Sandkassen ──────────────────────────────────────── */
+  .sandkasse-section {
+    background-color: var(--ds-color-base-active);
+    color: var(--ds-color-base-contrast-default);
+    padding-block: var(--ds-size-22);
+  }
+
+  .sandkasse-title {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-size-3);
+    font-size: var(--ds-heading-lg-font-size);
+    font-weight: 600;
+    margin: 0 0 var(--ds-size-3);
+  }
+
+  .sandkasse-desc {
+    font-size: var(--ds-body-md-font-size);
+    margin: 0;
+    opacity: 0.85;
+    max-width: 500px;
+  }
+</style>

--- a/apps/frontend/src/components/landing/Hero.astro
+++ b/apps/frontend/src/components/landing/Hero.astro
@@ -1,19 +1,34 @@
 ---
-// Hero — tagline with illustration, "Kom i gang" CTA
+// Hero — tagline with illustration, "Kom i gang" CTA. Feltene er redaksjonelle
+// (forsideHero-modulen); defaults under brukes når feltet er tomt.
 import AkselIcon from '../shared/AkselIcon.astro';
+interface Props {
+  overskrift?: string;
+  komIGangTekst?: string;
+  lenketekst?: string;
+  lenkeUrl?: string;
+  illustrasjon?: string;
+}
+const {
+  overskrift = 'Ansvarlig bruk av kunstig intelligens. For norske virksomheter, på norske premisser.',
+  komIGangTekst = 'Kom i gang',
+  lenketekst = 'Hva er KI og hva kan du bruke det til?',
+  lenkeUrl = '/veiledning/hva-er-ki',
+  illustrasjon = '/frontpage.svg',
+} = Astro.props;
 ---
 
 <section class="hero" data-layout-block="content">
   <div class="hero-grid">
     <div class="hero-text">
       <img src="/logo.svg" alt="KI Norge" class="hero-logo" />
-      <p class="hero-tagline ds-heading" data-size="xl"><strong>Felleskap for KI</strong> — innovativ og ansvarlig bruk av kunstig intelligens</p>
+      <p class="hero-tagline ds-heading" data-size="xl">{overskrift}</p>
       <p class="hero-cta">
-        Kom i gang: <a class="hero-cta-link ds-focus" href="/veiledning/hva-er-ki">Hva er KI og hva kan du bruke det til? <span class="hero-cta-arrow"><AkselIcon name="ArrowRight" size={24} /></span></a>
+        {komIGangTekst}: <a class="hero-cta-link ds-focus" href={lenkeUrl}>{lenketekst} <span class="hero-cta-arrow"><AkselIcon name="ArrowRight" size={24} /></span></a>
       </p>
     </div>
     <div class="hero-illustration">
-      <img src="/frontpage.svg" alt="" width="400" height="300" fetchpriority="high" />
+      <img src={illustrasjon} alt="" width="400" height="300" fetchpriority="high" />
     </div>
   </div>
 </section>

--- a/apps/frontend/src/components/layout/Footer.astro
+++ b/apps/frontend/src/components/layout/Footer.astro
@@ -1,26 +1,23 @@
 ---
-// Footer — CMS-redigerbar via globaleInnstillinger (footer flyttet dit fra forside).
-// Leser globaleInnstillinger først, faller tilbake til forside (overgangsperiode til
-// forside-footer-feltene fjernes), så hardkodet default. Ingen footer-innhold går tapt.
-import { getGlobaleInnstillinger, getForside } from '../../lib/umbraco';
+// Footer — CMS-redigerbar via globaleInnstillinger. Faller tilbake til hardkodet default.
+import { getGlobaleInnstillinger } from '../../lib/umbraco';
 import Logo from './Logo';
 let global = null;
-let forside = null;
-try { [global, forside] = await Promise.all([getGlobaleInnstillinger(), getForside()]); } catch (e) {}
+try { global = await getGlobaleInnstillinger(); } catch (e) {}
 
-const brand = global?.footerTittel || forside?.footerTittel || 'KI Norge';
-const desc = global?.footerBeskrivelse || forside?.footerBeskrivelse || 'Et tverrsektorielt samarbeid for å fremme ansvarlig og sikker bruk av kunstig intelligens i den norske forvaltningen.';
-const igUrl = global?.footerSosialInstagram || forside?.footerSosialInstagram || '#';
-const liUrl = global?.footerSosialLinkedin || forside?.footerSosialLinkedin || '#';
-const xUrl = global?.footerSosialX || forside?.footerSosialX || '#';
+const brand = global?.footerTittel || 'KI Norge';
+const desc = global?.footerBeskrivelse || 'Et tverrsektorielt samarbeid for å fremme ansvarlig og sikker bruk av kunstig intelligens i den norske forvaltningen.';
+const igUrl = global?.footerSosialInstagram || '#';
+const liUrl = global?.footerSosialLinkedin || '#';
+const xUrl = global?.footerSosialX || '#';
 
 const navCol1 = [
-  { text: global?.footerLenke1Tekst || forside?.footerLenke1Tekst || 'Om KI Norge', url: global?.footerLenke1Url || forside?.footerLenke1Url || '/om-oss' },
+  { text: global?.footerLenke1Tekst || 'Om KI Norge', url: global?.footerLenke1Url || '/om-oss' },
 ];
 const navCol2 = [
-  { text: global?.footerLenke3Tekst || forside?.footerLenke3Tekst || 'Personvern og informasjonskapsler', url: global?.footerLenke3Url || forside?.footerLenke3Url || '/personvern' },
-  { text: global?.footerLenke4Tekst || forside?.footerLenke4Tekst || 'Tilgjengelighet', url: global?.footerLenke4Url || forside?.footerLenke4Url || '/tilgjengelighet' },
-  { text: global?.footerLenke5Tekst || forside?.footerLenke5Tekst || 'Endre samtykke for informasjonskapsler', url: global?.footerLenke5Url || forside?.footerLenke5Url || '' },
+  { text: global?.footerLenke3Tekst || 'Personvern og informasjonskapsler', url: global?.footerLenke3Url || '/personvern' },
+  { text: global?.footerLenke4Tekst || 'Tilgjengelighet', url: global?.footerLenke4Url || '/tilgjengelighet' },
+  { text: global?.footerLenke5Tekst || 'Endre samtykke for informasjonskapsler', url: global?.footerLenke5Url || '' },
 ];
 ---
 

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -328,51 +328,25 @@ export interface EventItem {
   eventUrl?: string;
 }
 
+// Én forside-modul (block i forside.seksjoner). Flat: alle mulige felt valgfrie.
+export interface ForsideSeksjon {
+  contentType: string;
+  id: string;
+  overskrift?: string;
+  komIGangTekst?: string;
+  label?: string;
+  tittel?: string;
+  ingress?: string;
+  lenketekst?: string;
+  lenkeUrl?: string;
+  illustrasjon?: UmbracoMedia;
+  tekstHtml?: string;
+}
+
 export interface Forside {
   id: string;
   documentId: string;
-  heroOverskrift?: string;
-  heroTekst?: UmbracoBlock[];
-  heroBilde?: UmbracoMedia;
-  veiledningOverskrift?: string;
-  veiledning1Tittel?: string;
-  veiledning1Beskrivelse?: string;
-  veiledning1Url?: string;
-  veiledning2Tittel?: string;
-  veiledning2Beskrivelse?: string;
-  veiledning2Url?: string;
-  aktueltOverskrift?: string;
-  aktueltLenkeTekst?: string;
-  aktueltLenkeUrl?: string;
-  raadTittel?: string;
-  tips?: TipItem[];
-  sandkasseTittel?: string;
-  sandkasseTekst?: UmbracoBlock[];
-  sandkasseUrl?: string;
-  arrangementOverskrift?: string;
-  arrangementKommendeTekst?: string;
-  arrangementAvholdteTekst?: string;
-  arrangementer?: EventItem[];
-  footerTittel?: string;
-  footerBeskrivelse?: string;
-  footerSosialInstagram?: string;
-  footerSosialLinkedin?: string;
-  footerSosialX?: string;
-  footerLenke1Tekst?: string;
-  footerLenke1Url?: string;
-  footerLenke2Tekst?: string;
-  footerLenke2Url?: string;
-  footerLenke3Tekst?: string;
-  footerLenke3Url?: string;
-  footerLenke4Tekst?: string;
-  footerLenke4Url?: string;
-  footerLenke5Tekst?: string;
-  footerLenke5Url?: string;
-  rekkefolgeVeiledning?: number;
-  rekkefolgeAktuelt?: number;
-  rekkefolgeTreRaad?: number;
-  rekkefolgeSandkasse?: number;
-  rekkefolgeArrangement?: number;
+  seksjoner?: ForsideSeksjon[];
   seoTittel?: string;
   seoBeskrivelse?: string;
   seoBilde?: UmbracoMedia;
@@ -842,48 +816,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
     case 'forside':
       return {
         ...base,
-        heroOverskrift: props.heroOverskrift as string || undefined,
-        heroTekst: mapRichText(props.heroTekst),
-        heroBilde: mapMedia(props.heroBilde),
-        veiledningOverskrift: props.veiledningOverskrift as string || undefined,
-        veiledning1Tittel: props.veiledning1Tittel as string || undefined,
-        veiledning1Beskrivelse: props.veiledning1Beskrivelse as string || undefined,
-        veiledning1Url: props.veiledning1Url as string || undefined,
-        veiledning2Tittel: props.veiledning2Tittel as string || undefined,
-        veiledning2Beskrivelse: props.veiledning2Beskrivelse as string || undefined,
-        veiledning2Url: props.veiledning2Url as string || undefined,
-        aktueltOverskrift: props.aktueltOverskrift as string || undefined,
-        aktueltLenkeTekst: props.aktueltLenkeTekst as string || undefined,
-        aktueltLenkeUrl: props.aktueltLenkeUrl as string || undefined,
-        raadTittel: props.raadTittel as string || undefined,
-        tips: mapTipItems(props.tips),
-        sandkasseTittel: props.sandkasseTittel as string || undefined,
-        sandkasseTekst: mapRichText(props.sandkasseTekst),
-        sandkasseUrl: props.sandkasseUrl as string || undefined,
-        arrangementOverskrift: props.arrangementOverskrift as string || undefined,
-        arrangementKommendeTekst: props.arrangementKommendeTekst as string || undefined,
-        arrangementAvholdteTekst: props.arrangementAvholdteTekst as string || undefined,
-        arrangementer: mapEventItems(props.arrangementer),
-        footerTittel: props.footerTittel as string || undefined,
-        footerBeskrivelse: props.footerBeskrivelse as string || undefined,
-        footerSosialInstagram: props.footerSosialInstagram as string || undefined,
-        footerSosialLinkedin: props.footerSosialLinkedin as string || undefined,
-        footerSosialX: props.footerSosialX as string || undefined,
-        footerLenke1Tekst: props.footerLenke1Tekst as string || undefined,
-        footerLenke1Url: props.footerLenke1Url as string || undefined,
-        footerLenke2Tekst: props.footerLenke2Tekst as string || undefined,
-        footerLenke2Url: props.footerLenke2Url as string || undefined,
-        footerLenke3Tekst: props.footerLenke3Tekst as string || undefined,
-        footerLenke3Url: props.footerLenke3Url as string || undefined,
-        footerLenke4Tekst: props.footerLenke4Tekst as string || undefined,
-        footerLenke4Url: props.footerLenke4Url as string || undefined,
-        footerLenke5Tekst: props.footerLenke5Tekst as string || undefined,
-        footerLenke5Url: props.footerLenke5Url as string || undefined,
-        rekkefolgeVeiledning: props.rekkefolgeVeiledning as number || undefined,
-        rekkefolgeAktuelt: props.rekkefolgeAktuelt as number || undefined,
-        rekkefolgeTreRaad: props.rekkefolgeTreRaad as number || undefined,
-        rekkefolgeSandkasse: props.rekkefolgeSandkasse as number || undefined,
-        rekkefolgeArrangement: props.rekkefolgeArrangement as number || undefined,
+        seksjoner: mapForsideSeksjoner(props.seksjoner),
         seoTittel: props.seoTittel as string || undefined,
         seoBeskrivelse: props.seoBeskrivelse as string || undefined,
         seoBilde: mapMedia(props.seoBilde),
@@ -1302,6 +1235,30 @@ function pickerIds(value: unknown): string[] {
   if (!value) return [];
   const arr = Array.isArray(value) ? value : [value];
   return arr.map((item: any) => item?.id).filter((id): id is string => !!id);
+}
+
+function mapForsideSeksjoner(value: unknown): ForsideSeksjon[] | undefined {
+  const items = (value as any)?.items;
+  if (!Array.isArray(items)) return undefined;
+
+  return items.map((block: any): ForsideSeksjon => {
+    const content = block.content || block;
+    const props = content.properties || {};
+    const tekst = props.tekst as any;
+    return {
+      contentType: content.contentType,
+      id: content.id || '',
+      overskrift: (props.overskrift as string) || undefined,
+      komIGangTekst: (props.komIGangTekst as string) || undefined,
+      label: (props.label as string) || undefined,
+      tittel: (props.tittel as string) || undefined,
+      ingress: (props.ingress as string) || undefined,
+      lenketekst: (props.lenketekst as string) || undefined,
+      lenkeUrl: (props.lenkeUrl as string) || undefined,
+      illustrasjon: mapMedia(props.illustrasjon),
+      tekstHtml: tekst?.tag === '#root' ? richTextToHtml(tekst) : (typeof tekst === 'string' ? tekst : undefined),
+    };
+  });
 }
 
 function mapEksemplerSeksjoner(value: unknown): EksemplerSeksjon[] | undefined {

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -1,18 +1,13 @@
 ---
 import Layout from '../components/layout/Layout.astro';
-import Hero from '../components/landing/Hero.astro';
-import NewsCard from '../components/shared/NewsCard.astro';
-import CardGrid from '../components/shared/CardGrid.astro';
-import EventCard from '../components/shared/EventCard.astro';
-import ArrowLink from '../components/shared/ArrowLink.astro';
-import ExampleLinkCards from '../components/shared/ExampleLinkCards.astro';
-import TextWithImage from '../components/shared/TextWithImage.astro';
+import ForsideSeksjonerRenderer from '../components/landing/ForsideSeksjonerRenderer.astro';
 import { websiteSchema } from '../lib/seo';
-import { getForside, getArtikler, getKalenderhendelser, type Kalenderhendelse } from '../lib/umbraco';
+import { getForside, getArtikler, getKalenderhendelser, getEksempler, type Kalenderhendelse } from '../lib/umbraco';
 
 let forside = null;
 let latestArticles: any[] = [];
 let upcomingEvents: Kalenderhendelse[] = [];
+let eksempelKort: { href: string; title: string; tag: string }[] = [];
 try {
   forside = await getForside();
   const artiklerRes = await getArtikler(4);
@@ -23,15 +18,19 @@ try {
     .filter(h => new Date(h.sluttDato || h.startDato) >= now)
     .sort((a, b) => new Date(a.startDato).getTime() - new Date(b.startDato).getTime())
     .slice(0, 1);
-  } catch (e) {
+  const eksemplerRes = await getEksempler();
+  eksempelKort = eksemplerRes.data.slice(0, 2).map((c: any) => ({
+    href: `/caser/${c.slug}`,
+    title: c.tittel,
+    tag: 'Eksempel',
+  }));
+} catch (e) {
   console.error('Failed to fetch frontpage CMS data:', e);
 }
 
 const title = forside?.seoTittel || 'Hjem';
 const seoDescription = forside?.seoBeskrivelse || 'KI Norge - Norges nasjonale strategi for kunstig intelligens. Veiledning, regulatorisk sandkasse og gode eksempler for offentlig sektor.';
 const websiteJsonLd = websiteSchema(seoDescription);
-
-const featuredArticle = latestArticles[0];
 
 const monthNames = ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'];
 const formatEventDate = (iso: string) => {
@@ -44,194 +43,15 @@ const nextEventMultiDay = nextEvent?.sluttDato && new Date(nextEvent.sluttDato).
 ---
 
 <Layout title={title} description={seoDescription} hideLogo>
-  <Hero />
   <h1 class="ds-sr-only">ki.norge.no - {title}</h1>
   <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd).replace(/</g, '\\u003c')} />
 
-  <!-- Aktuelt -->
-  <section class="aktuelt" data-layout-block="edge">
-    <div data-layout-block="content">
-      <h2 class="ds-heading section-heading" data-size="lg">Aktuelt</h2>
-
-      <!-- Featured article -->
-      {featuredArticle && (
-        <NewsCard
-          href={`/artikler/${featuredArticle.slug}`}
-          title={featuredArticle.tittel}
-          tagColor="brand1"
-          lead={featuredArticle.lead || 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.'}
-          image={featuredArticle.image}
-          imageAlt=""
-          variant="featured"
-        />
-      )}
-
-      <!-- Image cards (3 across) -->
-      <CardGrid columns={3} divided>
-        {latestArticles.slice(1, 4).map(article => (
-          <NewsCard
-            href={`/artikler/${article.slug}`}
-            title={article.tittel}
-            variant="image"
-            image={article.image}
-            date={article.publishedAt}
-          />
-        ))}
-      </CardGrid>
-
-      <ArrowLink href="/artikler" text="Se alle artikler" />
-    </div>
-
-    <div class="arrangementer-section" data-layout-block="content">
-      <h2 class="ds-heading section-heading" data-size="lg">Kommende arrangementer</h2>
-      {nextEvent && nextEventDate && (
-        <EventCard
-          href={`/kalender/${nextEvent.slug}`}
-          title={nextEvent.tittel}
-          description={nextEvent.ingress || ''}
-          day={nextEventDate.day}
-          month={nextEventDate.month}
-          year={nextEventDate.year}
-          time={nextEvent.tid || ''}
-          timeNote={nextEventMultiDay ? 'Arrangement over flere dager' : undefined}
-          location={nextEvent.sted || ''}
-        />
-      )}
-      <ArrowLink href="/kalender" text="Se alle arrangementer" />
-    </div>
-  </section>
-
-  <!-- Veiledning -->
-  <section class="veiledning-section" data-layout-block="edge">
-    <div data-layout-block="content">
-      <TextWithImage title="Gjør dataene KI-klare" href="/veiledning" image="/woman-speaking.svg" imageAlt="Illustrasjon av kvinne som snakker" label="Veiledning">
-        <p slot="body">Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.</p>
-      </TextWithImage>
-    </div>
-  </section>
-
-  <!-- Lær av andre -->
-  <section data-layout-block="content" class="examples-section">
-    <h2 class="ds-heading section-heading" data-size="lg">Lær av andre</h2>
-    <ExampleLinkCards cards={[
-      { href: "/eksempler/ki-chat-staten", title: "KI-chat effektiviserer analysearbeid i staten", tag: "Eksempel" },
-      { href: "/eksempler/politiet-tale-til-tekst", title: "Politiet - Fra tale til tekst på minutter", tag: "Eksempel" },
-    ]} />
-    <ArrowLink href="/eksempler" text="Se alle eksempler" />
-  </section>
-
-  <!-- Den regulatoriske sandkassen -->
-  <section class="sandkasse-section" data-layout-block="edge">
-    <div data-layout-block="content">
-      <h2 class="sandkasse-title">
-        Den regulatoriske sandkassen
-      </h2>
-      <p class="sandkasse-desc">Juridisk veiledning for deg som ønsker å utvikle et risikofylt KI-prosjekt.</p>
-    </div>
-  </section>
+  <ForsideSeksjonerRenderer
+    seksjoner={forside?.seksjoner ?? []}
+    latestArticles={latestArticles}
+    nextEvent={nextEvent}
+    nextEventDate={nextEventDate}
+    nextEventMultiDay={nextEventMultiDay}
+    eksempelKort={eksempelKort}
+  />
 </Layout>
-
-<style>
-  /* Sections spacing */
-  :global(main) > * + * {
-    margin-top: var(--ds-size-6);
-  }
-
-  /* Section headings */
-  .section-heading {
-    margin: 0 0 var(--ds-size-8);
-  }
-
-  /* ── Aktuelt ─────────────────────────────────────────── */
-  .aktuelt {
-    background-color: var(--ds-color-brand2-surface-default);
-  }
-
-  .featured-article {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--ds-size-6);
-    text-decoration: none;
-    color: inherit;
-    margin-bottom: var(--ds-size-8);
-
-    @media (min-width: 768px) {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-
-  .featured-article-image {
-    aspect-ratio: 4 / 3;
-    background-color: #d9d9d9;
-    border-radius: var(--ds-border-radius-lg);
-  }
-
-  .featured-article-text {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-4);
-    justify-content: center;
-  }
-
-  .featured-article-title {
-    font-size: var(--ds-heading-sm-font-size);
-    font-weight: 600;
-    margin: 0;
-    line-height: 1.3;
-  }
-
-  .aktuelt :global(.card-grid) {
-    margin-bottom: var(--ds-size-6);
-  }
-
-  .aktuelt :global(.news-card--featured) {
-    margin-bottom: var(--ds-size-8);
-  }
-
-  /* ── Kommende arrangementer ──────────────────────────── */
-  .arrangementer-section {
-    border-top: 1px solid var(--ds-color-border-subtle);
-    padding-top: var(--ds-size-22);
-    margin-top: var(--ds-size-22);
-  }
-
-  .arrangementer-section :global(.event-card) {
-    margin-bottom: var(--ds-size-6);
-  }
-
-  /* ── Veiledning ──────────────────────────────────────── */
-  .veiledning-section {
-    
-  }
-
-
-
-  .examples-section {
-    & :global(.arrow-link) {
-      margin-block-start: var(--ds-size-6);
-    }
-  }
-
-  /* ── Sandkassen ──────────────────────────────────────── */
-  .sandkasse-section {
-    background-color: var(--ds-color-base-active);
-    color: var(--ds-color-base-contrast-default);
-    padding-block: var(--ds-size-22);
-  }
-
-  .sandkasse-title {
-    display: flex;
-    align-items: center;
-    gap: var(--ds-size-3);
-    font-size: var(--ds-heading-lg-font-size);
-    font-weight: 600;
-    margin: 0 0 var(--ds-size-3);
-  }
-
-  .sandkasse-desc {
-    font-size: var(--ds-body-md-font-size);
-    margin: 0;
-    opacity: 0.85;
-    max-width: 500px;
-  }
-</style>


### PR DESCRIPTION
Modulariserer forsiden til en reorderbar block-liste som matcher ny Figma, og fjerner de gamle flate feltene.

**CMS**
- `forside` har nå ett felt: `seksjoner` (block list) + SEO. 6 modul-typer: `forsideHero`, `forsideAktuelt`, `forsideArrangementer`, `forsideVeiledning`, `forsideLaerAvAndre`, `forsideSandkasse` (Figma-rekkefølge, reorderbar).
- `MigrateForside` snudd til opprydding: fjerner alle 38 gamle flate felt (Hero, Tre råd, Sandkasse, Veiledning, Aktuelt, Arrangement, Footer, Rekkefølge) + tomme grupper. Beholder SEO. Ingen content-skriving.
- "Tre råd" er ute (borte i ny design). Footer ligger kun i `globaleInnstillinger`.

**Frontend**
- Ny `ForsideSeksjonerRenderer` rendrer modulene og gjenbruker eksisterende komponenter (Hero, NewsCard, CardGrid, EventCard, TextWithImage, ExampleLinkCards, ArrowLink). Hver modul har dagens hardkodede verdier som default når feltet er tomt.
- `Hero` er props-drevet. `index.astro` henter data (artikler/arrangement/eksempler hentes auto som før) og delegerer til rendereren. `Footer.astro` leser kun `globaleInnstillinger`.
- `umbraco.ts`: nytt `ForsideSeksjon`-interface + `mapForsideSeksjoner`, slanket `Forside`-interface.

Stacket på #366 (base `feat/forside-footer-globalsettings`); retargetes til main når #366 er merget. Spec: `TODO/Forside-modularisering-spec.md`.