### PR TITLE
CMS: vask slug-feltet ved lagring (ContentSlugHandler)

### DIFF
--- a/apps/cms-umbraco/Composers/ContentSlugHandler.cs
+++ b/apps/cms-umbraco/Composers/ContentSlugHandler.cs
@@ -1,0 +1,55 @@
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Strings;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Vasker det redaktor-synlige slug-feltet til en URL-vennlig verdi ved lagring.
+/// Gjelder alle innholdstyper med et 'slug'-felt (artikkel, eksempel, side, veiledning,
+/// sandkasse, omOss osv.). Er slug tom, utledes den fra tittel (ellers nodenavnet).
+/// Idempotent: en allerede ren slug endres ikke. merkelapp handteres separat
+/// (MerkelappSlugHandler, fra navn).
+/// </summary>
+public class ContentSlugComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentSavingNotification, ContentSlugHandler>();
+    }
+}
+
+public class ContentSlugHandler : INotificationHandler<ContentSavingNotification>
+{
+    private readonly IShortStringHelper _shortStringHelper;
+
+    public ContentSlugHandler(IShortStringHelper shortStringHelper)
+    {
+        _shortStringHelper = shortStringHelper;
+    }
+
+    public void Handle(ContentSavingNotification notification)
+    {
+        foreach (var content in notification.SavedEntities)
+        {
+            // merkelapp har egen handler som utleder slug fra navn.
+            if (content.ContentType.Alias == "merkelapp") continue;
+            if (!content.HasProperty("slug")) continue;
+
+            var current = content.GetValue<string>("slug");
+            var source = !string.IsNullOrWhiteSpace(current)
+                ? current
+                : (content.GetValue<string>("tittel") ?? content.Name);
+
+            if (string.IsNullOrWhiteSpace(source)) continue;
+
+            var cleaned = _shortStringHelper.CleanStringForUrlSegment(source);
+            if (!string.IsNullOrWhiteSpace(cleaned) && cleaned != current)
+            {
+                content.SetValue("slug", cleaned);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Det redaktør-synlige `slug`-feltet ble aldri vasket. Feltbeskrivelsen lover «Genereres automatisk fra tittel hvis tom», men ingen handler implementerte det — kun `merkelapp.slug` ble vasket (fra navn).

Ny `ContentSavingNotification`-handler vasker `slug` til en URL-vennlig verdi ved lagring for alle innholdstyper med et `slug`-felt (utenom `merkelapp`). Er slug tom, utledes den fra `tittel`, ellers nodenavnet. Idempotent (allerede ren slug endres ikke). Samme mønster som `MerkelappSlugHandler` / `VeiledningStegGuideSlugHandler`.

NB: slug er fortsatt `mandatory` på de rike malene, så feltet må fylles — men verdien vaskes nå ved lagring. For å la redaktør la feltet stå tomt (auto fra tittel, jf. beskrivelsen) må slug gjøres ikke-obligatorisk, som guideSlug i #363.