### PR TITLE
Forside: preview henter kladd-innhold (manglet preview-flagg)

### DIFF
--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -4,13 +4,16 @@ import ForsideSeksjonerRenderer from '../components/landing/ForsideSeksjonerRend
 import { websiteSchema } from '../lib/seo';
 import { getForside, getArtikler, getKalenderhendelser, getEksempler, type Kalenderhendelse } from '../lib/umbraco';
 
+// Preview: forsiden må be om kladd-innhold, ellers vises bare publisert (bug: manglet her).
+const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
+
 let forside = null;
 let latestArticles: any[] = [];
 let upcomingEvents: Kalenderhendelse[] = [];
 let eksempelKort: { href: string; title: string; tag: string }[] = [];
 try {
-  forside = await getForside();
-  const artiklerRes = await getArtikler(4);
+  forside = await getForside({ preview: isPreview });
+  const artiklerRes = await getArtikler(4, { preview: isPreview });
   latestArticles = artiklerRes.data;
   const hendelserRes = await getKalenderhendelser();
   const now = new Date();


### PR DESCRIPTION
`index.astro` kalte `getForside()`/`getArtikler()` uten preview-flagg, så forsidens forhåndsvisning alltid viste publisert innhold. Kladd-seksjoner vistes derfor ikke i preview (kun etter publisering). Sender nå preview-flagget videre, slik de andre sidene gjør.