### PR TITLE
Rik artikkelmal: tre bakgrunnsfarger (Accent default) + helt-bilde som banner

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -352,9 +352,10 @@ public class ContentTypeComponent : IAsyncComponent
 
     private IDataType CreateOrGetBakgrunnDropdown()
     {
-        // Redaksjonell farge for artikkelen (brand1/2/3). "accent" = accent brand-farge (standard).
-        // Items asserts hver oppstart slik at en eksisterende datatype også oppdateres.
-        var items = new[] { "accent", "brand1", "brand2", "brand3" };
+        // Tre redaksjonelle bakgrunnsfarger for artikkelhodet. Accent er standard (frontend
+        // defaulter til accent når feltet er tomt). Items asserts hver oppstart slik at en
+        // eksisterende datatype også oppdateres.
+        var items = new[] { "accent", "brand1", "brand2" };
         var existing = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.DropDownListFlexible)
             .FirstOrDefault(dt => dt.Name == "Artikkelhode Bakgrunn");
         if (existing != null)
@@ -1729,7 +1730,7 @@ public class ContentTypeComponent : IAsyncComponent
             if (ct.PropertyTypes.Any(p => p.Alias == "bakgrunn")) continue;
             if (!ct.PropertyGroups.Any(g => g.Alias == "innstillinger"))
                 ct.AddPropertyGroup("innstillinger", "Innstillinger");
-            ct.AddPropertyType(Prop("bakgrunn", "Bakgrunn", _bakgrunnDropdownDt, description: "Redaksjonell farge for artikkelen (brand1/2/3, eller accent). Vises på artikkelhodet og arves av kort som lenker hit.", sortOrder: 2), "innstillinger");
+            ct.AddPropertyType(Prop("bakgrunn", "Bakgrunn", _bakgrunnDropdownDt, description: "Bakgrunnsfarge for artikkelhodet. Standard er Accent. Velg mellom Accent, Brand 1 og Brand 2. Arves av kort som lenker hit.", sortOrder: 2), "innstillinger");
             _contentTypeService.Save(ct);
             Console.WriteLine($"ContentTypeComposer: Ensured bakgrunn on '{alias}' (rik artikkelmal)");
         }

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -752,7 +752,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         ingress: props.ingress as string || '',
         artikkelBilde: mapMedia(props.artikkelBilde),
         bildeAlt: props.bildeAlt as string || '',
-        bakgrunn: (props.bakgrunn as string) || 'hvit',
+        bakgrunn: bakgrunnKey(props.bakgrunn) || 'accent',
         innhold: mapArtikkelBlocks(props.innhold),
         seoTittel: props.seoTittel as string || '',
         seoBeskrivelse: props.seoBeskrivelse as string || '',
@@ -841,7 +841,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         ingress: props.ingress as string || '',
         artikkelBilde: mapMedia(props.artikkelBilde),
         bildeAlt: props.bildeAlt as string || '',
-        bakgrunn: (props.bakgrunn as string) || 'ingen',
+        bakgrunn: bakgrunnKey(props.bakgrunn) || 'accent',
         innhold: mapArtikkelBlocks(props.innhold),
         seoTittel: props.seoTittel as string || undefined,
         seoBeskrivelse: props.seoBeskrivelse as string || undefined,
@@ -856,7 +856,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         ingress: props.ingress as string || '',
         artikkelBilde: mapMedia(props.artikkelBilde),
         bildeAlt: props.bildeAlt as string || '',
-        bakgrunn: (props.bakgrunn as string) || 'hvit',
+        bakgrunn: bakgrunnKey(props.bakgrunn) || 'accent',
         innhold: mapArtikkelBlocks(props.innhold),
         seoTittel: props.seoTittel as string || undefined,
         seoBeskrivelse: props.seoBeskrivelse as string || undefined,
@@ -1370,15 +1370,32 @@ export function getMediaUrl(media?: UmbracoMedia): string | undefined {
 }
 
 /**
- * Redaksjonell bakgrunnsfarge (#360) -> brand surface CSS-variabel for artikkelhodet.
- * brand1/2/3 gir brand-flate; 'ingen'/ukjent/tom gir ingen brand-bakgrunn (undefined).
+ * Normaliser bakgrunn-verdien fra CMS til en nokkel.
+ * Dropdown gir en streng ("accent"); ColorPicker med labels gir { label, value }.
  */
-export function bakgrunnSurface(bakgrunn?: string): string | undefined {
-  switch (bakgrunn) {
-    case 'brand1': return 'var(--ds-color-brand1-surface-default)';
-    case 'brand2': return 'var(--ds-color-brand2-surface-default)';
-    case 'brand3': return 'var(--ds-color-brand3-surface-default)';
-    default: return undefined;
+export function bakgrunnKey(raw: any): string | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw === 'string') return raw || undefined;
+  return (raw.label as string) || (raw.value as string) || undefined;
+}
+
+/**
+ * Redaksjonell bakgrunnsfarge for artikkelhodet -> DS surface CSS-variabel.
+ * Tre valg: accent (standard), brand1, brand2. Robust for label ("Accent"/"Brand 1"),
+ * nokkel ("accent") og hex ("e9c0c8"). Ukjent/tom -> accent.
+ */
+export function bakgrunnSurface(bakgrunn?: string): string {
+  switch ((bakgrunn || '').toLowerCase().replace(/[\s#]/g, '')) {
+    case 'brand1':
+    case 'dfc2d4':
+      return 'var(--ds-color-brand1-surface-active)';
+    case 'brand2':
+    case 'e2d8d2':
+      return 'var(--ds-color-brand2-surface-hover)';
+    case 'accent':
+    case 'e9c0c8':
+    default:
+      return 'var(--ds-color-accent-surface-active)';
   }
 }
 

--- a/apps/frontend/src/pages/artikler/[slug].astro
+++ b/apps/frontend/src/pages/artikler/[slug].astro
@@ -88,44 +88,24 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 </Layout>
 
 <style>
-  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  /* Hero: tittel over fullbredde banner-bilde (2:1, object-fit cover) */
   .article-hero-inner {
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: var(--ds-size-6);
   }
 
-  @media (min-width: 1024px) {
-    .article-hero-inner {
-      flex-direction: row;
-      align-items: center;
-    }
-  }
+  .article-hero-text { min-width: 0; }
 
-  .article-hero-text {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .article-hero-image {
-    flex-shrink: 0;
-    width: 100%;
-  }
-
-  @media (min-width: 1024px) {
-    .article-hero-image { width: 407px; }
-  }
+  .article-hero-image { width: 100%; }
 
   .article-hero-img {
     width: 100%;
-    height: auto;
+    aspect-ratio: 2 / 1;
+    max-height: 600px;
+    object-fit: cover;
     border-radius: 8px;
     display: block;
-    object-fit: cover;
-  }
-
-  @media (min-width: 1024px) {
-    .article-hero-img { height: 331px; }
   }
 
   /* More articles */

--- a/apps/frontend/src/pages/eksempler/[slug].astro
+++ b/apps/frontend/src/pages/eksempler/[slug].astro
@@ -85,38 +85,24 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 </Layout>
 
 <style>
-  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  /* Hero: tittel over fullbredde banner-bilde (2:1, object-fit cover) */
   .article-hero-inner {
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: var(--ds-size-6);
   }
 
-  @media (min-width: 1024px) {
-    .article-hero-inner {
-      flex-direction: row;
-      align-items: center;
-    }
-  }
+  .article-hero-text { min-width: 0; }
 
-  .article-hero-text { flex: 1; min-width: 0; }
-
-  .article-hero-image { flex-shrink: 0; width: 100%; }
-
-  @media (min-width: 1024px) {
-    .article-hero-image { width: 407px; }
-  }
+  .article-hero-image { width: 100%; }
 
   .article-hero-img {
     width: 100%;
-    height: auto;
+    aspect-ratio: 2 / 1;
+    max-height: 600px;
+    object-fit: cover;
     border-radius: 8px;
     display: block;
-    object-fit: cover;
-  }
-
-  @media (min-width: 1024px) {
-    .article-hero-img { height: 331px; }
   }
 
   /* More articles */

--- a/apps/frontend/src/pages/om-oss.astro
+++ b/apps/frontend/src/pages/om-oss.astro
@@ -77,38 +77,24 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 </Layout>
 
 <style>
-  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  /* Hero: tittel over fullbredde banner-bilde (2:1, object-fit cover) */
   .article-hero-inner {
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: var(--ds-size-6);
   }
 
-  @media (min-width: 1024px) {
-    .article-hero-inner {
-      flex-direction: row;
-      align-items: center;
-    }
-  }
+  .article-hero-text { min-width: 0; }
 
-  .article-hero-text { flex: 1; min-width: 0; }
-
-  .article-hero-image { flex-shrink: 0; width: 100%; }
-
-  @media (min-width: 1024px) {
-    .article-hero-image { width: 407px; }
-  }
+  .article-hero-image { width: 100%; }
 
   .article-hero-img {
     width: 100%;
-    height: auto;
+    aspect-ratio: 2 / 1;
+    max-height: 600px;
+    object-fit: cover;
     border-radius: 8px;
     display: block;
-    object-fit: cover;
-  }
-
-  @media (min-width: 1024px) {
-    .article-hero-img { height: 331px; }
   }
 
   /* Aktuelt */

--- a/apps/frontend/src/pages/sandkasse/index.astro
+++ b/apps/frontend/src/pages/sandkasse/index.astro
@@ -55,43 +55,23 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
 </Layout>
 
 <style>
-  /* Hero: tittel + hovedbilde ved siden av hverandre (under pa mobil) */
+  /* Hero: tittel over fullbredde banner-bilde (2:1, object-fit cover) */
   .article-hero-inner {
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: var(--ds-size-6);
   }
 
-  @media (min-width: 1024px) {
-    .article-hero-inner {
-      flex-direction: row;
-      align-items: center;
-    }
-  }
+  .article-hero-text { min-width: 0; }
 
-  .article-hero-text {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .article-hero-image {
-    flex-shrink: 0;
-    width: 100%;
-  }
-
-  @media (min-width: 1024px) {
-    .article-hero-image { width: 407px; }
-  }
+  .article-hero-image { width: 100%; }
 
   .article-hero-img {
     width: 100%;
-    height: auto;
+    aspect-ratio: 2 / 1;
+    max-height: 600px;
+    object-fit: cover;
     border-radius: 8px;
     display: block;
-    object-fit: cover;
-  }
-
-  @media (min-width: 1024px) {
-    .article-hero-img { height: 331px; }
   }
 </style>


### PR DESCRIPTION
## Endringer

**Bakgrunnsfarge på rik artikkelmal (3 valg, Accent som standard)**
- `bakgrunnSurface` mapper nå til riktige DS-tokens: Accent = `accent-surface-active` (#E9C0C8, standard), Brand 1 = `brand1-surface-active` (#DFC2D4), Brand 2 = `brand2-surface-hover` (#E2D8D2).
- Mappingen er robust for label, nøkkel og hex, og tom/ukjent verdi gir Accent.
- CMS: `bakgrunn`-dropdownen redusert fra fire til tre valg (`accent`, `brand1`, `brand2`), og beskrivelsen oppdatert (Standard er Accent).

**Helt-bilde (Hovedbilde)**
- Vises nå som fullbredde 2:1-banner med `object-fit: cover` på artikkel, eksempel, sandkasse og om-oss.
- Tidligere vokste bildet ukontrollert (full bredde med auto-høyde på smal skjerm, eller en 407px side-boks som klemte tittelen til vertikal tekst).