### PR TITLE
Forside: redigerbare kort i Aktuelt + Lær av andre

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -55,6 +55,8 @@ public class ContentTypeComponent : IAsyncComponent
     private IDataType _blockListVeiledningStegDt = null!;
     private IDataType _blockListVeiledningGuideDt = null!;
     private IDataType _blockListForsideDt = null!;
+    private IDataType _blockListForsideArtikkelKortDt = null!;
+    private IDataType _blockListForsideEksempelKortDt = null!;
 
     public ContentTypeComponent(
         IContentTypeService contentTypeService,
@@ -185,7 +187,23 @@ public class ContentTypeComponent : IAsyncComponent
             if (_contentTypeService.Get("forsideSandkasse") == null)
                 CreateForsideSandkasseElement();
 
+            // Kort-element-typer for forside (redaktør kan velge artikler/eksempler per kort).
+            // Må opprettes før block-list-datatypene som refererer dem.
+            if (_contentTypeService.Get("forsideArtikkelKort") == null)
+                CreateForsideArtikkelKortElement();
+            if (_contentTypeService.Get("forsideEksempelKort") == null)
+                CreateForsideEksempelKortElement();
+
+            _blockListForsideArtikkelKortDt = CreateOrGetBlockListDataType(
+                "Block List - Forside Artikkelkort", "forsideArtikkelKort");
+            _blockListForsideEksempelKortDt = CreateOrGetBlockListDataType(
+                "Block List - Forside Eksempelkort", "forsideEksempelKort");
+
             CreateBlockListDataTypes();
+
+            // Legg til kort/lenketekst/lenkeUrl på eksisterende forside-element-typer.
+            // Må kjøre etter at _blockListForsideArtikkelKortDt/_blockListForsideEksempelKortDt er satt.
+            MigrateForsideKortFelter();
 
             MigrateVeiledningElementNames();
             MigrateVeiledningObsRemoveVariant();
@@ -2513,6 +2531,9 @@ public class ContentTypeComponent : IAsyncComponent
         { Alias = "forsideAktuelt", Name = "Forside Aktuelt", Description = "Seksjon med siste artikler (innhold hentes automatisk)", Icon = "icon-newspaper-alt", IsElement = true };
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("kort", "Kort", _blockListForsideArtikkelKortDt, description: "Velg artikler. La stå tom for å vise nyeste automatisk. Første kort vises stort."), "innhold");
+        ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Default: Se alle artikler"), "innhold");
+        ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -2523,6 +2544,8 @@ public class ContentTypeComponent : IAsyncComponent
         { Alias = "forsideArrangementer", Name = "Forside Arrangementer", Description = "Seksjon med kommende arrangement (innhold hentes automatisk)", Icon = "icon-calendar", IsElement = true };
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Default: Se alle arrangementer"), "innhold");
+        ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -2548,6 +2571,31 @@ public class ContentTypeComponent : IAsyncComponent
         { Alias = "forsideLaerAvAndre", Name = "Forside Lær av andre", Description = "Seksjon med eksempler (innhold hentes automatisk)", Icon = "icon-light-bulb", IsElement = true };
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("kort", "Kort", _blockListForsideEksempelKortDt, description: "Velg eksempler. La stå tom for å vise nyeste automatisk."), "innhold");
+        ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Default: Se alle eksempler"), "innhold");
+        ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideArtikkelKortElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideArtikkelKort", Name = "Forside Artikkelkort", Description = "Et kort som peker på en artikkel på forsiden", Icon = "icon-newspaper-alt", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("artikkel", "Artikkel", _contentPickerDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("ingress", "Ingress (overstyr)", _textAreaDt, description: "La stå tom for å bruke artikkelens egen ingress."), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideEksempelKortElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideEksempelKort", Name = "Forside Eksempelkort", Description = "Et kort som peker på et eksempel på forsiden", Icon = "icon-light-bulb", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("eksempel", "Eksempel", _contentPickerDt, mandatory: true), "innhold");
+        ct.AddPropertyType(Prop("ingress", "Ingress (overstyr)", _textAreaDt, description: "La stå tom for å bruke eksemplets egen ingress."), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -2905,6 +2953,72 @@ public class ContentTypeComponent : IAsyncComponent
         {
             _contentTypeService.Save(ct);
             Console.WriteLine("ContentTypeComposer: Modulariserte forside (block list, fjernet gamle flate felt)");
+        }
+    }
+
+    // Additivt: legger til kort/lenketekst/lenkeUrl på eksisterende forside-element-typer.
+    // Krever at _blockListForsideArtikkelKortDt/_blockListForsideEksempelKortDt er initialisert først.
+    private void MigrateForsideKortFelter()
+    {
+        var aktuelt = _contentTypeService.Get("forsideAktuelt");
+        if (aktuelt != null)
+        {
+            bool changed = false;
+            if (!aktuelt.PropertyTypeExists("kort"))
+            {
+                aktuelt.AddPropertyType(Prop("kort", "Kort", _blockListForsideArtikkelKortDt, description: "Velg artikler. La stå tom for å vise nyeste automatisk. Første kort vises stort."), "innhold");
+                changed = true;
+            }
+            if (!aktuelt.PropertyTypeExists("lenketekst"))
+            {
+                aktuelt.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Default: Se alle artikler"), "innhold");
+                changed = true;
+            }
+            if (!aktuelt.PropertyTypeExists("lenkeUrl"))
+            {
+                aktuelt.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+                changed = true;
+            }
+            if (changed) _contentTypeService.Save(aktuelt);
+        }
+
+        var laer = _contentTypeService.Get("forsideLaerAvAndre");
+        if (laer != null)
+        {
+            bool changed = false;
+            if (!laer.PropertyTypeExists("kort"))
+            {
+                laer.AddPropertyType(Prop("kort", "Kort", _blockListForsideEksempelKortDt, description: "Velg eksempler. La stå tom for å vise nyeste automatisk."), "innhold");
+                changed = true;
+            }
+            if (!laer.PropertyTypeExists("lenketekst"))
+            {
+                laer.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Default: Se alle eksempler"), "innhold");
+                changed = true;
+            }
+            if (!laer.PropertyTypeExists("lenkeUrl"))
+            {
+                laer.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+                changed = true;
+            }
+            if (changed) _contentTypeService.Save(laer);
+        }
+
+        var arr = _contentTypeService.Get("forsideArrangementer");
+        if (arr != null)
+        {
+            bool changed = false;
+            if (!arr.PropertyTypeExists("lenketekst"))
+            {
+                arr.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Default: Se alle arrangementer"), "innhold");
+                changed = true;
+            }
+            if (!arr.PropertyTypeExists("lenkeUrl"))
+            {
+                arr.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt), "innhold");
+                changed = true;
+            }
+            if (changed) _contentTypeService.Save(arr);
         }
     }
 

--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -15,13 +15,43 @@ import { getMediaUrl, type ForsideSeksjon, type Kalenderhendelse } from '../../l
 interface Props {
   seksjoner: ForsideSeksjon[];
   latestArticles: any[];
+  eksempler?: any[];
   nextEvent: Kalenderhendelse | null;
   nextEventDate: { day: string; month: string; year: string } | null;
   nextEventMultiDay?: boolean | string;
   eksempelKort: { href: string; title: string; tag: string }[];
 }
-const { seksjoner, latestArticles, nextEvent, nextEventDate, nextEventMultiDay, eksempelKort } = Astro.props;
+const { seksjoner, latestArticles, eksempler = [], nextEvent, nextEventDate, nextEventMultiDay, eksempelKort } = Astro.props;
 const featuredArticle = latestArticles[0];
+
+// Normaliserer en pool-artikkel til kort-formen rendereren bruker (tittel/slug/lead/image).
+// Pool-artikler har ingress/artikkelBilde; vi mapper dem til lead/image.
+const artikkelTilKort = (a: any, ingressOverride?: string) => ({
+  tittel: a.tittel,
+  slug: a.slug,
+  lead: ingressOverride || a.lead || a.ingress,
+  image: a.image || getMediaUrl(a.artikkelBilde),
+  publishedAt: a.publishedAt,
+});
+
+// Slår opp redaktørvalgte kort i poolen og dropper de som ikke finnes.
+const resolveArtikkelKort = (kort: { id?: string; ingress?: string }[] | undefined) =>
+  (kort ?? [])
+    .map((k) => {
+      const article = latestArticles.find((a: any) => a.id === k.id);
+      return article ? artikkelTilKort(article, k.ingress) : null;
+    })
+    .filter((c): c is ReturnType<typeof artikkelTilKort> => c !== null);
+
+const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefined) =>
+  (kort ?? [])
+    .map((k) => {
+      const ex = eksempler.find((e: any) => e.id === k.id);
+      return ex
+        ? { href: `/caser/${ex.slug}`, title: ex.tittel, tag: 'Eksempel' as const, lead: k.ingress || ex.ingress }
+        : null;
+    })
+    .filter((c): c is { href: string; title: string; tag: 'Eksempel'; lead?: string } => c !== null);
 ---
 
 {seksjoner.map((block) => {
@@ -38,23 +68,28 @@ const featuredArticle = latestArticles[0];
   }
 
   if (block.contentType === 'forsideAktuelt') {
+    // Redaktørvalgte kort overstyrer auto-pool. Tomt → behold nåværende auto-oppførsel.
+    const valgte = block.kort?.length ? resolveArtikkelKort(block.kort) : [];
+    const useValgte = valgte.length > 0;
+    const featured = useValgte ? valgte[0] : (featuredArticle ? artikkelTilKort(featuredArticle) : null);
+    const smaa = useValgte ? valgte.slice(1) : latestArticles.slice(1, 4).map((a) => artikkelTilKort(a));
     return (
       <section class="aktuelt" data-layout-block="edge">
         <div data-layout-block="content">
           <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Aktuelt'}</h2>
-          {featuredArticle && (
+          {featured && (
             <NewsCard
-              href={`/artikler/${featuredArticle.slug}`}
-              title={featuredArticle.tittel}
+              href={`/artikler/${featured.slug}`}
+              title={featured.tittel}
               tagColor="brand1"
-              lead={featuredArticle.lead || 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.'}
-              image={featuredArticle.image}
+              lead={featured.lead || 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.'}
+              image={featured.image}
               imageAlt=""
               variant="featured"
             />
           )}
           <CardGrid columns={3} divided>
-            {latestArticles.slice(1, 4).map((article) => (
+            {smaa.map((article) => (
               <NewsCard
                 href={`/artikler/${article.slug}`}
                 title={article.tittel}
@@ -64,7 +99,7 @@ const featuredArticle = latestArticles[0];
               />
             ))}
           </CardGrid>
-          <ArrowLink href="/artikler" text="Se alle artikler" />
+          <ArrowLink href={block.lenkeUrl || '/artikler'} text={block.lenketekst || 'Se alle artikler'} />
         </div>
       </section>
     );
@@ -87,7 +122,7 @@ const featuredArticle = latestArticles[0];
             location={nextEvent.sted || ''}
           />
         )}
-        <ArrowLink href="/kalender" text="Se alle arrangementer" />
+        <ArrowLink href={block.lenkeUrl || '/kalender'} text={block.lenketekst || 'Se alle arrangementer'} />
       </section>
     );
   }
@@ -111,11 +146,14 @@ const featuredArticle = latestArticles[0];
   }
 
   if (block.contentType === 'forsideLaerAvAndre') {
+    // Redaktørvalgte eksempler overstyrer auto-pool. Tomt → behold nåværende oppførsel.
+    const valgte = block.kort?.length ? resolveEksempelKort(block.kort) : [];
+    const kort = valgte.length > 0 ? valgte : eksempelKort;
     return (
       <section data-layout-block="content" class="examples-section">
         <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Lær av andre'}</h2>
-        <ExampleLinkCards cards={eksempelKort.map((c, i) => ({ ...c, variant: i === 0 ? 'medium' : 'light' }))} />
-        <ArrowLink href="/eksempler" text="Se alle eksempler" />
+        <ExampleLinkCards cards={kort.map((c, i) => ({ ...c, variant: i === 0 ? 'medium' : 'light' }))} />
+        <ArrowLink href={block.lenkeUrl || '/eksempler'} text={block.lenketekst || 'Se alle eksempler'} />
       </section>
     );
   }

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -328,6 +328,13 @@ export interface EventItem {
   eventUrl?: string;
 }
 
+// Ett redaktørvalgt kort i forsideAktuelt/forsideLaerAvAndre.
+// id = node-id på valgt artikkel/eksempel. ingress = valgfri overstyring.
+export interface ForsideKort {
+  id?: string;
+  ingress?: string;
+}
+
 // Én forside-modul (block i forside.seksjoner). Flat: alle mulige felt valgfrie.
 export interface ForsideSeksjon {
   contentType: string;
@@ -341,6 +348,7 @@ export interface ForsideSeksjon {
   lenkeUrl?: string;
   illustrasjon?: UmbracoMedia;
   tekstHtml?: string;
+  kort?: ForsideKort[];
 }
 
 export interface Forside {
@@ -1257,8 +1265,29 @@ function mapForsideSeksjoner(value: unknown): ForsideSeksjon[] | undefined {
       lenkeUrl: (props.lenkeUrl as string) || undefined,
       illustrasjon: mapMedia(props.illustrasjon),
       tekstHtml: tekst?.tag === '#root' ? richTextToHtml(tekst) : (typeof tekst === 'string' ? tekst : undefined),
+      kort: mapForsideKort(props.kort),
     };
   });
+}
+
+// Leser nested block list (forsideArtikkelKort/forsideEksempelKort) under en forside-modul.
+// Hvert kort har en content-picker (artikkel eller eksempel) + valgfri ingress-overstyring.
+function mapForsideKort(value: unknown): ForsideKort[] | undefined {
+  const items = (value as any)?.items;
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+
+  return items
+    .map((block: any): ForsideKort => {
+      const content = block.content || block;
+      const props = content.properties || {};
+      // Artikkelkort bruker "artikkel", eksempelkort bruker "eksempel".
+      const id = pickerId(props.artikkel) ?? pickerId(props.eksempel);
+      return {
+        id,
+        ingress: (props.ingress as string) || undefined,
+      };
+    })
+    .filter((k: ForsideKort) => !!k.id);
 }
 
 function mapEksemplerSeksjoner(value: unknown): EksemplerSeksjon[] | undefined {

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -4,25 +4,27 @@ import ForsideSeksjonerRenderer from '../components/landing/ForsideSeksjonerRend
 import { websiteSchema } from '../lib/seo';
 import { getForside, getArtikler, getKalenderhendelser, getEksempler, type Kalenderhendelse } from '../lib/umbraco';
 
-// Preview: forsiden må be om kladd-innhold, ellers vises bare publisert (bug: manglet her).
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
 let forside = null;
 let latestArticles: any[] = [];
+let eksempler: any[] = [];
 let upcomingEvents: Kalenderhendelse[] = [];
 let eksempelKort: { href: string; title: string; tag: string }[] = [];
 try {
   forside = await getForside({ preview: isPreview });
-  const artiklerRes = await getArtikler(4, { preview: isPreview });
+  // Hent en stor pool slik at redaktørvalgte kort kan slås opp på id (ikke bare de 4 nyeste).
+  const artiklerRes = await getArtikler(60, { preview: isPreview });
   latestArticles = artiklerRes.data;
-  const hendelserRes = await getKalenderhendelser();
+  const hendelserRes = await getKalenderhendelser({ preview: isPreview });
   const now = new Date();
   upcomingEvents = hendelserRes.data
     .filter(h => new Date(h.sluttDato || h.startDato) >= now)
     .sort((a, b) => new Date(a.startDato).getTime() - new Date(b.startDato).getTime())
     .slice(0, 1);
-  const eksemplerRes = await getEksempler();
-  eksempelKort = eksemplerRes.data.slice(0, 2).map((c: any) => ({
+  const eksemplerRes = await getEksempler({ preview: isPreview });
+  eksempler = eksemplerRes.data;
+  eksempelKort = eksempler.slice(0, 2).map((c: any) => ({
     href: `/caser/${c.slug}`,
     title: c.tittel,
     tag: 'Eksempel',
@@ -52,6 +54,7 @@ const nextEventMultiDay = nextEvent?.sluttDato && new Date(nextEvent.sluttDato).
   <ForsideSeksjonerRenderer
     seksjoner={forside?.seksjoner ?? []}
     latestArticles={latestArticles}
+    eksempler={eksempler}
     nextEvent={nextEvent}
     nextEventDate={nextEventDate}
     nextEventMultiDay={nextEventMultiDay}


### PR DESCRIPTION
Gir tilbake redigerbarheten #368 strippet. `forsideAktuelt` og `forsideLaerAvAndre` får en `kort`-blokkliste der hvert kort velger en artikkel/eksempel (content picker) + valgfri ingress-overstyring (default fra innholdet). Tom liste = nyeste automatisk (som før). `lenketekst`/`lenkeUrl` redigerbar på Aktuelt/Arrangementer/Lær av andre. Additivt skjema + guardet migrate. Begge bygg grønne.