### PR TITLE
CMS: oppdater bakgrunn-beskrivelse på eksisterende felt

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -1741,14 +1741,27 @@ public class ContentTypeComponent : IAsyncComponent
     /// </summary>
     private void EnforceBakgrunnScope()
     {
+        const string bakgrunnDesc = "Bakgrunnsfarge for artikkelhodet. Standard er Accent. Velg mellom Accent, Brand 1 og Brand 2. Arves av kort som lenker hit.";
         foreach (var alias in new[] { "artikkel", "eksempel", "enkelVeiledning", "sandkasse", "omOss" })
         {
             var ct = _contentTypeService.Get(alias);
             if (ct == null) continue;
-            if (ct.PropertyTypes.Any(p => p.Alias == "bakgrunn")) continue;
+            var bakgrunn = ct.PropertyTypes.FirstOrDefault(p => p.Alias == "bakgrunn");
+            if (bakgrunn != null)
+            {
+                // Feltet finnes alt: oppdater beskrivelsen (AddPropertyType under kjorer ikke pa
+                // eksisterende felt, sa gammel tekst som "Standard er hvit" ble ellers liggende).
+                if (bakgrunn.Description != bakgrunnDesc)
+                {
+                    bakgrunn.Description = bakgrunnDesc;
+                    _contentTypeService.Save(ct);
+                    Console.WriteLine($"ContentTypeComposer: Oppdaterte bakgrunn-beskrivelse pa '{alias}'");
+                }
+                continue;
+            }
             if (!ct.PropertyGroups.Any(g => g.Alias == "innstillinger"))
                 ct.AddPropertyGroup("innstillinger", "Innstillinger");
-            ct.AddPropertyType(Prop("bakgrunn", "Bakgrunn", _bakgrunnDropdownDt, description: "Bakgrunnsfarge for artikkelhodet. Standard er Accent. Velg mellom Accent, Brand 1 og Brand 2. Arves av kort som lenker hit.", sortOrder: 2), "innstillinger");
+            ct.AddPropertyType(Prop("bakgrunn", "Bakgrunn", _bakgrunnDropdownDt, description: bakgrunnDesc, sortOrder: 2), "innstillinger");
             _contentTypeService.Save(ct);
             Console.WriteLine($"ContentTypeComposer: Ensured bakgrunn on '{alias}' (rik artikkelmal)");
         }


### PR DESCRIPTION
## Endring

`EnforceBakgrunnScope` satte bare beskrivelsen på `bakgrunn`-feltet ved første opprettelse (`if (... Any(... "bakgrunn")) continue;`). På eksisterende DB-er (lokal, tt02, prod) ble derfor gammel tekst stående ("Velg bakgrunnsfarge for artikkelhodet. Standard er hvit."), selv etter at koden ble endret i #373.

Nå oppdateres beskrivelsen også når feltet allerede finnes, til "Standard er Accent". Items (3 fargevalg) oppdateres allerede hver oppstart, så de var korrekte.