### PR TITLE
CMS: fiks bootstrap-krasj på fresh DB (Playwright smoke)

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -174,6 +174,20 @@ public class ContentTypeComponent : IAsyncComponent
                 CreateEksempelKontaktElement();
 
             // Forside-moduler (block list)
+            // Kort-element-typene og deres block-list-datatyper MÅ opprettes/resolves FØR
+            // forside-seksjonene (forsideAktuelt/forsideLaerAvAndre) som refererer dem.
+            // Ellers er _blockListForside*Dt null når seksjonen bygges -> hele
+            // InitializeAsync krasjer med "Value cannot be null (Parameter 'dataType')"
+            // og 0 content types seedes (fresh install / CI).
+            if (_contentTypeService.Get("forsideArtikkelKort") == null)
+                CreateForsideArtikkelKortElement();
+            if (_contentTypeService.Get("forsideEksempelKort") == null)
+                CreateForsideEksempelKortElement();
+            _blockListForsideArtikkelKortDt = CreateOrGetBlockListDataType(
+                "Block List - Forside Artikkelkort", "forsideArtikkelKort");
+            _blockListForsideEksempelKortDt = CreateOrGetBlockListDataType(
+                "Block List - Forside Eksempelkort", "forsideEksempelKort");
+
             if (_contentTypeService.Get("forsideHero") == null)
                 CreateForsideHeroElement();
             if (_contentTypeService.Get("forsideAktuelt") == null)
@@ -186,18 +200,6 @@ public class ContentTypeComponent : IAsyncComponent
                 CreateForsideLaerAvAndreElement();
             if (_contentTypeService.Get("forsideSandkasse") == null)
                 CreateForsideSandkasseElement();
-
-            // Kort-element-typer for forside (redaktør kan velge artikler/eksempler per kort).
-            // Må opprettes før block-list-datatypene som refererer dem.
-            if (_contentTypeService.Get("forsideArtikkelKort") == null)
-                CreateForsideArtikkelKortElement();
-            if (_contentTypeService.Get("forsideEksempelKort") == null)
-                CreateForsideEksempelKortElement();
-
-            _blockListForsideArtikkelKortDt = CreateOrGetBlockListDataType(
-                "Block List - Forside Artikkelkort", "forsideArtikkelKort");
-            _blockListForsideEksempelKortDt = CreateOrGetBlockListDataType(
-                "Block List - Forside Eksempelkort", "forsideEksempelKort");
 
             CreateBlockListDataTypes();
 


### PR DESCRIPTION
## Problem

Playwright smoke (`tests/cms/auth-and-tree.spec.ts › Diagnostics endpoint reports valid state`) feilet på main: `artikkelFields.hasIngress` var `false`. Repoet har ingen påkrevde checks, så flere PR-er (#372/#373/#374) ble merget med rød smoke.

## Rotårsak

`CreateForsideAktueltElement` og `CreateForsideLaerAvAndreElement` bruker `_blockListForsideArtikkelKortDt`/`_blockListForsideEksempelKortDt`, men i `InitializeAsync` ble disse block-list-datatypene resolvet **etter** at seksjonene ble opprettet. På en fresh DB (CI + ny lokal DB) var datatypen `null` når seksjonen ble bygget, så hele `InitializeAsync` kastet `Value cannot be null (Parameter 'dataType')` og **0 content types ble seedet**. Derfor manglet `artikkel` både `ingress` og `artikkelBilde`. Kom inn med kort-modulene i #374.

## Fiks

Flytt kort-element-typene (`forsideArtikkelKort`/`forsideEksempelKort`) og deres block-list-datatyper foran forside-seksjonene som refererer dem.

## Verifisert lokalt

Fersk DB booter uten krasj. `/api/diagnostics` gir nå `hasIngress: true`, `hasBilde: true`, og `artikkel` har alle felt.