### PR TITLE
Fix: frontend regressions from last 2-3 days

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -48,10 +48,10 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     .map((k) => {
       const ex = eksempler.find((e: any) => e.id === k.id);
       return ex
-        ? { href: `/caser/${ex.slug}`, title: ex.tittel, tag: 'Eksempel' as const, lead: k.ingress || ex.ingress }
+        ? { href: `/caser/${ex.slug}`, title: ex.tittel, tag: 'Eksempel' as const }
         : null;
     })
-    .filter((c): c is { href: string; title: string; tag: 'Eksempel'; lead?: string } => c !== null);
+    .filter((c): c is { href: string; title: string; tag: 'Eksempel' } => c !== null);
 ---
 
 {seksjoner.map((block) => {

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -315,19 +315,6 @@ export interface AccordionSection {
   body: UmbracoBlock[];
 }
 
-export interface TipItem {
-  tipsTitle: string;
-  tipsTekst: UmbracoBlock[];
-  tipsBilde?: UmbracoMedia;
-}
-
-export interface EventItem {
-  eventTittel: string;
-  eventDato?: string;
-  eventSted?: string;
-  eventUrl?: string;
-}
-
 // Ett redaktørvalgt kort i forsideAktuelt/forsideLaerAvAndre.
 // id = node-id på valgt artikkel/eksempel. ingress = valgfri overstyring.
 export interface ForsideKort {
@@ -376,13 +363,6 @@ export interface OmOssSeksjon {
   updatedAt: string;
   publishedAt: string;
   locale: string;
-}
-
-export interface OmOssSeksjonBlokk {
-  tittel: string;
-  tekst: string; // HTML from RichText
-  bilde?: UmbracoMedia;
-  bildeAlt?: string;
 }
 
 // Om Oss bruker rik artikkelmal (#362): samme artikkelhode + modul-blokkliste som artikkel.
@@ -1143,35 +1123,6 @@ function mapAccordionSections(value: unknown): AccordionSection[] {
     return {
       title: (props.title as string) || '',
       body: mapRichText(props.body) || [],
-    };
-  });
-}
-
-function mapTipItems(value: unknown): TipItem[] {
-  const items = Array.isArray(value) ? value : (value as any)?.items;
-  if (!Array.isArray(items)) return [];
-  return items.map((block: any) => {
-    const content = block.content || block;
-    const props = content.properties || content;
-    return {
-      tipsTitle: (props.tipsTitle as string) || '',
-      tipsTekst: mapRichText(props.tipsTekst) || [],
-      tipsBilde: mapMedia(props.tipsBilde),
-    };
-  });
-}
-
-function mapEventItems(value: unknown): EventItem[] {
-  const items = Array.isArray(value) ? value : (value as any)?.items;
-  if (!Array.isArray(items)) return [];
-  return items.map((block: any) => {
-    const content = block.content || block;
-    const props = content.properties || content;
-    return {
-      eventTittel: (props.eventTittel as string) || '',
-      eventDato: (props.eventDato as string) || undefined,
-      eventSted: (props.eventSted as string) || undefined,
-      eventUrl: (props.eventUrl as string) || undefined,
     };
   });
 }

--- a/apps/frontend/src/pages/artikler/[slug].astro
+++ b/apps/frontend/src/pages/artikler/[slug].astro
@@ -104,7 +104,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
     aspect-ratio: 2 / 1;
     max-height: 600px;
     object-fit: cover;
-    border-radius: 8px;
+    border-radius: var(--ds-border-radius-md);
     display: block;
   }
 

--- a/apps/frontend/src/pages/eksempler/[slug].astro
+++ b/apps/frontend/src/pages/eksempler/[slug].astro
@@ -101,7 +101,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
     aspect-ratio: 2 / 1;
     max-height: 600px;
     object-fit: cover;
-    border-radius: 8px;
+    border-radius: var(--ds-border-radius-md);
     display: block;
   }
 

--- a/apps/frontend/src/pages/om-oss.astro
+++ b/apps/frontend/src/pages/om-oss.astro
@@ -93,7 +93,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
     aspect-ratio: 2 / 1;
     max-height: 600px;
     object-fit: cover;
-    border-radius: 8px;
+    border-radius: var(--ds-border-radius-md);
     display: block;
   }
 

--- a/apps/frontend/src/pages/sandkasse/index.astro
+++ b/apps/frontend/src/pages/sandkasse/index.astro
@@ -71,7 +71,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
     aspect-ratio: 2 / 1;
     max-height: 600px;
     object-fit: cover;
-    border-radius: 8px;
+    border-radius: var(--ds-border-radius-md);
     display: block;
   }
 </style>


### PR DESCRIPTION
Gjennomgang av frontend-deltaene de siste dagene

## Commits
- **Fjern daud kode etter forside- og Om Oss-omlegging** (umbraco.ts). mapTipItems og mapEventItems har ingen kallsteder lenger, og interfacene TipItem, EventItem og OmOssSeksjonBlokk ble foreldreloese. Ingen oppførselsendring.
- **Fjern ubrukt lead-felt på eksempelkort** (ForsideSeksjonerRenderer). lead ble satt men aldri lest av ExampleLinkCards eller ExampleCard. Ingen synlig endring.
- **Bruk radius-token i artikkel-hero** (artikkel, eksempel, sandkasse, Om Oss). border-radius: 8px byttet til var(--ds-border-radius-md). Tokenet resolver til 8px, så visuelt identisk.