### PR TITLE
Oversikt-moduler + preview på navigasjonssider

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -57,6 +57,8 @@ public class ContentTypeComponent : IAsyncComponent
     private IDataType _blockListForsideDt = null!;
     private IDataType _blockListForsideArtikkelKortDt = null!;
     private IDataType _blockListForsideEksempelKortDt = null!;
+    private IDataType _blockListForstaLenkerDt = null!;          // Forstå regelverket: lenkeliste (forside)
+    private IDataType _blockListArtiklerSeksjonerDt = null!;     // Artikler-oversikt moduler
 
     public ContentTypeComponent(
         IContentTypeService contentTypeService,
@@ -173,6 +175,15 @@ public class ContentTypeComponent : IAsyncComponent
             if (_contentTypeService.Get("eksempelKontakt") == null)
                 CreateEksempelKontaktElement();
 
+            // Artikler-oversikt moduler (speiler eksempel-modulene). MÅ opprettes før
+            // CreateBlockListDataTypes() som bygger _blockListArtiklerSeksjonerDt.
+            if (_contentTypeService.Get("artikkelFeatured") == null)
+                CreateArtikkelFeaturedElement();
+            if (_contentTypeService.Get("artikkelGruppe") == null)
+                CreateArtikkelGruppeElement();
+            if (_contentTypeService.Get("artikkelRelatert") == null)
+                CreateArtikkelRelatertElement();
+
             // Forside-moduler (block list)
             // Kort-element-typene og deres block-list-datatyper MÅ opprettes/resolves FØR
             // forside-seksjonene (forsideAktuelt/forsideLaerAvAndre) som refererer dem.
@@ -183,10 +194,14 @@ public class ContentTypeComponent : IAsyncComponent
                 CreateForsideArtikkelKortElement();
             if (_contentTypeService.Get("forsideEksempelKort") == null)
                 CreateForsideEksempelKortElement();
+            if (_contentTypeService.Get("forsideForstaLenke") == null)
+                CreateForsideForstaLenkeElement();
             _blockListForsideArtikkelKortDt = CreateOrGetBlockListDataType(
                 "Block List - Forside Artikkelkort", "forsideArtikkelKort");
             _blockListForsideEksempelKortDt = CreateOrGetBlockListDataType(
                 "Block List - Forside Eksempelkort", "forsideEksempelKort");
+            _blockListForstaLenkerDt = CreateOrGetBlockListDataType(
+                "Block List - Forside Forstå Lenker", "forsideForstaLenke");
 
             if (_contentTypeService.Get("forsideHero") == null)
                 CreateForsideHeroElement();
@@ -200,6 +215,8 @@ public class ContentTypeComponent : IAsyncComponent
                 CreateForsideLaerAvAndreElement();
             if (_contentTypeService.Get("forsideSandkasse") == null)
                 CreateForsideSandkasseElement();
+            if (_contentTypeService.Get("forsideForstaRegelverket") == null)
+                CreateForsideForstaRegelverketElement();
 
             CreateBlockListDataTypes();
 
@@ -209,6 +226,9 @@ public class ContentTypeComponent : IAsyncComponent
 
             // Relabel/retype/standard-tekster + arrangement/veiledning-pickere på eksisterende moduler.
             MigrateForsideModuler();
+
+            // Nye felt på eksisterende modul-element-typer (eksempel-ingress/tags, aktuelt fremhevet).
+            MigrateModulFelter();
 
             MigrateVeiledningElementNames();
             MigrateVeiledningObsRemoveVariant();
@@ -1001,7 +1021,8 @@ public class ContentTypeComponent : IAsyncComponent
             IsElement = true,
         };
         ct.AddPropertyGroup("innhold", "Innhold");
-        ct.AddPropertyType(Prop("eksempel", "Eksempel", _contentPickerDt, mandatory: true, description: "Velg eksempelet som skal fremheves."), "innhold");
+        ct.AddPropertyType(Prop("eksempel", "Eksempel", _contentPickerDt, mandatory: true, description: "Velg eksempelet som skal fremheves.", sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("ingress", "Ingress (overstyr)", _textAreaDt, description: "Standard: eksemplets egen ingress. Skriv her for å overstyre.", sortOrder: 2), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -1040,8 +1061,11 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, description: "Valgfri overskrift over de relaterte lenkene.", sortOrder: 1), "innhold");
         ct.AddPropertyType(Prop("relatert1", "Relatert 1", _contentPickerDt, description: "Velg artikkel eller veiledning.", sortOrder: 2), "innhold");
-        ct.AddPropertyType(Prop("relatert2", "Relatert 2", _contentPickerDt, description: "Valgfri.", sortOrder: 3), "innhold");
-        ct.AddPropertyType(Prop("relatert3", "Relatert 3", _contentPickerDt, description: "Valgfri.", sortOrder: 4), "innhold");
+        ct.AddPropertyType(Prop("relatertTag1", "Merkelapp 1", _textStringDt, description: "Valgfri merkelapp på kort 1.", sortOrder: 3), "innhold");
+        ct.AddPropertyType(Prop("relatert2", "Relatert 2", _contentPickerDt, description: "Valgfri.", sortOrder: 4), "innhold");
+        ct.AddPropertyType(Prop("relatertTag2", "Merkelapp 2", _textStringDt, description: "Valgfri merkelapp på kort 2.", sortOrder: 5), "innhold");
+        ct.AddPropertyType(Prop("relatert3", "Relatert 3", _contentPickerDt, description: "Valgfri.", sortOrder: 6), "innhold");
+        ct.AddPropertyType(Prop("relatertTag3", "Merkelapp 3", _textStringDt, description: "Valgfri merkelapp på kort 3.", sortOrder: 7), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -1061,6 +1085,68 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("navn", "Navn", _textStringDt, description: "Kontaktpersonens navn.", sortOrder: 2), "innhold");
         ct.AddPropertyType(Prop("epost", "E-post", _textStringDt, description: "Kontaktpersonens e-postadresse.", sortOrder: 3), "innhold");
         ct.AddPropertyType(Prop("stilling", "Stilling", _textStringDt, description: "Kontaktpersonens stilling/tittel.", sortOrder: 4), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    // --- Artikler Oversikt element types (speiler eksempel-modulene, men for artikler) ---
+
+    private IContentType CreateArtikkelFeaturedElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        {
+            Alias = "artikkelFeatured",
+            Name = "Fremhevet artikkel",
+            Description = "Stor hero-blokk på Aktuelt-siden. Pek på én artikkel som vises som featured.",
+            Icon = "icon-bullhorn",
+            IsElement = true,
+        };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("artikkel", "Artikkel", _contentPickerDt, mandatory: true, description: "Velg artikkelen som skal fremheves.", sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("ingress", "Ingress (overstyr)", _textAreaDt, description: "Standard: artikkelens egen ingress. Skriv her for å overstyre.", sortOrder: 2), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateArtikkelGruppeElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        {
+            Alias = "artikkelGruppe",
+            Name = "Artikkel-gruppe",
+            Description = "Grid av artikler. Velg tittel (valgfri), antall kolonner (1-4) og opptil 6 artikler.",
+            Icon = "icon-grid",
+            IsElement = true,
+        };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, description: "Valgfri overskrift over gruppen.", sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("antallKolonner", "Antall kolonner", _kolonneDropdownDt, mandatory: true, description: "Hvor mange kort per rad i grid-visningen.", sortOrder: 2), "innhold");
+        for (int i = 1; i <= 6; i++)
+        {
+            ct.AddPropertyType(Prop($"artikkel{i}", $"Artikkel {i}", _contentPickerDt, description: i == 1 ? "Velg artikkel som vises i kortet." : "Valgfri, la stå tom hvis gruppen skal ha færre kort.", sortOrder: 2 + i), "innhold");
+        }
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateArtikkelRelatertElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        {
+            Alias = "artikkelRelatert",
+            Name = "Kort-gruppe (kun merkelapp)",
+            Description = "3 kort med kun merkelapp og tittel (ingen bilde). Pek på artikler eller veiledninger.",
+            Icon = "icon-link",
+            IsElement = true,
+        };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, description: "Valgfri overskrift over kortene.", sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("relatert1", "Relatert 1", _contentPickerDt, description: "Velg artikkel eller veiledning.", sortOrder: 2), "innhold");
+        ct.AddPropertyType(Prop("relatertTag1", "Merkelapp 1", _textStringDt, description: "Valgfri merkelapp på kort 1.", sortOrder: 3), "innhold");
+        ct.AddPropertyType(Prop("relatert2", "Relatert 2", _contentPickerDt, description: "Valgfri.", sortOrder: 4), "innhold");
+        ct.AddPropertyType(Prop("relatertTag2", "Merkelapp 2", _textStringDt, description: "Valgfri merkelapp på kort 2.", sortOrder: 5), "innhold");
+        ct.AddPropertyType(Prop("relatert3", "Relatert 3", _contentPickerDt, description: "Valgfri.", sortOrder: 6), "innhold");
+        ct.AddPropertyType(Prop("relatertTag3", "Merkelapp 3", _textStringDt, description: "Valgfri merkelapp på kort 3.", sortOrder: 7), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -1117,6 +1203,9 @@ public class ContentTypeComponent : IAsyncComponent
         _blockListEksemplerSeksjonerDt = CreateOrGetMultiBlockListDataType(
             "Block List - Eksempler Seksjoner",
             new[] { "eksempelFeatured", "eksempelGruppe", "eksempelRelatert", "eksempelKontakt" });
+        _blockListArtiklerSeksjonerDt = CreateOrGetMultiBlockListDataType(
+            "Block List - Artikler Seksjoner",
+            new[] { "artikkelFeatured", "artikkelGruppe", "artikkelRelatert" });
         _blockListVeiledningGuideDt = CreateOrGetMultiBlockListDataType(
             "Block List - Veiledning Guide",
             VeiledningGuideModules);
@@ -1333,6 +1422,7 @@ public class ContentTypeComponent : IAsyncComponent
         "forsideArrangementer",
         "forsideVeiledning",
         "forsideLaerAvAndre",
+        "forsideForstaRegelverket",
         "forsideSandkasse",
     };
 
@@ -2017,10 +2107,45 @@ public class ContentTypeComponent : IAsyncComponent
     {
         var ct = _contentTypeService.Get("eksempler");
         if (ct == null) return;
-        if (ct.PropertyTypes.Any(p => p.Alias == "seksjoner")) return;
-        ct.AddPropertyType(Prop("seksjoner", "Seksjoner", _blockListEksemplerSeksjonerDt, description: "Bygg opp /eksempler med fremhevet eksempel, grupper med 1–4 kolonner, relaterte lenker og kontakt-CTA. Reorder ved drag og drop.", sortOrder: 3), "innhold");
-        _contentTypeService.Save(ct);
-        Console.WriteLine("ContentTypeComposer: Migrated eksempler with seksjoner Block List");
+        bool changed = false;
+        if (!ct.PropertyTypes.Any(p => p.Alias == "seksjoner"))
+        {
+            ct.AddPropertyType(Prop("seksjoner", "Seksjoner", _blockListEksemplerSeksjonerDt, description: "Bygg opp /eksempler med fremhevet eksempel, grupper med 1–4 kolonner, relaterte lenker og kontakt-CTA. Reorder ved drag og drop.", sortOrder: 3), "innhold");
+            changed = true;
+        }
+        // Ingress på selve oversiktssiden droppes (Lars). Fremhevet-modulen har egen ingress.
+        if (RemoveProp(ct, "heroIngress")) changed = true;
+        if (changed)
+        {
+            _contentTypeService.Save(ct);
+            Console.WriteLine("ContentTypeComposer: Migrated eksempler oversikt (seksjoner, fjernet heroIngress)");
+        }
+    }
+
+    // Legg til nye felt på eksisterende modul-element-typer (eksempel/forside).
+    private void MigrateModulFelter()
+    {
+        var feat = _contentTypeService.Get("eksempelFeatured");
+        if (feat != null && !feat.PropertyTypeExists("ingress"))
+        {
+            feat.AddPropertyType(Prop("ingress", "Ingress (overstyr)", _textAreaDt, description: "Standard: eksemplets egen ingress. Skriv her for å overstyre.", sortOrder: 2), "innhold");
+            _contentTypeService.Save(feat);
+        }
+        var rel = _contentTypeService.Get("eksempelRelatert");
+        if (rel != null)
+        {
+            bool changed = false;
+            if (!rel.PropertyTypeExists("relatertTag1")) { rel.AddPropertyType(Prop("relatertTag1", "Merkelapp 1", _textStringDt, description: "Valgfri merkelapp på kort 1.", sortOrder: 3), "innhold"); changed = true; }
+            if (!rel.PropertyTypeExists("relatertTag2")) { rel.AddPropertyType(Prop("relatertTag2", "Merkelapp 2", _textStringDt, description: "Valgfri merkelapp på kort 2.", sortOrder: 5), "innhold"); changed = true; }
+            if (!rel.PropertyTypeExists("relatertTag3")) { rel.AddPropertyType(Prop("relatertTag3", "Merkelapp 3", _textStringDt, description: "Valgfri merkelapp på kort 3.", sortOrder: 7), "innhold"); changed = true; }
+            if (changed) _contentTypeService.Save(rel);
+        }
+        var aktuelt = _contentTypeService.Get("forsideAktuelt");
+        if (aktuelt != null && !aktuelt.PropertyTypeExists("fremhevetArtikkel"))
+        {
+            aktuelt.AddPropertyType(Prop("fremhevetArtikkel", "Fremhevet artikkel", _contentPickerDt, description: "Velg artikkelen som vises stort. Standard: nyeste artikkel.", sortOrder: 1), "innhold");
+            _contentTypeService.Save(aktuelt);
+        }
     }
 
     private IContentType CreateArtiklerOversikt()
@@ -2037,7 +2162,8 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("heroTittel", "Tittel", _textStringDt, description: "Vises som overskrift på /artikler. Default er 'Aktuelt' hvis tom.", sortOrder: 1), "innhold");
         ct.AddPropertyType(Prop("heroSubtittel", "Subtittel", _textStringDt, description: "Kort støttetekst under tittelen. Kan stå tom.", sortOrder: 2), "innhold");
-        ct.AddPropertyType(Prop("featuredArtikkel", "Fremhevet artikkel", _contentPickerDt, description: "Velg artikkel som vises stort øverst. Tom = bruk nyeste automatisk.", sortOrder: 3), "innhold");
+        ct.AddPropertyType(Prop("featuredArtikkel", "Fremhevet artikkel", _contentPickerDt, description: "Velg artikkel som vises stort øverst. Tom = bruk nyeste automatisk. Brukes når Seksjoner er tom.", sortOrder: 3), "innhold");
+        ct.AddPropertyType(Prop("seksjoner", "Seksjoner", _blockListArtiklerSeksjonerDt, description: "Bygg opp /artikler med fremhevet artikkel, kort-grupper (1–4 kolonner) og merkelapp-kort. Reorder ved drag og drop. La stå tom for automatisk visning.", sortOrder: 4), "innhold");
 
         ct.AddPropertyGroup("seo", "SEO");
         ct.AddPropertyType(Prop("seoTittel", "SEO-tittel", _textStringDt, description: "Overstyr tittel i søkeresultater og sosiale medier"), "seo");
@@ -2090,6 +2216,11 @@ public class ContentTypeComponent : IAsyncComponent
             ct.AddPropertyType(Prop("seoTittel", "SEO-tittel", _textStringDt, description: "Overstyr tittel i søkeresultater og sosiale medier"), "seo");
             ct.AddPropertyType(Prop("seoBeskrivelse", "SEO-beskrivelse", _textAreaDt, description: "Overstyr beskrivelse i søkeresultater og sosiale medier"), "seo");
             ct.AddPropertyType(Prop("seoBilde", "SEO-bilde", _mediaPickerDt, description: "Bilde som vises ved deling på sosiale medier"), "seo");
+            changed = true;
+        }
+        if (!ct.PropertyTypeExists("seksjoner"))
+        {
+            ct.AddPropertyType(Prop("seksjoner", "Seksjoner", _blockListArtiklerSeksjonerDt, description: "Bygg opp /artikler med fremhevet artikkel, kort-grupper (1–4 kolonner) og merkelapp-kort. Reorder ved drag og drop. La stå tom for automatisk visning.", sortOrder: 4), "innhold");
             changed = true;
         }
 
@@ -2580,7 +2711,8 @@ public class ContentTypeComponent : IAsyncComponent
         { Alias = "forsideAktuelt", Name = "Forside Aktuelt", Description = "Seksjon med siste artikler (innhold hentes automatisk)", Icon = "icon-newspaper-alt", IsElement = true };
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
-        ct.AddPropertyType(Prop("kort", "Kort", _blockListForsideArtikkelKortDt, description: "Velg artikler. La stå tom for å vise nyeste automatisk. Første kort vises stort."), "innhold");
+        ct.AddPropertyType(Prop("fremhevetArtikkel", "Fremhevet artikkel", _contentPickerDt, description: "Velg artikkelen som vises stort. Standard: nyeste artikkel.", sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("kort", "Kort", _blockListForsideArtikkelKortDt, description: "Velg artikler til de små kortene. La stå tom for å vise nyeste automatisk."), "innhold");
         ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Standard: Se alle artikler"), "innhold");
         ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt, description: "Standard: /artikler"), "innhold");
         _contentTypeService.Save(ct);
@@ -2659,6 +2791,27 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("tekst", "Tekst", _textAreaDt, description: "Kort beskrivelse under overskriften."), "innhold");
         ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt, description: "Standard: /sandkasse"), "innhold");
         ct.AddPropertyType(Prop("illustrasjon", "Illustrasjon", _mediaPickerDt), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideForstaLenkeElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideForstaLenke", Name = "Forstå regelverket-lenke", Description = "En lenke som peker på en veiledning eller artikkel", Icon = "icon-link", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("lenke", "Lenke", _contentPickerDt, mandatory: true, description: "Velg veiledning eller artikkel. Tittel og lenke hentes automatisk."), "innhold");
+        _contentTypeService.Save(ct);
+        return ct;
+    }
+
+    private IContentType CreateForsideForstaRegelverketElement()
+    {
+        var ct = new ContentType(_shortStringHelper, -1)
+        { Alias = "forsideForstaRegelverket", Name = "Forstå regelverket", Description = "Enkel lenkeliste til veiledninger/artikler om regelverk", Icon = "icon-book-alt", IsElement = true };
+        ct.AddPropertyGroup("innhold", "Innhold");
+        ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, description: "Standard: Forstå regelverket", sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("lenker", "Lenker", _blockListForstaLenkerDt, description: "Velg veiledninger/artikler som vises som enkel lenkeliste.", sortOrder: 2), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }

--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -73,11 +73,15 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
   }
 
   if (block.contentType === 'forsideAktuelt') {
-    // Redaktørvalgte kort overstyrer auto-pool. Tomt → behold nåværende auto-oppførsel.
+    // Fremhevet artikkel velges eksplisitt, ellers første valgte kort, ellers nyeste.
+    const fremhevet = block.fremhevetArtikkelId ? latestArticles.find((a: any) => a.id === block.fremhevetArtikkelId) : null;
     const valgte = block.kort?.length ? resolveArtikkelKort(block.kort) : [];
-    const useValgte = valgte.length > 0;
-    const featured = useValgte ? valgte[0] : (featuredArticle ? artikkelTilKort(featuredArticle) : null);
-    const smaa = useValgte ? valgte.slice(1) : latestArticles.slice(1, 4).map((a) => artikkelTilKort(a));
+    const featured = fremhevet ? artikkelTilKort(fremhevet)
+      : valgte.length > 0 ? valgte[0]
+      : featuredArticle ? artikkelTilKort(featuredArticle) : null;
+    // Små kort: valgte kort hvis satt, ellers nyeste. Den fremhevede tas ut.
+    const pool = valgte.length > 0 ? valgte : latestArticles.map((a) => artikkelTilKort(a));
+    const smaa = pool.filter((c) => c.slug !== featured?.slug).slice(0, 3);
     return (
       <section class="aktuelt" data-layout-block="edge">
         <div data-layout-block="content">
@@ -173,6 +177,34 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     );
   }
 
+  if (block.contentType === 'forsideForstaRegelverket') {
+    const lenker = (block.forstaLenkeIds ?? [])
+      .map((id) => {
+        const art = latestArticles.find((a: any) => a.id === id);
+        if (art) return { href: `/artikler/${art.slug}`, title: art.tittel };
+        const veil = veiledninger.find((v) => v.id === id);
+        if (veil) return { href: `/veiledning/${veil.slug}`, title: veil.tittel };
+        return null;
+      })
+      .filter((l): l is { href: string; title: string } => l !== null);
+    if (lenker.length === 0) return null;
+    return (
+      <section class="forsta-section" data-layout-block="content">
+        <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Forstå regelverket'}</h2>
+        <ul class="forsta-liste">
+          {lenker.map((l) => (
+            <li>
+              <a class="forsta-lenke" href={l.href}>
+                <span>{l.title}</span>
+                <span class="forsta-pil" aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    );
+  }
+
   if (block.contentType === 'forsideSandkasse') {
     const sandkasseLinkId = `sandkasse-link-${block.id}`;
     return (
@@ -230,6 +262,47 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     & :global(.arrow-link) {
       margin-block-start: var(--ds-size-6);
     }
+  }
+
+  /* ── Forstå regelverket (enkel lenkeliste) ───────────── */
+  .forsta-liste {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  @media (min-width: 768px) {
+    .forsta-liste {
+      grid-template-columns: repeat(2, 1fr);
+      column-gap: var(--ds-size-10);
+    }
+  }
+
+  .forsta-lenke {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--ds-size-4);
+    padding-block: var(--ds-size-4);
+    border-block-end: 1px solid var(--ds-color-surface-active);
+    color: var(--ds-color-text-default);
+    text-decoration: none;
+    font-size: var(--ds-heading-xs-font-size);
+  }
+
+  .forsta-lenke:hover span:first-child {
+    text-decoration: underline;
+  }
+
+  .forsta-pil {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    color: var(--ds-color-base-default);
   }
 
   /* ── Sandkassen ──────────────────────────────────────── */

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -226,12 +226,28 @@ export interface Side extends Artikkel {}
 
 export interface Eksempel extends Artikkel {}
 
+export interface ArtiklerSeksjon {
+  contentType: 'artikkelFeatured' | 'artikkelGruppe' | 'artikkelRelatert';
+  id: string;
+  // Featured: én artikkel-referanse + valgfri ingress-overstyring
+  artikkelId?: string;
+  ingress?: string;
+  // Gruppe: tittel + kolonner + 1-6 artikkel-referanser
+  tittel?: string;
+  antallKolonner?: number;
+  artikkelIds?: string[];
+  // Relatert (kun merkelapp): tittel + 1-3 referanser + per-kort merkelapp
+  relatertIds?: string[];
+  relatertTags?: Array<string | undefined>;
+}
+
 export interface ArtiklerOversikt {
   id: string;
   documentId: string;
   heroTittel?: string;
   heroSubtittel?: string;
   featuredArtikkelId?: string;
+  seksjoner?: ArtiklerSeksjon[];
   seoTittel?: string;
   seoBeskrivelse?: string;
   seoBilde?: UmbracoMedia;
@@ -267,7 +283,6 @@ export interface EksemplerOversikt {
   id: string;
   documentId: string;
   heroTittel?: string;
-  heroIngress?: string;
   seksjoner?: EksemplerSeksjon[];
   seoTittel?: string;
   seoBeskrivelse?: string;
@@ -351,6 +366,8 @@ export interface ForsideSeksjon {
   tekst?: string;
   arrangementId?: string;
   veiledningId?: string;
+  fremhevetArtikkelId?: string;
+  forstaLenkeIds?: string[];
   kort?: ForsideKort[];
 }
 
@@ -725,7 +742,6 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
       return {
         ...base,
         heroTittel: props.heroTittel as string || '',
-        heroIngress: props.heroIngress as string || '',
         seksjoner: mapEksemplerSeksjoner(props.seksjoner),
         seoTittel: props.seoTittel as string || '',
         seoBeskrivelse: props.seoBeskrivelse as string || '',
@@ -740,6 +756,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         heroTittel: props.heroTittel as string || '',
         heroSubtittel: props.heroSubtittel as string || '',
         featuredArtikkelId: featuredNode?.id || undefined,
+        seksjoner: mapArtiklerSeksjoner(props.seksjoner),
         seoTittel: props.seoTittel as string || '',
         seoBeskrivelse: props.seoBeskrivelse as string || '',
         seoBilde: mapMedia(props.seoBilde),
@@ -1264,9 +1281,21 @@ function mapForsideSeksjoner(value: unknown): ForsideSeksjon[] | undefined {
       tekst: typeof tekst === 'string' ? (tekst || undefined) : (tekst?.tag === '#root' ? richTextToHtml(tekst) : undefined),
       arrangementId: pickerId(props.arrangement),
       veiledningId: pickerId(props.veiledning),
+      fremhevetArtikkelId: pickerId(props.fremhevetArtikkel),
+      forstaLenkeIds: mapForstaLenker(props.lenker),
       kort: mapForsideKort(props.kort),
     };
   });
+}
+
+// Leser nested block list (forsideForstaLenke) under "Forstå regelverket"-modulen.
+// Hvert element har en content-picker (lenke) til veiledning/artikkel.
+function mapForstaLenker(value: unknown): string[] | undefined {
+  const items = (value as any)?.items;
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+  return items
+    .map((block: any) => pickerId((block.content || block).properties?.lenke))
+    .filter((id: string | undefined): id is string => !!id);
 }
 
 // Leser nested block list (forsideArtikkelKort/forsideEksempelKort) under en forside-modul.
@@ -1340,6 +1369,45 @@ function mapEksemplerSeksjoner(value: unknown): EksemplerSeksjon[] | undefined {
         navn: props.navn || undefined,
         epost: props.epost || undefined,
         stilling: props.stilling || undefined,
+      };
+    }
+    return { contentType: ct, id };
+  });
+}
+
+function mapArtiklerSeksjoner(value: unknown): ArtiklerSeksjon[] | undefined {
+  const items = (value as any)?.items;
+  if (!Array.isArray(items)) return undefined;
+
+  return items.map((block: any): ArtiklerSeksjon => {
+    const content = block.content || block;
+    const ct = content.contentType;
+    const props = content.properties || {};
+    const id = content.id || '';
+
+    if (ct === 'artikkelFeatured') {
+      return { contentType: ct, id, artikkelId: pickerId(props.artikkel), ingress: (props.ingress as string) || undefined };
+    }
+    if (ct === 'artikkelGruppe') {
+      const refs = [1, 2, 3, 4, 5, 6].map((n) => pickerId(props[`artikkel${n}`])).filter((x): x is string => !!x);
+      return {
+        contentType: ct,
+        id,
+        tittel: (props.tittel as string) || undefined,
+        antallKolonner: Number(props.antallKolonner) || 3,
+        artikkelIds: refs,
+      };
+    }
+    if (ct === 'artikkelRelatert') {
+      const refs = [1, 2, 3]
+        .map((n) => ({ id: pickerId(props[`relatert${n}`]), tag: props[`relatertTag${n}`] }))
+        .filter((r): r is { id: string; tag: unknown } => !!r.id);
+      return {
+        contentType: ct,
+        id,
+        tittel: (props.tittel as string) || undefined,
+        relatertIds: refs.map((r) => r.id),
+        relatertTags: refs.map((r) => (typeof r.tag === 'string' && r.tag ? r.tag : undefined)),
       };
     }
     return { contentType: ct, id };

--- a/apps/frontend/src/pages/artikler/index.astro
+++ b/apps/frontend/src/pages/artikler/index.astro
@@ -1,17 +1,22 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
-import { getArtikler, getArtiklerOversikt, getPlainText, getMediaUrl, type Artikkel } from '../../lib/umbraco';
+import { getArtikler, getArtiklerOversikt, getVeiledningGuider, getPlainText, getMediaUrl, type Artikkel, type VeiledningGuide } from '../../lib/umbraco';
+
+const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
 let articles: Artikkel[] = [];
+let guider: VeiledningGuide[] = [];
 let oversikt = null;
 try {
-  const [artiklerRes, oversiktRes] = await Promise.all([
-    getArtikler(),
-    getArtiklerOversikt(),
+  const [artiklerRes, oversiktRes, guiderRes] = await Promise.all([
+    getArtikler(undefined, { preview: isPreview }),
+    getArtiklerOversikt({ preview: isPreview }),
+    getVeiledningGuider({ preview: isPreview }),
   ]);
   articles = artiklerRes.data;
   oversikt = oversiktRes;
+  guider = guiderRes.data;
 } catch (e) {
   console.error('Failed to fetch artikler:', e);
 }
@@ -21,6 +26,24 @@ const heroSubtittel = oversikt?.heroSubtittel || '';
 const seoTitle = oversikt?.seoTittel || heroTittel;
 const seoDesc = oversikt?.seoBeskrivelse || 'Nyheter, analyser og artikler om kunstig intelligens i norsk offentlig sektor.';
 
+const seksjoner = oversikt?.seksjoner || [];
+
+const artikkelById = new Map(articles.map(a => [a.id, a]));
+const relatertById = new Map<string, Artikkel | VeiledningGuide>();
+articles.forEach(a => relatertById.set(a.id, a));
+guider.forEach(g => relatertById.set(g.id, g));
+
+function getImageUrl(article: Artikkel) {
+  // Bruk getMediaUrl slik at media-URLen blir absolutt mot CMS-hosten.
+  return getMediaUrl(article.artikkelBilde);
+}
+
+function getTag(article: Artikkel) {
+  if (article.bakgrunn === 'lyseblaa') return 'Offentlig sektor';
+  return 'KI-strategien';
+}
+
+// Auto-layout (fallback når redaktøren ikke har bygd seksjoner): featured + kort + bildegrid.
 const featuredOverride = oversikt?.featuredArtikkelId
   ? articles.find(a => a.id === oversikt!.featuredArtikkelId)
   : null;
@@ -31,18 +54,6 @@ const imageGridTop = rest.slice(3, 6);
 const imageGridBottom = rest.slice(6, 8);
 const bottomFeatured = rest[8];
 const remaining = rest.slice(9);
-
-function getImageUrl(article: Artikkel) {
-  // Bruk getMediaUrl slik at media-URLen blir absolutt mot CMS-hosten.
-  // Ra artikkelBilde.url er relativ (/media/...) og ville blitt hentet fra
-  // frontend-domenet, ikke CMS, og gitt 404.
-  return getMediaUrl(article.artikkelBilde);
-}
-
-function getTag(article: Artikkel) {
-  if (article.bakgrunn === 'lyseblaa') return 'Offentlig sektor';
-  return 'KI-strategien';
-}
 ---
 
 <Layout title={seoTitle} description={seoDesc}>
@@ -52,85 +63,145 @@ function getTag(article: Artikkel) {
       {heroSubtittel && <p class="artikler-subtitle">{heroSubtittel}</p>}
     </header>
 
-    {featured && (
-      <NewsCard
-        variant="featured"
-        href={`/artikler/${featured.slug}`}
-        title={featured.tittel}
-        lead={featured.ingress || getPlainText(featured.innhold, 150)}
-        image={getImageUrl(featured)}
-        imageAlt={featured.bildeAlt}
-      />
-    )}
-
-    {compactCards.length > 0 && (
-      <div class="compact-grid">
-        {compactCards.map(article => (
+    {seksjoner.length > 0 ? seksjoner.map(s => {
+      if (s.contentType === 'artikkelFeatured' && s.artikkelId) {
+        const a = artikkelById.get(s.artikkelId);
+        if (!a) return null;
+        return (
           <NewsCard
-            variant="small"
-            href={`/artikler/${article.slug}`}
-            title={article.tittel}
-            tag={getTag(article)}
-            date={article.publishedAt}
+            variant="featured"
+            href={`/artikler/${a.slug}`}
+            title={a.tittel}
+            lead={s.ingress || a.ingress || getPlainText(a.innhold, 150)}
+            image={getImageUrl(a)}
+            imageAlt={a.bildeAlt}
           />
-        ))}
-      </div>
-    )}
+        );
+      }
 
-    {imageGridTop.length > 0 && (
-      <div class="image-grid">
-        {imageGridTop.map(article => (
+      if (s.contentType === 'artikkelGruppe') {
+        const items = (s.artikkelIds || []).map(id => artikkelById.get(id)).filter((a): a is Artikkel => !!a);
+        if (items.length === 0) return null;
+        const cols = s.antallKolonner || 3;
+        return (
+          <div class="artikler-gruppe">
+            {s.tittel && <h2 class="ds-heading section-heading" data-size="lg">{s.tittel}</h2>}
+            <div class={`image-grid ${cols <= 2 ? 'image-grid--2col' : ''}`}>
+              {items.map(a => (
+                <NewsCard
+                  variant="image"
+                  href={`/artikler/${a.slug}`}
+                  title={a.tittel}
+                  date={a.publishedAt}
+                  image={getImageUrl(a)}
+                  imageAlt={a.bildeAlt}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      }
+
+      if (s.contentType === 'artikkelRelatert') {
+        const items = (s.relatertIds || []).map(id => relatertById.get(id)).filter((x): x is Artikkel | VeiledningGuide => !!x);
+        if (items.length === 0) return null;
+        return (
+          <div class="artikler-gruppe">
+            {s.tittel && <h2 class="ds-heading section-heading" data-size="lg">{s.tittel}</h2>}
+            <div class="compact-grid">
+              {items.map((item, i) => {
+                const href = articles.some(a => a.id === item.id) ? `/artikler/${item.slug}` : `/veiledning/${item.slug}`;
+                return <NewsCard variant="small" href={href} title={item.tittel} tag={s.relatertTags?.[i]} date={item.publishedAt} />;
+              })}
+            </div>
+          </div>
+        );
+      }
+
+      return null;
+    }) : (
+      <Fragment>
+        {featured && (
           <NewsCard
-            variant="image"
-            href={`/artikler/${article.slug}`}
-            title={article.tittel}
-            date={article.publishedAt}
-            image={getImageUrl(article)}
-            imageAlt={article.bildeAlt}
+            variant="featured"
+            href={`/artikler/${featured.slug}`}
+            title={featured.tittel}
+            lead={featured.ingress || getPlainText(featured.innhold, 150)}
+            image={getImageUrl(featured)}
+            imageAlt={featured.bildeAlt}
           />
-        ))}
-      </div>
-    )}
+        )}
 
-    {imageGridBottom.length > 0 && (
-      <div class="image-grid image-grid--2col">
-        {imageGridBottom.map(article => (
+        {compactCards.length > 0 && (
+          <div class="compact-grid">
+            {compactCards.map(article => (
+              <NewsCard
+                variant="small"
+                href={`/artikler/${article.slug}`}
+                title={article.tittel}
+                tag={getTag(article)}
+                date={article.publishedAt}
+              />
+            ))}
+          </div>
+        )}
+
+        {imageGridTop.length > 0 && (
+          <div class="image-grid">
+            {imageGridTop.map(article => (
+              <NewsCard
+                variant="image"
+                href={`/artikler/${article.slug}`}
+                title={article.tittel}
+                date={article.publishedAt}
+                image={getImageUrl(article)}
+                imageAlt={article.bildeAlt}
+              />
+            ))}
+          </div>
+        )}
+
+        {imageGridBottom.length > 0 && (
+          <div class="image-grid image-grid--2col">
+            {imageGridBottom.map(article => (
+              <NewsCard
+                variant="image"
+                href={`/artikler/${article.slug}`}
+                title={article.tittel}
+                date={article.publishedAt}
+                image={getImageUrl(article)}
+                imageAlt={article.bildeAlt}
+              />
+            ))}
+          </div>
+        )}
+
+        {bottomFeatured && (
           <NewsCard
-            variant="image"
-            href={`/artikler/${article.slug}`}
-            title={article.tittel}
-            date={article.publishedAt}
-            image={getImageUrl(article)}
-            imageAlt={article.bildeAlt}
+            variant="featured"
+            href={`/artikler/${bottomFeatured.slug}`}
+            title={bottomFeatured.tittel}
+            lead={bottomFeatured.ingress || getPlainText(bottomFeatured.innhold, 150)}
+            image={getImageUrl(bottomFeatured)}
+            imageAlt={bottomFeatured.bildeAlt}
           />
-        ))}
-      </div>
-    )}
+        )}
 
-    {bottomFeatured && (
-      <NewsCard
-        variant="featured"
-        href={`/artikler/${bottomFeatured.slug}`}
-        title={bottomFeatured.tittel}
-        lead={bottomFeatured.ingress || getPlainText(bottomFeatured.innhold, 150)}
-        image={getImageUrl(bottomFeatured)}
-        imageAlt={bottomFeatured.bildeAlt}
-      />
-    )}
-
-    {remaining.length > 0 && (
-      <div class="image-grid">
-        {remaining.map(article => (
-          <NewsCard
-            variant="image"
-            href={`/artikler/${article.slug}`}
-            title={article.tittel}
-            date={article.publishedAt}
-            image={getImageUrl(article)}
-            imageAlt={article.bildeAlt}
-          />
-        ))}
-      </div>
+        {remaining.length > 0 && (
+          <div class="image-grid">
+            {remaining.map(article => (
+              <NewsCard
+                variant="image"
+                href={`/artikler/${article.slug}`}
+                title={article.tittel}
+                date={article.publishedAt}
+                image={getImageUrl(article)}
+                imageAlt={article.bildeAlt}
+              />
+            ))}
+          </div>
+        )}
+      </Fragment>
     )}
 
     {articles.length === 0 && (
@@ -160,13 +231,22 @@ function getTag(article: Artikkel) {
     color: var(--ds-color-neutral-text-subtle);
   }
 
+  .artikler-gruppe {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ds-size-8);
+  }
+
+  .section-heading {
+    margin: 0;
+  }
+
   .compact-grid {
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--ds-size-12);
     border-block: 1px solid var(--ds-color-surface-active);
     padding-block: var(--ds-size-9);
-    rule: 1px solid var(--ds-color-surface-active);
 
     @media (min-width: 768px) {
       grid-template-columns: repeat(3, 1fr);
@@ -177,7 +257,6 @@ function getTag(article: Artikkel) {
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--ds-size-12);
-    rule: 1px solid var(--ds-color-surface-active);
     border-block-end: 1px solid var(--ds-color-surface-active);
     padding-block-end: var(--ds-size-9);
 

--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -6,16 +6,18 @@ import ExampleCard from '../../components/shared/ExampleCard.astro';
 import ArticleCardCompact from '../../components/shared/ArticleCardCompact.astro';
 import { getEksempler, getEksemplerOversikt, getArtikler, getVeiledningGuider, getMediaUrl, type Eksempel, type Artikkel, type VeiledningGuide } from '../../lib/umbraco';
 
+const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
+
 let eksempler: Eksempel[] = [];
 let oversikt = null;
 let artikler: Artikkel[] = [];
 let guider: VeiledningGuide[] = [];
 try {
   const [oversiktData, eksemplerRes, artiklerRes, guiderRes] = await Promise.all([
-    getEksemplerOversikt(),
-    getEksempler(),
-    getArtikler(),
-    getVeiledningGuider(),
+    getEksemplerOversikt({ preview: isPreview }),
+    getEksempler({ preview: isPreview }),
+    getArtikler(undefined, { preview: isPreview }),
+    getVeiledningGuider({ preview: isPreview }),
   ]);
   oversikt = oversiktData;
   eksempler = eksemplerRes.data;
@@ -26,9 +28,8 @@ try {
 }
 
 const heroTittel = oversikt?.heroTittel || 'Eksempler';
-const heroIngress = oversikt?.heroIngress || 'Lær av andre offentlige virksomheters erfaringer med kunstig intelligens.';
 const seoTitle = oversikt?.seoTittel || heroTittel;
-const seoDesc = oversikt?.seoBeskrivelse || heroIngress;
+const seoDesc = oversikt?.seoBeskrivelse || 'Lær av andre offentlige virksomheters erfaringer med kunstig intelligens.';
 
 const eksempelById = new Map(eksempler.map(e => [e.id, e]));
 const relatertById = new Map<string, Artikkel | VeiledningGuide>();
@@ -42,7 +43,6 @@ const seksjoner = oversikt?.seksjoner || [];
   <div class="eksempler-page" data-layout-block="content">
     <header class="eksempler-header">
       <h1 class="ds-heading eksempler-title" data-size="xl">{heroTittel}</h1>
-      {heroIngress && <p class="eksempler-lead">{heroIngress}</p>}
     </header>
 
     {seksjoner.length === 0 && eksempler.length > 0 && (

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -17,21 +17,21 @@ try {
   // alltid PUBLISERT innhold, slik at preview matcher det publikum ser (ingen upubliserte lekker inn).
   forside = await getForside({ preview: isPreview });
   // Hent en stor pool slik at redaktørvalgte kort kan slås opp på id (ikke bare de 4 nyeste).
-  const artiklerRes = await getArtikler(60);
+  const artiklerRes = await getArtikler(60, { preview: isPreview });
   latestArticles = artiklerRes.data;
-  const hendelserRes = await getKalenderhendelser();
+  const hendelserRes = await getKalenderhendelser({ preview: isPreview });
   const now = new Date();
   upcomingEvents = hendelserRes.data
     .filter(h => new Date(h.sluttDato || h.startDato) >= now)
     .sort((a, b) => new Date(a.startDato).getTime() - new Date(b.startDato).getTime());
-  const eksemplerRes = await getEksempler();
+  const eksemplerRes = await getEksempler({ preview: isPreview });
   eksempler = eksemplerRes.data;
   eksempelKort = eksempler.slice(0, 2).map((c: any) => ({
     href: `/caser/${c.slug}`,
     title: c.tittel,
     tag: 'Eksempel',
   }));
-  const veiledningerRes = await getVeiledningGuider();
+  const veiledningerRes = await getVeiledningGuider({ preview: isPreview });
   veiledninger = veiledningerRes.data;
 } catch (e) {
   console.error('Failed to fetch frontpage CMS data:', e);

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -11,15 +11,17 @@ import AkselIcon from '../../components/shared/AkselIcon.astro';
 import LinkList from '../../components/shared/LinkList.astro';
 import { getVeiledningOversikt, getVeiledningGuider, getEksempler, getMediaUrl } from '../../lib/umbraco';
 
+const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
+
 let cmsData: Awaited<ReturnType<typeof getVeiledningOversikt>> = null;
 let guides: Awaited<ReturnType<typeof getVeiledningGuider>> = { data: [], meta: { pagination: { page: 1, pageSize: 0, pageCount: 0, total: 0 } } };
 let cases: Awaited<ReturnType<typeof getEksempler>> = { data: [], meta: { pagination: { page: 1, pageSize: 0, pageCount: 0, total: 0 } } };
 
 try {
   [cmsData, guides, cases] = await Promise.all([
-    getVeiledningOversikt(),
-    getVeiledningGuider(),
-    getEksempler(),
+    getVeiledningOversikt({ preview: isPreview }),
+    getVeiledningGuider({ preview: isPreview }),
+    getEksempler({ preview: isPreview }),
   ]);
 } catch (e) {
   console.error('Failed to fetch veiledning page data:', e);


### PR DESCRIPTION
Stacker på #380 (base er den grenen, ikke main). Base kan settes til main etter at #380 er merget.

## Artikler-oversikt blir modulær
Speiler eksempler-oversikt. Nye element-typer artikkelFeatured, artikkelGruppe (1–4 kolonner) og artikkelRelatert (kort med kun merkelapp + tittel). Ny Block List og seksjoner-felt på artikler-oversikt. Frontend rendrer modulene og faller tilbake til dagens auto-layout når seksjoner er tom.

## Eksempler-oversikt
- Fremhevet eksempel får redigerbar ingress (overstyr)
- Relatert innhold får merkelapp per kort (relatertTag1-3)
- Ingress på selve oversiktssiden er fjernet

## Forside
- Ny modul "Forstå regelverket": enkel lenkeliste der redaktøren peker på veiledninger/artikler via content-picker (tittel og lenke hentes automatisk)
- Aktuelt: fremhevet artikkel kan velges eksplisitt, ellers nyeste

## Preview
Listesidene (artikler, eksempler, veiledning, forside) sendte ikke preview-flagget videre til list-getterne, så kladd-preview krevde lagring først. Nå sendes preview til alle getterne.

Skjemaendringene migreres additivt på eksisterende noder ved oppstart (heroIngress fjernes på eksempler-oversikt).