### PR TITLE
feat: add SiteimproveBot-Crawler to allowed user agents in robots.txt

### DIFF
--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -12,6 +12,7 @@ export const GET: APIRoute = ({ url }) => {
   const body = isProd
     ? `# Allows Siteimprove only (todo: allow at launch)
 User-agent: SiteimproveBot
+User-agent: SiteimproveBot-Crawler
 Allow: /
 Disallow: /admin-tilgang
 Disallow: /preview-tilgang


### PR DESCRIPTION


## Summary

This pull request makes a minor update to the `robots.txt` generation logic to include an additional user agent for crawling.

- Added `User-agent: SiteimproveBot-Crawler` to the generated `robots.txt` to allow this crawler access.

