### PR TITLE
Frontend: linjeskift i trekkspill-modulen

### DIFF
--- a/apps/frontend/src/components/shared/ArticleBlocksRenderer.astro
+++ b/apps/frontend/src/components/shared/ArticleBlocksRenderer.astro
@@ -98,7 +98,7 @@ const renderItems = groupConsecutiveTrekkspill(blocks);
               <summary>
                 {block.content.tittel}
               </summary>
-              <div set:html={block.content.innhold} />
+              <div class="article-accordion-body" set:html={block.content.innhold} />
             </details>
           ))}
         </div>

--- a/apps/frontend/src/components/shared/VeiledningBlocksRenderer.astro
+++ b/apps/frontend/src/components/shared/VeiledningBlocksRenderer.astro
@@ -48,7 +48,7 @@ const moduleIcons: Record<string, string> = {
         {item.blocks.map((block) => (
           <details class="ds-details">
             <summary>{block.content.tittel}</summary>
-            <div set:html={block.content.innhold} />
+            <div class="trekkspill-innhold" set:html={block.content.innhold} />
           </details>
         ))}
       </div>
@@ -85,7 +85,7 @@ const moduleIcons: Record<string, string> = {
             {trekkspill.map((t) => (
               <details class="ds-details">
                 <summary>{t.tittel}</summary>
-                <div set:html={t.innhold} />
+                <div class="trekkspill-innhold" set:html={t.innhold} />
               </details>
             ))}
           </div>
@@ -120,6 +120,27 @@ const moduleIcons: Record<string, string> = {
     padding-inline-start: var(--ds-size-6);
   }
   .veiledning-tekst :global(li) {
+    margin-bottom: var(--ds-size-1);
+  }
+
+  /* Rik tekst i trekkspill-kroppen. Uten dette har avsnitt (Enter i RTE) ingen
+     margin (ds-paragraph er margin-løs) og linjeskift forsvinner. (#393) */
+  .trekkspill-innhold {
+    font-size: var(--ds-body-md-font-size);
+    line-height: var(--ds-body-md-line-height);
+  }
+  .trekkspill-innhold :global(p) {
+    margin: 0 0 var(--ds-size-3);
+  }
+  .trekkspill-innhold :global(p:last-child) {
+    margin-bottom: 0;
+  }
+  .trekkspill-innhold :global(ul),
+  .trekkspill-innhold :global(ol) {
+    margin: var(--ds-size-2) 0 var(--ds-size-3);
+    padding-inline-start: var(--ds-size-6);
+  }
+  .trekkspill-innhold :global(li) {
     margin-bottom: var(--ds-size-1);
   }
 

--- a/apps/frontend/src/styles/article-blocks.css
+++ b/apps/frontend/src/styles/article-blocks.css
@@ -293,3 +293,13 @@
 .article-accordion-group .ds-details {
   --dsc-details-background: var(--ds-color-surface-default);
 }
+
+/* Rik tekst i trekkspill-kroppen. ds-paragraph har ingen egen margin, så avsnitt
+   (Enter i RTE) kolliderer uten dette. Speiler .article-text-block. (#393) */
+.article-accordion-body p { margin: 0 0 var(--ds-size-4); }
+.article-accordion-body p:last-child { margin-bottom: 0; }
+.article-accordion-body ul, .article-accordion-body ol {
+  margin-block-start: var(--ds-size-2);
+  margin-block-end: var(--ds-size-5);
+  padding-inline-start: var(--ds-size-6);
+}


### PR DESCRIPTION
## Problem
Linjeskift/avsnitt i trekkspill-modulen vises ikke på frontend selv om de legges inn i Umbraco (#393).

## Årsak
Trekkspill-innholdet er rik tekst som rendres med `set:html`. `.ds-paragraph` (designsystemet) har ingen egen margin, så hver rik-tekst-kropp setter `p { margin }` selv (`.article-text-block`, `.veiledning-tekst`, `.veiledning-modul-body`). Accordion-kroppen hadde ingen klasse og dermed ingen margin, så avsnitt kolliderte.

## Endring
- Klasse + margin-regler på accordion-kroppen i begge renderere (artikkel + veiledning), inkl. nestet trekkspill i `veiledningInfo`.
- Speiler eksisterende avsnitt/liste-spacing.

Fixes #393