### PR TITLE
Veiledning: legg til Enkel liste (seksjon 3) på navigasjonssiden

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -2975,12 +2975,19 @@ public class ContentTypeComponent : IAsyncComponent
             ct.AddPropertyType(Prop("seksjon2Kort", "Kort", _blockListVeiledningKortDt), "seksjon2");
             changed = true;
         }
+        // Seksjon 3 (vises som "Enkel liste" i backoffice) — enkel lenkeliste, kun
+        // tittel + URL brukes på frontend ("Forstå regelverket"-seksjonen). (#389)
+        if (!ct.PropertyGroups.Any(g => g.Alias == "seksjon3"))
+        {
+            ct.AddPropertyGroup("seksjon3", "Enkel liste");
+            ct.AddPropertyType(Prop("seksjon3Tittel", "Tittel", _textStringDt), "seksjon3");
+            ct.AddPropertyType(Prop("seksjon3Kort", "Kort", _blockListVeiledningKortDt), "seksjon3");
+            changed = true;
+        }
         // Re-label til beskrivende modulnavn (Dorte, Figma-tavle 2026-06-04). Aliasene
         // beholdes, så ingen data flyttes. Kjorer hver oppstart slik at noder opprettet
-        // med de gamle "Seksjon 1/2"-navnene ogsaa oppdateres.
-        // TODO: "Enkel liste" (seksjon 3) mangler fortsatt — egen oppgave, henger sammen
-        // med planlagt sidetre-/modulkatalog-restrukturering.
-        foreach (var (alias, name) in new[] { ("seksjon1", "Fremhevet veiledning og artikler"), ("seksjon2", "Rik liste") })
+        // med de gamle "Seksjon 1/2/3"-navnene ogsaa oppdateres.
+        foreach (var (alias, name) in new[] { ("seksjon1", "Fremhevet veiledning og artikler"), ("seksjon2", "Rik liste"), ("seksjon3", "Enkel liste") })
         {
             var grp = ct.PropertyGroups.FirstOrDefault(g => g.Alias == alias);
             if (grp != null && grp.Name != name) { grp.Name = name; changed = true; }
@@ -2989,6 +2996,7 @@ public class ContentTypeComponent : IAsyncComponent
         {
             ("seksjon1Tittel", "Tittel"), ("seksjon1Kort", "Kort"),
             ("seksjon2Tittel", "Tittel"), ("seksjon2Kort", "Kort"),
+            ("seksjon3Tittel", "Tittel"), ("seksjon3Kort", "Kort"),
         })
         {
             var pt = ct.PropertyTypes.FirstOrDefault(x => x.Alias == alias);

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -451,14 +451,6 @@ export interface VeiledningKort {
   ikon?: string;
 }
 
-export interface VerktoyKort {
-  tittel: string;
-  beskrivelse?: string;
-  url?: string;
-  bilde?: UmbracoMedia;
-  ikon?: string;
-}
-
 export interface VeiledningOversikt {
   id: string;
   documentId: string;
@@ -470,8 +462,8 @@ export interface VeiledningOversikt {
   seksjon1Kort?: VeiledningKort[];
   seksjon2Tittel?: string;
   seksjon2Kort?: VeiledningKort[];
-  verktoyTittel?: string;
-  verktoyKort?: VerktoyKort[];
+  seksjon3Tittel?: string;
+  seksjon3Kort?: VeiledningKort[];
   seoTittel?: string;
   seoBeskrivelse?: string;
   seoBilde?: UmbracoMedia;
@@ -900,8 +892,8 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         seksjon1Kort: mapVeiledningKort(props.seksjon1Kort),
         seksjon2Tittel: props.seksjon2Tittel as string || undefined,
         seksjon2Kort: mapVeiledningKort(props.seksjon2Kort),
-        verktoyTittel: props.verktoyTittel as string || undefined,
-        verktoyKort: mapVerktoyKort(props.verktoyKort),
+        seksjon3Tittel: props.seksjon3Tittel as string || undefined,
+        seksjon3Kort: mapVeiledningKort(props.seksjon3Kort),
         seoTittel: props.seoTittel as string || undefined,
         seoBeskrivelse: props.seoBeskrivelse as string || undefined,
         seoBilde: mapMedia(props.seoBilde),
@@ -1196,22 +1188,6 @@ function mapVeiledningKort(value: unknown): VeiledningKort[] {
       tittel: (props.tittel as string) || '',
       beskrivelse: (props.beskrivelse as string) || undefined,
       url: (props.url as string) || undefined,
-      ikon: (props.ikon as string) || undefined,
-    };
-  });
-}
-
-function mapVerktoyKort(value: unknown): VerktoyKort[] {
-  const items = Array.isArray(value) ? value : (value as any)?.items;
-  if (!Array.isArray(items)) return [];
-  return items.map((block: any) => {
-    const content = block.content || block;
-    const props = content.properties || content;
-    return {
-      tittel: (props.tittel as string) || '',
-      beskrivelse: (props.beskrivelse as string) || undefined,
-      url: (props.url as string) || undefined,
-      bilde: mapMedia(props.bilde),
       ikon: (props.ikon as string) || undefined,
     };
   });

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -54,9 +54,9 @@ const richLinks = (cmsData?.seksjon2Kort?.length ?? 0) > 0
       href: `/veiledning/${g.slug}`,
     }));
 
-// Simple link list — "Forstå regelverket"
-const simpleLinks = cmsData?.verktoyKort
-  ? cmsData.verktoyKort.map(k => ({
+// Simple link list — "Forstå regelverket" (seksjon3 "Enkel liste", #389)
+const simpleLinks = (cmsData?.seksjon3Kort?.length ?? 0) > 0
+  ? cmsData!.seksjon3Kort!.map(k => ({
       title: k.tittel,
       href: k.url || '#',
     }))
@@ -128,7 +128,7 @@ const seoDesc = cmsData?.seoBeskrivelse || heroText;
   <!-- Forstå regelverket — Simple link list -->
   {simpleLinks.length > 0 && (
     <section class="veil-simple-links" data-layout-block="content">
-      <LinkList links={simpleLinks} heading={cmsData?.verktoyTittel || 'Forstå regelverket'} />
+      <LinkList links={simpleLinks} heading={cmsData?.seksjon3Tittel || 'Forstå regelverket'} />
     </section>
   )}
 


### PR DESCRIPTION
## Problem
Navigasjonssiden for veiledning manglet seksjon 3 "Enkel liste" (#389). Frontend leste den enkle lista ("Forstå regelverket") fra det fjernede `verktoyKort`-feltet, så den var ikke redigerbar.

## Endring
- CMS: ny `seksjon3`-gruppe "Enkel liste" (`seksjon3Tittel` + `seksjon3Kort`) på `veiledninger`-containeren, speiler seksjon1/seksjon2.
- Frontend: `veiledning/index.astro` leser `seksjon3Kort`/`seksjon3Tittel`; interface + mapping oppdatert, fjernet død `verktoy`-kode.

Fixes #389