### PR TITLE
CMS: auto-vask av interne lenkefelt (modulær Lenke / URL-datatype)

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -28,6 +28,7 @@ public class ContentTypeComponent : IAsyncComponent
 
     // Data types (resolved at init time)
     private IDataType _textStringDt = null!;
+    private IDataType _urlDt = null!;                 // Lenke / URL: TextBox-felt som auto-vaskes (interne stier) ved lagring
     private IDataType _textAreaDt = null!;
     private IDataType _richTextDt = null!;            // Standard RichText (full toolbar)
     private IDataType _richTextDtRestricted = null!;  // Restricted RichText (no headings, no source editor)
@@ -308,6 +309,10 @@ public class ContentTypeComponent : IAsyncComponent
             Step("globaleInnstillinger", () => { if (_contentTypeService.Get("globaleInnstillinger") == null) CreateGlobaleInnstillinger(); });
             Step("migrateGlobaleInnstillinger", () => MigrateGlobaleInnstillinger());
 
+            // Repeker manuelle lenkefelt til "Lenke / URL"-datatypen så de auto-vaskes
+            // (UrlFieldWashHandler). Kjøres til slutt når alle content types finnes.
+            Step("repointUrlFields", () => RepointUrlFields());
+
             // RichText data types are ensured by ResolveDataTypes() at the very start of this method.
             // Standard + Restricted variants get correct toolbar+extensions config every startup.
             // No need to call again here.
@@ -324,6 +329,7 @@ public class ContentTypeComponent : IAsyncComponent
     private void ResolveDataTypes()
     {
         _textStringDt = FindDataType(Constants.PropertyEditors.Aliases.TextBox);
+        _urlDt = CreateOrGetUrlTextBox();
         _textAreaDt = FindDataType(Constants.PropertyEditors.Aliases.TextArea);
         // RichText: ensure both standard and restricted variants exist with correct config.
         // Toolbar/extension configs live in StandardToolbar/StandardExtensions and
@@ -444,6 +450,73 @@ public class ContentTypeComponent : IAsyncComponent
         };
         _dataTypeService.Save(dt);
         return dt;
+    }
+
+    // Gjenbrukbart "Lenke / URL"-felt: vanlig TextBox, men en egen datatype slik at
+    // UrlFieldWashHandler kan kjenne den igjen og vaske interne stier ved lagring.
+    // Eksterne URLer (http..., mailto:, bart domene osv.) lar washeren stå urørt.
+    // Bruk denne datatypen på alle felt der en redaktør skriver inn en lenke.
+    private IDataType CreateOrGetUrlTextBox()
+    {
+        const string name = "Lenke / URL";
+        var existing = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+            .FirstOrDefault(dt => dt.Name == name);
+        if (existing != null) return existing;
+
+        var editor = _propertyEditors[Constants.PropertyEditors.Aliases.TextBox]
+            ?? throw new InvalidOperationException("TextBox editor not found");
+
+        var dt = new DataType(editor, _configSerializer)
+        {
+            Name = name,
+            DatabaseType = ValueStorageType.Nvarchar,
+            EditorUiAlias = "Umb.PropertyEditorUi.TextBox",
+            ConfigurationData = new Dictionary<string, object>(),
+        };
+        _dataTypeService.Save(dt);
+        return dt;
+    }
+
+    // Felt der redaktører skriver inn en lenke for hånd. Repekes til "Lenke / URL"-datatypen
+    // slik at de vaskes automatisk (UrlFieldWashHandler). Innholdspickere og slug er holdt utenfor.
+    // Nye URL-felt: bruk _urlDt direkte i Create-metoden, eller legg dem til her.
+    private static readonly (string ContentType, string Property)[] UrlFields =
+    {
+        ("kalenderhendelse", "lenke"),
+        ("forsideHero", "lenkeUrl"),
+        ("forsideAktuelt", "lenkeUrl"),
+        ("forsideArrangementer", "lenkeUrl"),
+        ("forsideVeiledning", "lenkeUrl"),
+        ("forsideLaerAvAndre", "lenkeUrl"),
+        ("forsideSandkasse", "lenkeUrl"),
+        ("artikkelInfoBoks", "lesMerUrl"),
+        ("veiledningInfo", "lesMerUrl"),
+        ("veiledningKort", "url"),
+        ("verktoyKort", "url"),
+        ("globaleInnstillinger", "footerLenke1Url"),
+        ("globaleInnstillinger", "footerLenke3Url"),
+        ("globaleInnstillinger", "footerLenke4Url"),
+        ("globaleInnstillinger", "footerLenke5Url"),
+    };
+
+    // Repeker eksisterende lenkefelt fra vanlig TextBox til "Lenke / URL"-datatypen.
+    // TextBox -> TextBox (samme Nvarchar-lagring), så lagrede verdier er uberørt.
+    // Idempotent: hopper over felt som allerede peker riktig.
+    private void RepointUrlFields()
+    {
+        foreach (var (ctAlias, propAlias) in UrlFields)
+        {
+            var ct = _contentTypeService.Get(ctAlias);
+            var prop = ct?.PropertyTypes.FirstOrDefault(p => p.Alias == propAlias);
+            if (ct == null || prop == null) continue;
+            if (prop.DataTypeKey == _urlDt.Key) continue;
+
+            prop.DataTypeId = _urlDt.Id;
+            prop.DataTypeKey = _urlDt.Key;
+            prop.ValueStorageType = _urlDt.DatabaseType;
+            _contentTypeService.Save(ct);
+            Console.WriteLine($"ContentTypeComposer: repekte {ctAlias}.{propAlias} til 'Lenke / URL'-datatypen");
+        }
     }
 
     private IDataType FindDataType(string editorAlias)

--- a/apps/cms-umbraco/Composers/InternalUrlWasher.cs
+++ b/apps/cms-umbraco/Composers/InternalUrlWasher.cs
@@ -1,0 +1,56 @@
+using System.Text.RegularExpressions;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Vasker lenkefelt som redaktører fyller ut for hånd. KUN interne stier vaskes.
+/// Eksterne URLer lar vi stå helt urørt (bortsett fra trimming), fordi en redaktør
+/// som limer inn en ekte URL ikke skal risikere at den blir ødelagt.
+///
+/// Ekstern = noe som har et skjema (http:, https:, mailto:, tel:, ftp: ...),
+/// er protokoll-relativ (//host), er et anker (#...) eller ser ut som et bart
+/// domene (datatilsynet.no/...). Alt annet behandles som intern sti.
+///
+/// Intern vask: trim, ett innledende skråstrek, ingen avsluttende skråstrek,
+/// kollapser doble skråstreker. Query (?) og fragment (#) bevares uendret.
+/// Idempotent: en allerede vasket verdi returneres uendret.
+/// </summary>
+public static class InternalUrlWasher
+{
+    // Skjema som http:, https:, mailto:, tel:, ftp: ... (RFC 3986 scheme).
+    private static readonly Regex SchemeRegex =
+        new(@"^[a-zA-Z][a-zA-Z0-9+.\-]*:", RegexOptions.Compiled);
+
+    // Bart domene uten skjema: "datatilsynet.no", "example.com/sti". Sjekkes på
+    // første segment (før /, ? eller #). Krever minst én prikk og bokstav-TLD.
+    private static readonly Regex BareDomainRegex =
+        new(@"^[a-z0-9\-]+(\.[a-z0-9\-]+)*\.[a-z]{2,}$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static string? Wash(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return value;
+
+        var v = value.Trim();
+
+        // Ekstern eller spesiell: la stå (kun trimmet).
+        if (SchemeRegex.IsMatch(v) || v.StartsWith("//") || v.StartsWith("#")) return v;
+
+        // Skill path fra query/fragment så vi aldri rører ?...  eller #...
+        var cut = v.IndexOfAny(new[] { '?', '#' });
+        var path = cut >= 0 ? v.Substring(0, cut) : v;
+        var suffix = cut >= 0 ? v.Substring(cut) : string.Empty;
+
+        // Bart domene (uten skjema) i path-delen -> ekstern, ikke prefiks skråstrek
+        // (ellers blir "datatilsynet.no/x" til "/datatilsynet.no/x" og ødelagt).
+        var firstSegment = path.Split('/')[0];
+        if (BareDomainRegex.IsMatch(firstSegment)) return v;
+
+        // Intern sti: rydd opp.
+        path = path.Replace(" ", string.Empty);
+        if (!path.StartsWith("/")) path = "/" + path;
+        while (path.Contains("//")) path = path.Replace("//", "/");
+        if (path.Length > 1 && path.EndsWith("/")) path = path.TrimEnd('/');
+
+        return path + suffix;
+    }
+}

--- a/apps/cms-umbraco/Composers/UrlFieldWashHandler.cs
+++ b/apps/cms-umbraco/Composers/UrlFieldWashHandler.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Vasker alle felt som bruker "Lenke / URL"-datatypen ved lagring, uansett hvor de
+/// ligger: direkte på en document type, eller nede i en Block List / Block Grid.
+/// Vaskingen kjenner datatypen igjen på dens key, så datatypen er modulær: ta den i
+/// bruk på et hvilket som helst felt og det vaskes automatisk. Kun interne stier
+/// vaskes (se <see cref="InternalUrlWasher"/>); eksterne URLer står urørt.
+/// Speiler mønsteret til <c>ContentSlugHandler</c>.
+/// </summary>
+public class UrlFieldWashComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentSavingNotification, UrlFieldWashHandler>();
+    }
+}
+
+public class UrlFieldWashHandler : INotificationHandler<ContentSavingNotification>
+{
+    private const string UrlDataTypeName = "Lenke / URL";
+
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IDataTypeService _dataTypeService;
+
+    private Guid? _urlKey;
+    private bool _urlKeyResolved;
+
+    public UrlFieldWashHandler(IContentTypeService contentTypeService, IDataTypeService dataTypeService)
+    {
+        _contentTypeService = contentTypeService;
+        _dataTypeService = dataTypeService;
+    }
+
+    public void Handle(ContentSavingNotification notification)
+    {
+        var urlKey = ResolveUrlKey();
+        if (urlKey == null) return;
+
+        // Memo for (contentTypeKey, alias) -> (datatype-key, editor-alias) under denne lagringen.
+        var memo = new Dictionary<(Guid, string), (Guid?, string?)>();
+
+        foreach (var content in notification.SavedEntities)
+        {
+            foreach (var property in content.Properties)
+            {
+                var pt = property.PropertyType;
+
+                if (pt.DataTypeKey == urlKey)
+                {
+                    var cur = content.GetValue<string>(property.Alias);
+                    var washed = InternalUrlWasher.Wash(cur);
+                    if (washed != cur) content.SetValue(property.Alias, washed);
+                    continue;
+                }
+
+                if (IsBlockEditor(pt.PropertyEditorAlias))
+                {
+                    var raw = content.GetValue<string>(property.Alias);
+                    if (TryWashBlockJson(raw, urlKey.Value, memo, out var updated))
+                    {
+                        content.SetValue(property.Alias, updated);
+                    }
+                }
+            }
+        }
+    }
+
+    private Guid? ResolveUrlKey()
+    {
+        if (_urlKeyResolved) return _urlKey;
+        _urlKeyResolved = true;
+        _urlKey = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+            .FirstOrDefault(dt => dt.Name == UrlDataTypeName)?.Key;
+        return _urlKey;
+    }
+
+    private static bool IsBlockEditor(string? editorAlias) =>
+        editorAlias == Constants.PropertyEditors.Aliases.BlockList ||
+        editorAlias == Constants.PropertyEditors.Aliases.BlockGrid;
+
+    // Parser block-JSON, vasker URL-verdier (rekursivt for blokker-i-blokker) og
+    // serialiserer tilbake. Returnerer false (og rører ingenting) ved ugyldig JSON.
+    private bool TryWashBlockJson(string? raw, Guid urlKey,
+        Dictionary<(Guid, string), (Guid?, string?)> memo, out string updated)
+    {
+        updated = raw ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(raw) || raw[0] != '{') return false;
+
+        JsonNode? root;
+        try { root = JsonNode.Parse(raw); }
+        catch (JsonException) { return false; }
+
+        if (root is not JsonObject obj) return false;
+
+        var changed = WashContainer(obj, urlKey, memo);
+        if (changed) updated = obj.ToJsonString();
+        return changed;
+    }
+
+    private bool WashContainer(JsonObject container, Guid urlKey,
+        Dictionary<(Guid, string), (Guid?, string?)> memo)
+    {
+        var changed = false;
+        foreach (var arrayName in new[] { "contentData", "settingsData" })
+        {
+            if (container[arrayName] is not JsonArray arr) continue;
+            foreach (var item in arr)
+            {
+                if (item is JsonObject block) changed |= WashBlock(block, urlKey, memo);
+            }
+        }
+        return changed;
+    }
+
+    private bool WashBlock(JsonObject block, Guid urlKey,
+        Dictionary<(Guid, string), (Guid?, string?)> memo)
+    {
+        if (block["contentTypeKey"]?.GetValue<string>() is not string ctKeyStr ||
+            !Guid.TryParse(ctKeyStr, out var ctKey) ||
+            block["values"] is not JsonArray values)
+        {
+            return false;
+        }
+
+        var changed = false;
+        foreach (var v in values)
+        {
+            if (v is not JsonObject val) continue;
+            if (val["alias"]?.GetValue<string>() is not string alias) continue;
+
+            var (dtKey, editorAlias) = ResolveProp(ctKey, alias, memo);
+
+            if (dtKey == urlKey)
+            {
+                if (val["value"] is JsonValue jv && jv.TryGetValue<string>(out var cur))
+                {
+                    var washed = InternalUrlWasher.Wash(cur);
+                    if (washed != cur) { val["value"] = washed; changed = true; }
+                }
+            }
+            else if (IsBlockEditor(editorAlias))
+            {
+                // Blokk-i-blokk: verdien kan være en JSON-streng eller et JSON-objekt.
+                if (val["value"] is JsonValue inner && inner.TryGetValue<string>(out var innerStr))
+                {
+                    if (TryWashBlockJson(innerStr, urlKey, memo, out var upd)) { val["value"] = upd; changed = true; }
+                }
+                else if (val["value"] is JsonObject innerObj)
+                {
+                    if (WashContainer(innerObj, urlKey, memo)) changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    private (Guid?, string?) ResolveProp(Guid ctKey, string alias,
+        Dictionary<(Guid, string), (Guid?, string?)> memo)
+    {
+        if (memo.TryGetValue((ctKey, alias), out var cached)) return cached;
+
+        var ct = _contentTypeService.Get(ctKey);
+        var p = ct?.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == alias);
+        var result = (p?.DataTypeKey, p?.PropertyEditorAlias);
+        memo[(ctKey, alias)] = result;
+        return result;
+    }
+}


### PR DESCRIPTION
Redaktører skrev inn lenker for hånd i mange felt uten noen vasking. Denne PR-en samler alle slike felt om én gjenbrukbar datatype som vaskes automatisk ved lagring.

## Endring
- Ny datatype "Lenke / URL" (`_urlDt`), TextBox-basert. Ta den i bruk på et hvilket som helst lenkefelt så vaskes det.
- `UrlFieldWashHandler` (`ContentSaving`, søster av `ContentSlugHandler`) vasker felt bundet til datatypen, både på document types og nestet i block list/grid. Kjenner igjen datatypen på key, så den er modulær.
- `RepointUrlFields` repeker 15 eksisterende lenkefelt fra vanlig TextBox til datatypen. TextBox til TextBox med samme Nvarchar-lagring, så lagrede verdier er uberørt. Idempotent og isolert i `Step`.

## Vasking er intern-only
Kun interne stier vaskes (ett ledende skråstrek, ingen avsluttende, kollaps av `//`, query/fragment bevart). Alt eksternt står urørt (kun trimmet): skjema (`http:`, `mailto:`, `tel:` ...), `//`, `#` og bare domener (`datatilsynet.no/...`). Slik kan ikke en innlimt ekte URL bli ødelagt.

## Felt som dekkes
`kalenderhendelse.lenke`, de seks `forside*.lenkeUrl`, `artikkelInfoBoks`/`veiledningInfo.lesMerUrl`, `veiledningKort`/`verktoyKort.url`, og footer-lenkene `footerLenke1/3/4/5Url` på `globaleInnstillinger`.

## Verifisert
- CMS bygger uten feil.
- `InternalUrlWasher.Wash` kjørt mot 22 grensetilfeller (intern, ekstern, bart domene, query, anker, tom, idempotens). Alle korrekte.

`RepointUrlFields` endrer eksisterende skjema (datatype-bytte) ved oppstart. Verdisikkert (TextBox til TextBox), men kjører på neste dis-core-deploy.