### PR TITLE
fix: reduce spaces between sections

### DIFF
--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -165,6 +165,11 @@ const seksjoner = oversikt?.seksjoner?.length ? oversikt.seksjoner : fallbackSek
     padding-block: var(--ds-size-10) var(--ds-size-22);
   }
 
+  .eksempler-section:has(.example-link-cards) + .eksempler-section:has(.example-link-cards) {
+    margin-top: var(--ds-size-0);
+    padding-top: var(--ds-size-0);
+  }
+
   .eksempler-header {
     display: flex;
     width: 100%;


### PR DESCRIPTION
Før:
<img width="1096" height="636" alt="Screenshot 2026-06-08 at 15 39 16" src="https://github.com/user-attachments/assets/f90eb1bc-338f-464a-847c-5304e1f26b5e" />

Etter:
<img width="1100" height="545" alt="Screenshot 2026-06-08 at 15 38 42" src="https://github.com/user-attachments/assets/00e20ba5-63be-451a-91d3-75c2cb0de451" />
