### PR TITLE
Frontend: leveranse-resizing av media (webp + nedskalering per kontekst)

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -10,7 +10,7 @@ import ArrowLink from '../shared/ArrowLink.astro';
 import ExampleLinkCards from '../shared/ExampleLinkCards.astro';
 import TextWithImage from '../shared/TextWithImage.astro';
 import AkselIcon from '../shared/AkselIcon.astro';
-import { getMediaUrl, type ForsideSeksjon, type Kalenderhendelse, type VeiledningGuide } from '../../lib/umbraco';
+import { getMediaUrl, MEDIA_WIDTH, type ForsideSeksjon, type Kalenderhendelse, type VeiledningGuide } from '../../lib/umbraco';
 
 interface Props {
   seksjoner: ForsideSeksjon[];
@@ -35,7 +35,7 @@ const artikkelTilKort = (a: any, ingressOverride?: string) => ({
   tittel: a.tittel,
   slug: a.slug,
   lead: ingressOverride || a.lead || a.ingress,
-  image: a.image || getMediaUrl(a.artikkelBilde),
+  image: a.image || getMediaUrl(a.artikkelBilde, MEDIA_WIDTH.card),
   publishedAt: a.publishedAt,
 });
 

--- a/apps/frontend/src/lib/media-url.test.ts
+++ b/apps/frontend/src/lib/media-url.test.ts
@@ -33,11 +33,36 @@ describe('toAbsoluteMediaUrl', () => {
 });
 
 describe('getMediaUrl', () => {
-  test('gjør media-objektets url absolutt', () => {
-    expect(lib.getMediaUrl({ url: '/media/a/b.jpg' } as never)).toBe(`${CMS}/media/a/b.jpg`);
+  test('gjør media-objektets url absolutt og default-optimaliserer (content-bredde, webp)', () => {
+    expect(lib.getMediaUrl({ url: '/media/a/b.jpg' } as never))
+      .toBe(`${CMS}/media/a/b.jpg?width=${lib.MEDIA_WIDTH.content}&format=webp&quality=80`);
+  });
+  test('respekterer eksplisitt bredde (f.eks. hero)', () => {
+    expect(lib.getMediaUrl({ url: '/media/a/b.jpg' } as never, lib.MEDIA_WIDTH.hero))
+      .toBe(`${CMS}/media/a/b.jpg?width=${lib.MEDIA_WIDTH.hero}&format=webp&quality=80`);
   });
   test('undefined media gir undefined', () => {
     expect(lib.getMediaUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe('toAbsoluteMediaUrl med width (leveranse-resizing)', () => {
+  test('legger width/format/quality på relativ media-URL', () => {
+    expect(lib.toAbsoluteMediaUrl('/media/x/foo.jpg', 800))
+      .toBe(`${CMS}/media/x/foo.jpg?width=800&format=webp&quality=80`);
+  });
+  test('legger params på allerede-absolutt media-URL', () => {
+    expect(lib.toAbsoluteMediaUrl('https://cdn.example/x.jpg', 800))
+      .toBe('https://cdn.example/x.jpg?width=800&format=webp&quality=80');
+  });
+  test('hopper over SVG (vektor skal ikke rasteres)', () => {
+    expect(lib.toAbsoluteMediaUrl('/media/x/logo.svg', 800)).toBe(`${CMS}/media/x/logo.svg`);
+  });
+  test('hopper over GIF (bevarer animasjon)', () => {
+    expect(lib.toAbsoluteMediaUrl('/media/x/anim.gif', 800)).toBe(`${CMS}/media/x/anim.gif`);
+  });
+  test('uten width er media-URLen urørt (f.eks. og:image)', () => {
+    expect(lib.toAbsoluteMediaUrl('/media/x/foo.jpg')).toBe(`${CMS}/media/x/foo.jpg`);
   });
 });
 

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -1427,18 +1427,40 @@ function parseJsonArray(value: string | undefined): string[] {
   }
 }
 
+// Standard bredder for leveranse-resizing (ImageSharp width-param). Originalen
+// i CMS er urort; vi henter en nedskalert webp per kontekst. Tallene dekker
+// retina (2x) pa typisk visnings-storrelse. Juster her, ett sted.
+export const MEDIA_WIDTH = {
+  hero: 1600, // stor toppfigur, bred desktop + retina
+  content: 1200, // bilde i artikkelspalten
+  card: 800, // kort/listebilde
+} as const;
+
+// Legger pa ImageSharp-resizing nar en width er gitt. Umbraco rendrer da en
+// nedskalert webp on-demand og cacher den. SVG/GIF hoppes over (vektor/animasjon
+// skal ikke rasteres). Uten width returneres URLen urort (f.eks. og:image).
+function withImageParams(url: string, width?: number): string {
+  if (!width) return url;
+  if (/\.(svg|gif)(\?|$)/i.test(url)) return url;
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}width=${width}&format=webp&quality=80`;
+}
+
 // Gjor en relativ Umbraco media-URL (/media/...) absolutt mot CMS-hosten.
-// Passerer allerede-absolutte (http) og ikke-media-URLer uendret.
-export function toAbsoluteMediaUrl(url?: string): string | undefined {
+// Passerer allerede-absolutte (http) og ikke-media-URLer uendret. Med en width
+// legges leveranse-resizing pa (kun pa faktiske media-URLer).
+export function toAbsoluteMediaUrl(url?: string, width?: number): string | undefined {
   if (!url) return undefined;
-  if (url.startsWith('http')) return url;
-  if (url.startsWith('/media')) return `${UMBRACO_PUBLIC_URL}${url}`;
+  if (url.startsWith('http')) return withImageParams(url, width);
+  if (url.startsWith('/media')) return withImageParams(`${UMBRACO_PUBLIC_URL}${url}`, width);
   return url;
 }
 
-// Helper to get full media URL
-export function getMediaUrl(media?: UmbracoMedia): string | undefined {
-  return toAbsoluteMediaUrl(media?.url);
+// Full media-URL for et media-objekt. Default-optimaliserer til content-bredde
+// slik at et nytt bilde aldri serveres i full storrelse ved et uhell; send
+// MEDIA_WIDTH.hero / .card (eller egen width) for andre kontekster.
+export function getMediaUrl(media?: UmbracoMedia, width: number = MEDIA_WIDTH.content): string | undefined {
+  return toAbsoluteMediaUrl(media?.url, width);
 }
 
 /**

--- a/apps/frontend/src/pages/artikler/[slug].astro
+++ b/apps/frontend/src/pages/artikler/[slug].astro
@@ -4,7 +4,7 @@ import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
 
-import { getArtikkel, getArtikler, getPlainText, getMediaUrl, bakgrunnSurface } from '../../lib/umbraco';
+import { getArtikkel, getArtikler, getPlainText, getMediaUrl, MEDIA_WIDTH, bakgrunnSurface } from '../../lib/umbraco';
 import { articleSchema, breadcrumbSchema } from '../../lib/seo';
 
 const { slug } = Astro.params;
@@ -58,7 +58,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <ArticleLayout publishedAt={article.publishedAt} byline={(bylineBlock?.content ?? null) as any}>
     {heroImage?.url && (
       <div class="article-hero-image">
-        <img src={getMediaUrl(heroImage) || '/article_placeholder.png'} alt={article.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+        <img src={getMediaUrl(heroImage, MEDIA_WIDTH.hero) || '/article_placeholder.png'} alt={article.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
       </div>
     )}
 
@@ -79,7 +79,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
             title={a.tittel}
             date={a.publishedAt}
             lead={getPlainText(a.innhold, 80)}
-            image={getMediaUrl(a.artikkelBilde)}
+            image={getMediaUrl(a.artikkelBilde, MEDIA_WIDTH.card)}
             variant="image"
           />
         ))}

--- a/apps/frontend/src/pages/artikler/index.astro
+++ b/apps/frontend/src/pages/artikler/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
-import { getArtikler, getArtiklerOversikt, getVeiledningGuider, getPlainText, getMediaUrl, type Artikkel, type VeiledningGuide } from '../../lib/umbraco';
+import { getArtikler, getArtiklerOversikt, getVeiledningGuider, getPlainText, getMediaUrl, MEDIA_WIDTH, type Artikkel, type VeiledningGuide } from '../../lib/umbraco';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
@@ -35,7 +35,7 @@ guider.forEach(g => relatertById.set(g.id, g));
 
 function getImageUrl(article: Artikkel) {
   // Bruk getMediaUrl slik at media-URLen blir absolutt mot CMS-hosten.
-  return getMediaUrl(article.artikkelBilde);
+  return getMediaUrl(article.artikkelBilde, MEDIA_WIDTH.card);
 }
 
 function getTag(article: Artikkel) {

--- a/apps/frontend/src/pages/eksempler/[slug].astro
+++ b/apps/frontend/src/pages/eksempler/[slug].astro
@@ -4,7 +4,7 @@ import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import ExampleCard from '../../components/shared/ExampleCard.astro';
 
-import { getEksempel, getEksempler, getPlainText, getMediaUrl, bakgrunnSurface, type Eksempel } from '../../lib/umbraco';
+import { getEksempel, getEksempler, getPlainText, getMediaUrl, MEDIA_WIDTH, bakgrunnSurface, type Eksempel } from '../../lib/umbraco';
 import { eksempelSchema, breadcrumbSchema } from '../../lib/seo';
 
 const { slug } = Astro.params;
@@ -57,7 +57,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <ArticleLayout publishedAt={article.publishedAt} byline={(bylineBlock?.content ?? null) as any}>
     {heroImage?.url && (
       <div class="article-hero-image" data-layout-block="edge">
-        <img src={getMediaUrl(heroImage)} alt={article.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+        <img src={getMediaUrl(heroImage, MEDIA_WIDTH.hero)} alt={article.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
       </div>
     )}
 

--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -4,7 +4,7 @@ import ArticleCardFeatured from '../../components/shared/ArticleCardFeatured.ast
 import ExampleLinkCards from '../../components/shared/ExampleLinkCards.astro';
 import ExampleCard from '../../components/shared/ExampleCard.astro';
 import ArticleCardCompact from '../../components/shared/ArticleCardCompact.astro';
-import { getEksempler, getEksemplerOversikt, getArtikler, getVeiledningGuider, getMediaUrl, type Eksempel, type Artikkel, type VeiledningGuide, type EksemplerSeksjon } from '../../lib/umbraco';
+import { getEksempler, getEksemplerOversikt, getArtikler, getVeiledningGuider, getMediaUrl, MEDIA_WIDTH, type Eksempel, type Artikkel, type VeiledningGuide, type EksemplerSeksjon } from '../../lib/umbraco';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
@@ -88,7 +88,7 @@ const seksjoner = oversikt?.seksjoner?.length ? oversikt.seksjoner : fallbackSek
                 href={`/eksempler/${e.slug}`}
                 title={e.tittel}
                 lead={s.ingress || e.ingress}
-                image={e.artikkelBilde ? getMediaUrl(e.artikkelBilde) : '/article_placeholder.png'}
+                image={e.artikkelBilde ? getMediaUrl(e.artikkelBilde, MEDIA_WIDTH.card) : '/article_placeholder.png'}
                 imageAlt={e.bildeAlt || ''}
               />
             </div>

--- a/apps/frontend/src/pages/kalender/[slug].astro
+++ b/apps/frontend/src/pages/kalender/[slug].astro
@@ -4,7 +4,7 @@ import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
 import AkselIcon from '../../components/shared/AkselIcon.astro';
 import NewsCard from '../../components/shared/NewsCard.astro';
-import { getKalenderhendelser, getArtikler, getPlainText, getMediaUrl, type Kalenderhendelse } from '../../lib/umbraco';
+import { getKalenderhendelser, getArtikler, getPlainText, getMediaUrl, MEDIA_WIDTH, type Kalenderhendelse } from '../../lib/umbraco';
 import { breadcrumbSchema } from '../../lib/seo';
 
 const { slug } = Astro.params;
@@ -112,7 +112,7 @@ const påmeldingUrl = hendelse.lenke || '#';
             title={a.tittel}
             date={a.publishedAt}
             variant="image"
-            image={getMediaUrl(a.artikkelBilde)}
+            image={getMediaUrl(a.artikkelBilde, MEDIA_WIDTH.card)}
           />
         ))}
       </div>

--- a/apps/frontend/src/pages/om-oss.astro
+++ b/apps/frontend/src/pages/om-oss.astro
@@ -3,7 +3,7 @@ import Layout from '../components/layout/Layout.astro';
 import ArticleLayout from '../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../components/shared/ArticleBlocksRenderer.astro';
 import NewsCard from '../components/shared/NewsCard.astro';
-import { getOmOss, getArtikler, getPlainText, getMediaUrl, bakgrunnSurface } from '../lib/umbraco';
+import { getOmOss, getArtikler, getPlainText, getMediaUrl, MEDIA_WIDTH, bakgrunnSurface } from '../lib/umbraco';
 import { breadcrumbSchema } from '../lib/seo';
 
 // Om Oss er rik artikkelmal (#362): artikkelhode (tittel/ingress/hovedbilde) + innhold-blokkliste.
@@ -49,7 +49,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <ArticleLayout publishedAt={omOss?.publishedAt} byline={(bylineBlock?.content ?? null) as any}>
     {heroImage?.url && (
       <div class="article-hero-image">
-        <img src={getMediaUrl(heroImage)} alt={omOss?.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+        <img src={getMediaUrl(heroImage, MEDIA_WIDTH.hero)} alt={omOss?.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
       </div>
     )}
     {omOss?.ingress && (
@@ -68,7 +68,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
             title={article.tittel}
             date={article.publishedAt}
             lead={getPlainText(article.innhold, 80)}
-            image={getMediaUrl(article.artikkelBilde)}
+            image={getMediaUrl(article.artikkelBilde, MEDIA_WIDTH.card)}
             variant="image"
           />
         ))}

--- a/apps/frontend/src/pages/sandkasse/index.astro
+++ b/apps/frontend/src/pages/sandkasse/index.astro
@@ -2,7 +2,7 @@
 import Layout from '../../components/layout/Layout.astro';
 import ArticleLayout from '../../components/shared/ArticleLayout.astro';
 import ArticleBlocksRenderer from '../../components/shared/ArticleBlocksRenderer.astro';
-import { getSandkasse, getMediaUrl, getPlainText, bakgrunnSurface } from '../../lib/umbraco';
+import { getSandkasse, getMediaUrl, MEDIA_WIDTH, getPlainText, bakgrunnSurface } from '../../lib/umbraco';
 import { breadcrumbSchema } from '../../lib/seo';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
@@ -39,7 +39,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
       </div>
       {heroImage?.url && (
         <div class="article-hero-image">
-          <img src={getMediaUrl(heroImage)} alt={sandkasse.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
+          <img src={getMediaUrl(heroImage, MEDIA_WIDTH.hero)} alt={sandkasse.bildeAlt || ''} class="article-hero-img" loading="eager" decoding="async" />
         </div>
       )}
     </div>

--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -9,6 +9,7 @@ import {
   getEnkelVeiledning,
   getPlainText,
   getMediaUrl,
+  MEDIA_WIDTH,
 } from '../../lib/umbraco';
 import { articleSchema, breadcrumbSchema } from '../../lib/seo';
 
@@ -37,7 +38,7 @@ if (enkel) {
     seoTitle,
     seoDesc,
     seoImage,
-    heroImage: heroImage?.url ? getMediaUrl(heroImage) : undefined,
+    heroImage: heroImage?.url ? getMediaUrl(heroImage, MEDIA_WIDTH.hero) : undefined,
     articleJsonLd: articleSchema({
       headline: seoTitle,
       description: seoDesc,

--- a/apps/frontend/src/pages/veiledning/[guide]/[step]/[stegartikkel].astro
+++ b/apps/frontend/src/pages/veiledning/[guide]/[step]/[stegartikkel].astro
@@ -7,6 +7,7 @@ import {
   getStegartikkel,
   getPlainText,
   getMediaUrl,
+  MEDIA_WIDTH,
 } from '../../../../lib/umbraco';
 import { articleSchema, breadcrumbSchema } from '../../../../lib/seo';
 
@@ -27,7 +28,7 @@ const seoTitle = article.seoTittel || article.tittel;
 const seoDesc = article.seoBeskrivelse || article.ingress || getPlainText(article.innhold, 200);
 const heroImage = article.artikkelBilde || article.seoBilde;
 const seoImage = article.seoBilde?.url || article.artikkelBilde?.url;
-const heroImageUrl = heroImage?.url ? getMediaUrl(heroImage) : undefined;
+const heroImageUrl = heroImage?.url ? getMediaUrl(heroImage, MEDIA_WIDTH.hero) : undefined;
 
 const articleJsonLd = articleSchema({
   headline: seoTitle,

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -9,7 +9,7 @@ import TextWithImage from '../../components/shared/TextWithImage.astro';
 import ExampleLinkCards from '../../components/shared/ExampleLinkCards.astro';
 import AkselIcon from '../../components/shared/AkselIcon.astro';
 import LinkList from '../../components/shared/LinkList.astro';
-import { getVeiledningOversikt, getVeiledningGuider, getEksempler, getMediaUrl } from '../../lib/umbraco';
+import { getVeiledningOversikt, getVeiledningGuider, getEksempler, getMediaUrl, MEDIA_WIDTH } from '../../lib/umbraco';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
@@ -29,7 +29,7 @@ try {
 
 const heroTitle = cmsData?.heroTittel || 'Guider & veiledning';
 const heroText = cmsData?.heroTekst || 'Lurer du på hva det er lurt å tenke på når du bruker KI eller lager KI-løsninger? Her finner du veiledninger laget og kvalitetssikret av jurister og andre fagfolk.';
-const heroImageUrl = cmsData?.heroBilde ? getMediaUrl(cmsData.heroBilde) : undefined;
+const heroImageUrl = cmsData?.heroBilde ? getMediaUrl(cmsData.heroBilde, MEDIA_WIDTH.hero) : undefined;
 
 // Featured article — "Kom i gang"
 const featuredTitle = cmsData?.seksjon1Kort?.[0]?.tittel || 'Hva er KI og hva kan du bruke det til?';


### PR DESCRIPTION
Bilder lastes opp i full oppløsning i CMS (eks. 9,2 MB / 5150px) men rendres i små slots. Frontend henter nå en nedskalert webp via Umbracos ImageSharp i stedet for originalen.

- `getMediaUrl(media, width?)` legger på `width`/`format=webp`/`quality=80` og default-optimaliserer til content-bredde, så et bilde aldri serveres i full størrelse ved et uhell.
- `MEDIA_WIDTH` (hero 1600, content 1200, card 800); hero- og kort-bilder overstyrer per visning.
- SVG/GIF hoppes over (vektor/animasjon). `og:image` står urørt så sosiale previews får full størrelse.

Holte-bildet: 9,2 MB til ~20 KB i hero-slot.
