### PR TITLE
Frontend: send seoBilde til og:image på forside, oversikter og guide

### DIFF
--- a/apps/frontend/src/pages/artikler/index.astro
+++ b/apps/frontend/src/pages/artikler/index.astro
@@ -56,7 +56,7 @@ const bottomFeatured = rest[8];
 const remaining = rest.slice(9);
 ---
 
-<Layout title={seoTitle} description={seoDesc}>
+<Layout title={seoTitle} description={seoDesc} ogImage={oversikt?.seoBilde?.url}>
   <section data-layout-block="content" class="artikler-page">
     <header class="artikler-header">
       <h1 class="ds-heading" data-size="xl">{heroTittel}</h1>

--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -61,7 +61,7 @@ const fallbackSeksjoner: EksemplerSeksjon[] = [
 const seksjoner = oversikt?.seksjoner?.length ? oversikt.seksjoner : fallbackSeksjoner;
 ---
 
-<Layout title={seoTitle} description={seoDesc}>
+<Layout title={seoTitle} description={seoDesc} ogImage={oversikt?.seoBilde?.url}>
   <div class="eksempler-page">
     <header class="eksempler-header" data-layout-block="content">
       <h1 class="ds-heading eksempler-title" data-size="xl">{heroTittel}</h1>

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -42,7 +42,7 @@ const seoDescription = forside?.seoBeskrivelse || 'KI Norge - Norges nasjonale s
 const websiteJsonLd = websiteSchema(seoDescription);
 ---
 
-<Layout title={title} description={seoDescription} hideLogo>
+<Layout title={title} description={seoDescription} ogImage={forside?.seoBilde?.url} hideLogo>
   <h1 class="ds-sr-only">ki.norge.no - {title}</h1>
   
   <ForsideSeksjonerRenderer

--- a/apps/frontend/src/pages/kalender/index.astro
+++ b/apps/frontend/src/pages/kalender/index.astro
@@ -67,7 +67,7 @@ const isMultiDay = (startIso: string, endIso?: string) => {
 const parseTagger = (s?: string) =>
   (s || '').split(',').map(t => t.trim()).filter(Boolean);
 ---
-<Layout title={seoTitle} description={seoDesc}>
+<Layout title={seoTitle} description={seoDesc} ogImage={kalender?.seoBilde?.url}>
   <header class="kalender-header" data-layout-block="content">
     <h1 class="ds-heading" data-size="xl">{tittel}</h1>
     {ingress && <p class="kalender-ingress">{ingress}</p>}

--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -117,7 +117,7 @@ if (guideData) {
     <script type="application/ld+json" set:html={JSON.stringify(enkelCtx.breadcrumbJsonLd).replace(/</g, '\\u003c')} />
   </Layout>
 ) : guideData && guideCtx ? (
-  <Layout title={guideCtx.seoTitle} description={guideCtx.seoDesc} bodyColor="brand1">
+  <Layout title={guideCtx.seoTitle} description={guideCtx.seoDesc} ogImage={guideData.seoBilde?.url} bodyColor="brand1">
     <div class="article-page" data-layout-block="content">
       <div class="guide-header">
         <h1 class="ds-heading" data-size="xl">{guideData.tittel}</h1>

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -82,7 +82,7 @@ const seoTitle = cmsData?.seoTittel || 'Guider & veiledning';
 const seoDesc = cmsData?.seoBeskrivelse || heroText;
 ---
 
-<Layout title={seoTitle} description={seoDesc}>
+<Layout title={seoTitle} description={seoDesc} ogImage={cmsData?.seoBilde?.url}>
   <!-- Hero -->
   <section class="veil-hero" data-layout-block="content">
     <h1 class="ds-heading" data-size="xl">{heroTitle}</h1>


### PR DESCRIPTION
Forsiden, oversiktssidene (artikler/eksempler/veiledning/kalender) og flerstegs-guidene sendte aldri seoBilde videre til og:image, så de falt alltid tilbake på statisk og-image.png selv når redaktøren hadde satt et delingsbilde. Kobler seoBilde til ogImage-propen, likt artikkel- og eksempelsidene som allerede gjør det.

Artikkel-type sider beholder kjeden seoBilde til artikkelBilde (toppbildet) til statisk default. Forside, oversikter og flerstegs-guide har bare seoBilde-felt, så der blir kjeden seoBilde til statisk default.