### PR TITLE
Kalender: konsistent EventCard-mapping + merkelapp

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -303,7 +303,7 @@ public class ContentTypeComponent : IAsyncComponent
             Step("migrateVeiledningGuideAllowedChildren", () => MigrateVeiledningGuideAllowedChildren());
             Step("addOversiktFieldsToVeiledninger", () => AddOversiktFieldsToVeiledninger());
 
-            EnsureType("kalenderhendelse", () => CreateKalenderhendelse());
+            EnsureType("kalenderhendelse", () => CreateKalenderhendelse(), () => MigrateKalenderhendelse());
             EnsureType("kalender", () => CreateKalender());
 
             Step("globaleInnstillinger", () => { if (_contentTypeService.Get("globaleInnstillinger") == null) CreateGlobaleInnstillinger(); });
@@ -2391,7 +2391,7 @@ public class ContentTypeComponent : IAsyncComponent
         };
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, mandatory: true, sortOrder: 1), "innhold");
-        ct.AddPropertyType(Prop("type", "Type", _textStringDt, description: "Workshop, Frokostseminar, Konferanse...", sortOrder: 2), "innhold");
+        ct.AddPropertyType(Prop("type", "Merkelapp", _textStringDt, description: "Kommaseparert, f.eks. \"Frokostseminar, Offentlig\". Vises som merkelapp(er) på kortet.", sortOrder: 2), "innhold");
         ct.AddPropertyType(Prop("ingress", "Ingress", _textAreaDt, description: "Kort beskrivelse for kortvisning.", sortOrder: 3), "innhold");
         ct.AddPropertyType(Prop("detaljertBeskrivelse", "Detaljert beskrivelse", _richTextDt, description: "Vises på enkeltsiden og i featured-boksen.", sortOrder: 4), "innhold");
         ct.AddPropertyType(Prop("startDato", "Startdato", _datePickerDt, mandatory: true, sortOrder: 5), "innhold");
@@ -2399,13 +2399,24 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("tid", "Tid", _textStringDt, description: "Klokkeslett, f.eks. \"09:00-11:00\" eller \"Hele dagen\".", sortOrder: 7), "innhold");
         ct.AddPropertyType(Prop("sted", "Sted", _textStringDt, description: "Fysisk adresse eller \"Digitalt\".", sortOrder: 8), "innhold");
         ct.AddPropertyType(Prop("lenke", "Lenke", _textStringDt, description: "URL til påmelding eller mer info.", sortOrder: 9), "innhold");
-        ct.AddPropertyType(Prop("tagger", "Tagger", _textAreaDt, description: "Kommaseparert liste med tagger.", sortOrder: 10), "innhold");
 
         ct.AddPropertyGroup("innstillinger", "Innstillinger");
         ct.AddPropertyType(Prop("slug", "Slug", _textStringDt, mandatory: true, description: "URL-vennlig identifikator.", sortOrder: 1), "innstillinger");
         SetStandardGroupSortOrders(ct);
         _contentTypeService.Save(ct);
         return ct;
+    }
+
+    // type -> Merkelapp (kommaseparert), og tagger droppes (slått sammen med merkelapp).
+    private void MigrateKalenderhendelse()
+    {
+        var ct = _contentTypeService.Get("kalenderhendelse");
+        if (ct == null) return;
+        bool changed = false;
+        changed |= SetPropLabel(ct, "type", "Merkelapp");
+        changed |= SetPropDescription(ct, "type", "Kommaseparert, f.eks. \"Frokostseminar, Offentlig\". Vises som merkelapp(er) på kortet.");
+        changed |= RemoveProp(ct, "tagger");
+        if (changed) _contentTypeService.Save(ct);
     }
 
     private IContentType CreateKalender()

--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -11,6 +11,7 @@ import ExampleLinkCards from '../shared/ExampleLinkCards.astro';
 import TextWithImage from '../shared/TextWithImage.astro';
 import AkselIcon from '../shared/AkselIcon.astro';
 import { getMediaUrl, type ForsideSeksjon, type Kalenderhendelse, type VeiledningGuide } from '../../lib/umbraco';
+import { hendelseTilEventCard } from '../../lib/kalender';
 
 interface Props {
   seksjoner: ForsideSeksjon[];
@@ -22,12 +23,6 @@ interface Props {
 }
 const { seksjoner, latestArticles, eksempler = [], upcomingEvents = [], veiledninger = [], eksempelKort } = Astro.props;
 const featuredArticle = latestArticles[0];
-
-const monthNames = ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'];
-const formatEventDate = (iso: string) => {
-  const d = new Date(iso);
-  return { day: String(d.getDate()), month: monthNames[d.getMonth()], year: String(d.getFullYear()) };
-};
 
 // Normaliserer en pool-artikkel til kort-formen rendereren bruker (tittel/slug/lead/image).
 // Pool-artikler har ingress/artikkelBilde; vi mapper dem til lead/image.
@@ -117,24 +112,12 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
   if (block.contentType === 'forsideArrangementer') {
     // Redaktørvalgt arrangement overstyrer auto. Tomt → neste kommende.
     const valgt = (block.arrangementId && upcomingEvents.find((e) => e.id === block.arrangementId)) || upcomingEvents[0] || null;
-    const dato = valgt ? formatEventDate(valgt.startDato) : null;
-    const flerDager = valgt?.sluttDato && new Date(valgt.sluttDato).toDateString() !== new Date(valgt.startDato).toDateString();
     return (
       <section class="arrangementer" data-layout-block="edge">
         <div class="arrangementer-section" data-layout-block="content">
           <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Kommende arrangementer'}</h2>
-          {valgt && dato && (
-            <EventCard
-              href={`/kalender/${valgt.slug}`}
-              title={valgt.tittel}
-              description={valgt.ingress || ''}
-              day={dato.day}
-              month={dato.month}
-              year={dato.year}
-              time={valgt.tid || ''}
-              timeNote={flerDager ? 'Arrangement over flere dager' : undefined}
-              location={valgt.sted || ''}
-            />
+          {valgt && (
+            <EventCard {...hendelseTilEventCard(valgt)} />
           )}
           <ArrowLink href={block.lenkeUrl || '/kalender'} text={block.lenketekst || 'Se alle arrangementer'} />
         </div>

--- a/apps/frontend/src/lib/kalender.test.ts
+++ b/apps/frontend/src/lib/kalender.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { parseMerkelapp, isFlerDager, formatHendelseDato, hendelseTilEventCard } from './kalender';
+
+describe('parseMerkelapp', () => {
+  test('splitter kommaseparert og trimmer', () => {
+    expect(parseMerkelapp('Frokostseminar, Offentlig , Politiet')).toEqual(['Frokostseminar', 'Offentlig', 'Politiet']);
+  });
+  test('tom/undefined gir tom liste', () => {
+    expect(parseMerkelapp(undefined)).toEqual([]);
+    expect(parseMerkelapp('')).toEqual([]);
+    expect(parseMerkelapp('  ,  ')).toEqual([]);
+  });
+});
+
+describe('formatHendelseDato', () => {
+  test('endags gir dag uten etterstilt punktum', () => {
+    expect(formatHendelseDato('2026-06-16T00:00:00')).toEqual({ day: '16', month: 'juni', year: '2026' });
+  });
+  test('flerdags gir range i day', () => {
+    expect(formatHendelseDato('2026-06-16T00:00:00', '2026-06-17T00:00:00'))
+      .toEqual({ day: '16. — 17', month: 'juni', year: '2026' });
+  });
+  test('lik start og slutt regnes som endags', () => {
+    expect(formatHendelseDato('2026-06-16T00:00:00', '2026-06-16T00:00:00').day).toBe('16');
+  });
+  test('tom startdato gir tomme felt', () => {
+    expect(formatHendelseDato('')).toEqual({ day: '', month: '', year: '' });
+  });
+});
+
+describe('isFlerDager', () => {
+  test('uten sluttdato er false', () => {
+    expect(isFlerDager('2026-06-16T00:00:00')).toBe(false);
+  });
+  test('sluttdato paa annen dag er true', () => {
+    expect(isFlerDager('2026-06-16T00:00:00', '2026-06-18T00:00:00')).toBe(true);
+  });
+});
+
+describe('hendelseTilEventCard', () => {
+  const base = {
+    id: '1', documentId: '1', tittel: 'Bærekraftseminar', slug: 'baerekraftseminar',
+    type: 'Frokostseminar, Offentlig', ingress: 'Om grøn teknologi.',
+    startDato: '2026-06-16T00:00:00', sluttDato: '2026-06-17T00:00:00',
+    tid: '09:00-16:00', sted: 'Digitalt',
+    createdAt: '', updatedAt: '', publishedAt: '', locale: 'nb-NO',
+  } as never;
+
+  test('kort-variant: tittel, ingress, merkelapp som tags, range-dato, href', () => {
+    expect(hendelseTilEventCard(base)).toEqual({
+      href: '/kalender/baerekraftseminar',
+      title: 'Bærekraftseminar',
+      description: 'Om grøn teknologi.',
+      tags: ['Frokostseminar', 'Offentlig'],
+      day: '16. — 17', month: 'juni', year: '2026',
+      time: '09:00-16:00',
+      timeNote: 'Arrangement over flere dager',
+      location: 'Digitalt',
+    });
+  });
+
+  test('featured-variant: tittel og ingress tomme (vises utenfor kortet)', () => {
+    const d = hendelseTilEventCard(base, { variant: 'featured' });
+    expect(d.title).toBe('');
+    expect(d.description).toBe('');
+    expect(d.tags).toEqual(['Frokostseminar', 'Offentlig']);
+  });
+
+  test('clickable:false dropper href (tidligere arrangement)', () => {
+    expect(hendelseTilEventCard(base, { clickable: false }).href).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/lib/kalender.ts
+++ b/apps/frontend/src/lib/kalender.ts
@@ -1,0 +1,74 @@
+import type { Kalenderhendelse } from './umbraco';
+
+// Norske maanedsnavn. Vi bruker en fast tabell (ikke toLocaleString('nb-NO'))
+// fordi ICU-locale-data ikke er garantert tilgjengelig paa Cloudflare Workers,
+// og toLocaleString da kan falle tilbake til engelske navn.
+const MANEDER = [
+  'januar', 'februar', 'mars', 'april', 'mai', 'juni',
+  'juli', 'august', 'september', 'oktober', 'november', 'desember',
+];
+
+// Merkelapp (alias fortsatt "type") er en kommaseparert liste,
+// f.eks. "Frokostseminar, Offentlig". Hvert ledd blir en merkelapp paa kortet.
+export function parseMerkelapp(value?: string): string[] {
+  return (value || '').split(',').map(t => t.trim()).filter(Boolean);
+}
+
+export function isFlerDager(startIso: string, endIso?: string): boolean {
+  if (!endIso) return false;
+  const s = new Date(startIso);
+  const e = new Date(endIso);
+  return e.getTime() > s.getTime() && e.toDateString() !== s.toDateString();
+}
+
+// Range-aware datolabel. Endags: { day: "16" }. Flerdags: { day: "16. — 17" }.
+// EventCard rendrer "{day}. {month}" + year, saa day har ikke etterstilt punktum.
+export function formatHendelseDato(startIso: string, endIso?: string): { day: string; month: string; year: string } {
+  if (!startIso) return { day: '', month: '', year: '' };
+  const start = new Date(startIso);
+  const day = String(start.getDate());
+  const month = MANEDER[start.getMonth()] ?? '';
+  const year = String(start.getFullYear());
+  if (isFlerDager(startIso, endIso)) {
+    const end = new Date(endIso!);
+    return { day: `${day}. — ${end.getDate()}`, month, year };
+  }
+  return { day, month, year };
+}
+
+export interface EventCardData {
+  href?: string;
+  title: string;
+  description: string;
+  tags: string[];
+  day: string;
+  month: string;
+  year: string;
+  time: string;
+  timeNote?: string;
+  location: string;
+}
+
+// Felles mapping fra hendelse til EventCard-props. Brukt av forside, kalender-liste
+// og featured-boks, saa de tre ikke kan drifte fra hverandre.
+// featured-varianten viser tittel som <h2> og ingress som paragraf UTENFOR kortet,
+// derfor utelates title/description der (rendres tomme, EventCard skjuler dem).
+export function hendelseTilEventCard(
+  h: Kalenderhendelse,
+  opts: { variant?: 'featured' | 'kort'; clickable?: boolean } = {},
+): EventCardData {
+  const { variant = 'kort', clickable = true } = opts;
+  const dato = formatHendelseDato(h.startDato, h.sluttDato);
+  return {
+    href: clickable ? `/kalender/${h.slug}` : undefined,
+    title: variant === 'featured' ? '' : h.tittel,
+    description: variant === 'featured' ? '' : (h.ingress || ''),
+    tags: parseMerkelapp(h.type),
+    day: dato.day,
+    month: dato.month,
+    year: dato.year,
+    time: h.tid || '',
+    timeNote: isFlerDager(h.startDato, h.sluttDato) ? 'Arrangement over flere dager' : undefined,
+    location: h.sted || '',
+  };
+}

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -192,6 +192,7 @@ export interface Kalenderhendelse {
   documentId: string;
   tittel: string;
   slug: string;
+  /** Merkelapp(er), kommaseparert (f.eks. "Frokostseminar, Offentlig"). CMS-alias er fortsatt "type". */
   type?: string;
   ingress?: string;
   detaljertBeskrivelse?: UmbracoBlock[];
@@ -200,7 +201,6 @@ export interface Kalenderhendelse {
   tid?: string;
   sted?: string;
   lenke?: string;
-  tagger?: string;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
@@ -787,7 +787,6 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         tid: props.tid as string || undefined,
         sted: props.sted as string || undefined,
         lenke: props.lenke as string || undefined,
-        tagger: props.tagger as string || undefined,
       } as T;
 
     case 'kalender':
@@ -1409,7 +1408,6 @@ function mapFeaturedHendelse(value: unknown): Kalenderhendelse | null {
     tid: p.tid || undefined,
     sted: p.sted || undefined,
     lenke: p.lenke || undefined,
-    tagger: p.tagger || undefined,
     createdAt: node.createDate || '',
     updatedAt: node.updateDate || '',
     publishedAt: node.createDate || '',

--- a/apps/frontend/src/pages/kalender/index.astro
+++ b/apps/frontend/src/pages/kalender/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../../components/layout/Layout.astro';
 import EventCard from '../../components/shared/EventCard.astro';
 import { getKalender, getKalenderhendelser, type Kalenderhendelse } from '../../lib/umbraco';
+import { hendelseTilEventCard } from '../../lib/kalender';
 
 let kalender = null;
 let hendelser: Kalenderhendelse[] = [];
@@ -39,33 +40,6 @@ const tidligere = hendelser
   .filter(h => h.id !== featuredId)
   .filter(h => effectiveEnd(h) < now)
   .sort((a, b) => sortByStart(b, a));
-
-const fmtMonth = (d: Date) => d.toLocaleString('nb-NO', { month: 'long' });
-const formatDate = (iso: string) => {
-  if (!iso) return { day: '', month: '', year: '' };
-  const d = new Date(iso);
-  return { day: String(d.getDate()), month: fmtMonth(d), year: String(d.getFullYear()) };
-};
-const formatDateRange = (startIso: string, endIso?: string) => {
-  const start = new Date(startIso);
-  const end = endIso ? new Date(endIso) : null;
-  const startDay = start.getDate();
-  const startMonth = fmtMonth(start);
-  const startYear = start.getFullYear();
-  if (!end || end.getTime() === start.getTime()) {
-    return { dateLabel: `${startDay}.`, month: startMonth, year: String(startYear) };
-  }
-  const endDay = end.getDate();
-  return { dateLabel: `${startDay}. — ${endDay}.`, month: startMonth, year: String(startYear) };
-};
-const isMultiDay = (startIso: string, endIso?: string) => {
-  if (!endIso) return false;
-  const s = new Date(startIso);
-  const e = new Date(endIso);
-  return e.getTime() > s.getTime() && e.toDateString() !== s.toDateString();
-};
-const parseTagger = (s?: string) =>
-  (s || '').split(',').map(t => t.trim()).filter(Boolean);
 ---
 <Layout title={seoTitle} description={seoDesc} ogImage={kalender?.seoBilde?.url}>
   <header class="kalender-header" data-layout-block="content">
@@ -73,29 +47,15 @@ const parseTagger = (s?: string) =>
     {ingress && <p class="kalender-ingress">{ingress}</p>}
   </header>
 
-  {featured && (() => {
-    const multiDay = isMultiDay(featured.startDato, featured.sluttDato);
-    const featuredRange = formatDateRange(featured.startDato, featured.sluttDato);
-    return (
-      <section class="kalender-featured" data-layout-block="edge">
-        <div class="kalender-featured-inner" data-layout-block="content">
-          <h2 class="ds-heading" data-size="lg">{featured.tittel}</h2>
-          {featured.ingress && <p class="kalender-featured-ingress">{featured.ingress}</p>}
-          <EventCard
-            title={featured.type || ''}
-            tags={parseTagger(featured.tagger)}
-            day={featuredRange.dateLabel.charAt(featuredRange.dateLabel.length - 1) === '.' && !multiDay ? featuredRange.dateLabel.slice(0, -1) : featuredRange.dateLabel}
-            month={featuredRange.month}
-            year={featuredRange.year}
-            time={featured.tid || ''}
-            timeNote={multiDay ? 'Arrangement over flere dager' : undefined}
-            location={featured.sted || ''}
-            href={`/kalender/${featured.slug}`}
-          />
-        </div>
-      </section>
-    );
-  })()}
+  {featured && (
+    <section class="kalender-featured" data-layout-block="edge">
+      <div class="kalender-featured-inner" data-layout-block="content">
+        <h2 class="ds-heading" data-size="lg">{featured.tittel}</h2>
+        {featured.ingress && <p class="kalender-featured-ingress">{featured.ingress}</p>}
+        <EventCard {...hendelseTilEventCard(featured, { variant: 'featured' })} />
+      </div>
+    </section>
+  )}
 
   <section class="kalender-arrangementer" data-layout-block="content">
     <h2 class="ds-heading" data-size="md">Arrangementer</h2>
@@ -111,24 +71,9 @@ const parseTagger = (s?: string) =>
           <p class="kalender-empty">Ingen kommende arrangement.</p>
         ) : (
           <div class="kalender-list">
-            {kommende.map(h => {
-              const date = formatDate(h.startDato);
-              const multiDay = isMultiDay(h.startDato, h.sluttDato);
-              return (
-                <EventCard
-                  title={h.tittel}
-                  description={h.ingress || ''}
-                  tags={parseTagger(h.tagger)}
-                  day={date.day}
-                  month={date.month}
-                  year={date.year}
-                  time={h.tid || ''}
-                  timeNote={multiDay ? 'Arrangement over flere dager' : undefined}
-                  location={h.sted || ''}
-                  href={`/kalender/${h.slug}`}
-                />
-              );
-            })}
+            {kommende.map(h => (
+              <EventCard {...hendelseTilEventCard(h)} />
+            ))}
           </div>
         )}
       </ds-tabpanel>
@@ -138,21 +83,9 @@ const parseTagger = (s?: string) =>
           <p class="kalender-empty">Ingen tidligere arrangement.</p>
         ) : (
           <div class="kalender-list">
-            {tidligere.map(h => {
-              const date = formatDate(h.startDato);
-              return (
-                <EventCard
-                  title={h.tittel}
-                  description={h.ingress || ''}
-                  tags={parseTagger(h.tagger)}
-                  day={date.day}
-                  month={date.month}
-                  year={date.year}
-                  time={h.tid || ''}
-                  location={h.sted || ''}
-                />
-              );
-            })}
+            {tidligere.map(h => (
+              <EventCard {...hendelseTilEventCard(h, { clickable: false })} />
+            ))}
           </div>
         )}
       </ds-tabpanel>


### PR DESCRIPTION
Forside, kalender-liste og featured-boks bygde `EventCard`-props ulikt: tittel kom fra `type` ett sted og `tittel` et annet, dato var range-aware kun i featured, og forsiden sendte ikke merkelapp. Nå går alle tre via én delt mapper (`hendelseTilEventCard`), så de ikke kan drifte fra hverandre.

- **Tittel = `tittel` overalt.** Featured viser tittel som h2 over kortet, så kortet selv har ingen tittel (matcher designet). `type` som featured-tittel var en glipp.
- **Merkelapp = `type`** (kommaseparert til piller), vist på alle kort. `tagger` droppes (slått sammen, var tomt og overlappet).
- **Range-aware dato overalt**, med faste norske månedsnavn (`toLocaleString('nb-NO')` er upålitelig på Cloudflare Workers).
- **CMS:** `type` får label "Merkelapp" + kommaseparert beskrivelse, `tagger` fjernes via migrate på eksisterende `kalenderhendelse`.

`EventCard.astro` er urørt (markup/CSS).
