### PR TITLE
Frontend: fiks cookie-banner som aldri viste (ugyldig knapp-id)

### DIFF
--- a/apps/frontend/src/components/shared/CookieNotice.astro
+++ b/apps/frontend/src/components/shared/CookieNotice.astro
@@ -14,10 +14,10 @@ const neiLabel = gi?.cookieNeiLabel || 'Avslå';
     <h2 class="cookie-notice__title">{tittel}</h2>
     <div class="cookie-notice__text" set:html={beskrivelseHtml}></div>
     <div class="cookie-notice__actions">
-      <button id="ds-button cookie-notice-allow" type="button" class="cookie-notice__btn">
+      <button id="cookie-notice-allow" type="button" class="cookie-notice__btn">
         {jaLabel}
       </button>
-      <button id="ds-button cookie-notice-deny" type="button" class="cookie-notice__btn">
+      <button id="cookie-notice-deny" type="button" class="cookie-notice__btn">
         {neiLabel}
       </button>
     </div>


### PR DESCRIPTION
Cookie-banneret viste seg aldri.

Knappene hadde `id="ds-button cookie-notice-allow"` (og `-deny`). Mellomrom i id-en gjorde at `getElementById('cookie-notice-allow')` returnerte null, guarden i skriptet returnerte tidlig, og `notice.hidden = false` ble aldri kjørt.

Fjernet `ds-button ` fra begge id-ene slik at de matcher oppslagene i skriptet.