### PR TITLE
Veiledning: preview for stegartikkel + riktig obs-ikon

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -1024,6 +1024,14 @@ public class ContentTypeComponent : IAsyncComponent
             changed = true;
         }
 
+        // Backoffice-ikon: bytt advarselstrekant til "merk deg dette" (Dorte).
+        // Publisert side bruker HandKnot; her oppdateres eksisterende noder i prod/tt02.
+        if (ct.Icon != "icon-pushpin")
+        {
+            ct.Icon = "icon-pushpin";
+            changed = true;
+        }
+
         if (changed)
             _contentTypeService.Save(ct);
     }

--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -992,7 +992,7 @@ public class ContentTypeComponent : IAsyncComponent
             Alias = "veiledningObs",
             Name = "Obs",
             Description = "Varselboks med tittel og tekst. Brukes for å fremheve viktig informasjon i et veiledningssteg.",
-            Icon = "icon-alert",
+            Icon = "icon-pushpin",
             IsElement = true,
         };
         ct.AddPropertyGroup("innhold", "Innhold");

--- a/apps/frontend/src/components/shared/VeiledningBlocksRenderer.astro
+++ b/apps/frontend/src/components/shared/VeiledningBlocksRenderer.astro
@@ -37,7 +37,7 @@ const renderItems = groupBlocks(blocks || []);
 const moduleIcons: Record<string, string> = {
   veiledningInfo: 'InformationSquare',
   veiledningEksempel: 'LightBulb',
-  veiledningObs: 'ExclamationmarkTriangle',
+  veiledningObs: 'HandKnot',
 };
 ---
 

--- a/apps/frontend/src/pages/veiledning/[guide]/[step]/[stegartikkel].astro
+++ b/apps/frontend/src/pages/veiledning/[guide]/[step]/[stegartikkel].astro
@@ -17,7 +17,7 @@ const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('
 const guideData = await getVeiledningGuide(guideSlug!, { preview: isPreview });
 if (!guideData) return Astro.redirect('/veiledning');
 
-const allSteps = await getVeiledningSteg(guideSlug!);
+const allSteps = await getVeiledningSteg(guideSlug!, { preview: isPreview });
 const currentStep = allSteps.find(s => s.slug === stepSlug);
 if (!currentStep) return Astro.redirect(`/veiledning/${guideSlug}`);
 


### PR DESCRIPTION
Tre tilbakemeldinger fra Dorte på veiledning.

## Preview stegartikkel
Ruten hentet stegene uten preview-flagg, så kladd-steg falt ut av lista og forhåndsvisning redirectet til guide-forsiden. Sender nå `{ preview }` til `getVeiledningSteg`.

## Obs-modul ikon
Advarselstrekanten er byttet til `HandKnot` ("merk deg dette") på publisert side, etter oppdatert design i Figma. Obs betyr viktig info, ikke vær forsiktig.

Backoffice-ikon `icon-alert` til `icon-pushpin`, både ved oppretting og som idempotent migrate på eksisterende `veiledningObs` (prod/tt02).