### PR TITLE
Fjern nbsp fra innhold ved render og lagring

### DIFF
--- a/apps/cms-umbraco/Composers/NbspWashHandler.cs
+++ b/apps/cms-umbraco/Composers/NbspWashHandler.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Gjør alle non-breaking spaces (U+00A0) og literal nbsp-entiteter om til vanlige
+/// mellomrom ved lagring. De snik seg inn ved innliming fra Word o.l. og gir fast
+/// mellomrom som ikke bryter ved linjeskift, eller en synlig "&amp;nbsp;" når entiteten
+/// limes inn som ren tekst. Treffer tekst- og RichText-felt direkte på en document type,
+/// og alt nede i Block List / Block Grid (blank erstatning på blokk-JSON er trygt, fordi
+/// nbsp bare opptrer i tekstinnhold, aldri i JSON- eller HTML-syntaks). Speiler mønsteret
+/// til <see cref="UrlFieldWashHandler"/>.
+///
+/// Påvirker innhold som lagres etter at handleren er deployet. Eksisterende noder vaskes
+/// først når de re-lagres. Frontend normaliserer uansett nbsp ved rendering, så publikum
+/// ser ren tekst med en gang (se normalizeNbsp i frontend).
+/// </summary>
+public class NbspWashComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentSavingNotification, NbspWashHandler>();
+    }
+}
+
+public class NbspWashHandler : INotificationHandler<ContentSavingNotification>
+{
+    // U+00A0 og entitet-formene &nbsp; &#160; &#xA0; (med valgfrie ledende nuller) -> mellomrom.
+    private static readonly Regex Nbsp =
+        new("\u00A0|&nbsp;|&#0*160;|&#x0*A0;", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Felt-typer hvor nbsp realistisk dukker opp. Block List/Grid vaskes som hel JSON-streng.
+    private static readonly HashSet<string> WashableEditors = new()
+    {
+        Constants.PropertyEditors.Aliases.RichText,
+        Constants.PropertyEditors.Aliases.TextBox,
+        Constants.PropertyEditors.Aliases.TextArea,
+        Constants.PropertyEditors.Aliases.BlockList,
+        Constants.PropertyEditors.Aliases.BlockGrid,
+    };
+
+    public void Handle(ContentSavingNotification notification)
+    {
+        foreach (var content in notification.SavedEntities)
+        {
+            foreach (var property in content.Properties)
+            {
+                if (!WashableEditors.Contains(property.PropertyType.PropertyEditorAlias)) continue;
+
+                var cur = content.GetValue<string>(property.Alias);
+                if (string.IsNullOrEmpty(cur)) continue;
+
+                var washed = Nbsp.Replace(cur, " ");
+                if (washed != cur) content.SetValue(property.Alias, washed);
+            }
+        }
+    }
+}

--- a/apps/frontend/src/lib/richtext-classes.test.ts
+++ b/apps/frontend/src/lib/richtext-classes.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, test } from 'vitest';
-import { applyDsClasses } from './richtext-classes';
+import { applyDsClasses, normalizeNbsp } from './richtext-classes';
+
+// U+00A0 bygd uten å skrive et usynlig tegn i kildekoden.
+const NBSP = String.fromCharCode(0xA0);
+
+describe('normalizeNbsp', () => {
+  test('erstatter ekte non-breaking space (U+00A0) med vanlig mellomrom', () => {
+    expect(normalizeNbsp('Holte' + NBSP + 'er')).toBe('Holte er');
+  });
+
+  test('erstatter literal nbsp-entitet limt inn som tekst', () => {
+    expect(normalizeNbsp('tekst&nbsp;her')).toBe('tekst her');
+    expect(normalizeNbsp('a&#160;b')).toBe('a b');
+    expect(normalizeNbsp('a&#xa0;b')).toBe('a b');
+    expect(normalizeNbsp('a&#XA0;b')).toBe('a b');
+  });
+
+  test('kollapser nbsp inntil mellomrom og flere nbsp til ett mellomrom', () => {
+    expect(normalizeNbsp('a' + NBSP + NBSP + 'b')).toBe('a b');
+    expect(normalizeNbsp('a' + NBSP + ' b')).toBe('a b');
+    expect(normalizeNbsp('a ' + NBSP + ' b')).toBe('a b');
+    expect(normalizeNbsp('a&nbsp; b')).toBe('a b');
+  });
+
+  test('beholder ledende/etterhengende mellomrom (nettleseren trimmer ved render)', () => {
+    expect(normalizeNbsp('slutt' + NBSP)).toBe('slutt ');
+    expect(normalizeNbsp(NBSP + 'start')).toBe(' start');
+  });
+
+  test('rører ikke rene vanlige mellomrom og tom input', () => {
+    expect(normalizeNbsp('a b c')).toBe('a b c');
+    expect(normalizeNbsp('a  b')).toBe('a  b');
+    expect(normalizeNbsp('')).toBe('');
+  });
+});
 
 describe('applyDsClasses', () => {
   test('legger ds-list på ul og ol', () => {

--- a/apps/frontend/src/lib/richtext-classes.ts
+++ b/apps/frontend/src/lib/richtext-classes.ts
@@ -30,6 +30,25 @@ function stripForeignFonts(el: Element): void {
   else el.removeAttribute('style');
 }
 
+// Non-breaking space (U+00A0) og literal nbsp-entiteter snik seg inn ved innliming
+// fra Word o.l. De gir fast mellomrom som ikke bryter ved linjeskift, og en entitet
+// limt inn som ren tekst (&nbsp;) vises som synlig "&nbsp;" på siden. Vi gjør all
+// nbsp om til vanlig mellomrom: et løp av mellomrom som inneholder minst én nbsp
+// kollapses til ETT vanlig mellomrom. Da blir "ord<nbsp>ord" til "ord ord", og en
+// nbsp inntil et vanlig mellomrom forsvinner. Vi trimmer ikke start/slutt her i
+// koden, for en tekstnode kan ha et bevisst mellomrom inntil et inline-element
+// (<em>, <strong> ...) som ikke skal limes sammen, og "start/slutt av linje" er
+// uansett en layout-greie nettleseren trimmer selv ved rendering. Rene vanlige
+// mellomrom (uten nbsp) røres ikke; HTML kollapser dem ved rendering. Kalles på rå
+// tekstnoder før escaping, så den fanger både tegnet og entitet-som-tekst.
+const NBSP_ENTITY = /&nbsp;|&#0*160;|&#x0*A0;/gi;
+const NBSP_RUN = /[ \t]*\u00A0[ \t\u00A0]*/g;
+
+export function normalizeNbsp(text: string): string {
+  if (!text) return text;
+  return text.replace(NBSP_ENTITY, '\u00A0').replace(NBSP_RUN, ' ');
+}
+
 export function applyDsClasses(html: string): string {
   if (!html) return '';
   const { document } = parseHTML(`<div>${html}</div>`);

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -521,7 +521,7 @@ interface CompatResponse<T> {
 
 // ── Umbraco RichText JSON → HTML converter ──────────────────────
 
-import { applyDsClasses } from './richtext-classes';
+import { applyDsClasses, normalizeNbsp } from './richtext-classes';
 
 interface RichTextNode {
   tag: string;
@@ -543,7 +543,7 @@ export function absolutizeMediaUrls(html: string): string {
 function richTextToHtml(node: RichTextNode): string {
   // Text node
   if (node.tag === '#text') {
-    return escapeHtml(node.text || '');
+    return escapeHtml(normalizeNbsp(node.text || ''));
   }
 
   // Root node — render children, then tag designsystem classes onto bare


### PR DESCRIPTION
Non-breaking spaces (U+00A0) og literal nbsp-entiteter har sneket seg inn mange steder ved innliming fra Word o.l. De gir fast mellomrom som ikke bryter ved linjeskift, og en entitet limt inn som ren tekst vises som synlig "&nbsp;".

## Frontend
`normalizeNbsp` i `richtext-classes.ts` gjør U+00A0 og nbsp-entiteter om til vanlig mellomrom, og kollapser et mellomromsløp som inneholder nbsp til ett mellomrom. Kalles i `richTextToHtml` på rå tekstnoder før escaping, så den fanger både tegnet og entitet-som-tekst. Start/slutt trimmer nettleseren selv ved render. Rene vanlige mellomrom røres ikke.

## Backend
`NbspWashHandler` vasker nbsp til vanlig mellomrom ved lagring (`ContentSavingNotification`) for RichText-, TextBox-, TextArea- og Block List/Grid-felt. Speiler `UrlFieldWashHandler`. Påvirker innhold som lagres etter deploy.

## Tester
Nye enhetstester for `normalizeNbsp` (tegn, entitet-former, kollaps, bevart start/slutt). 40/40 grønne, CMS bygger uten feil.