### PR TITLE
fix: fjern død /caser-rute, bruk /eksempler overalt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,16 +35,15 @@ Frontend henter innhold via Umbraco Delivery API v2. CMS-databasen replikeres ti
 **Stack:** Astro (server mode) + React (islands) + @digdir/designsystemet-react + @digdir/designsystemet-css
 
 **Sider** (`apps/frontend/src/pages/`)
-- Forsiden, artikler, caser, veiledning (guide + steg), sandkasse, FAQ, kontakt, om-oss, ki-ordbok, søk, status (admin-only)
-- Dynamiske ruter: `artikler/[slug]`, `caser/[slug]`, `veiledning/[guide]`, `veiledning/[guide]/[step]`
-- `eksempler/[slug]` og `eksempler/index` redirecter til `/caser/...` (301)
+- Forsiden, artikler, eksempler, veiledning (guide + steg), sandkasse, FAQ, kontakt, om-oss, ki-ordbok, søk, status (admin-only)
+- Dynamiske ruter: `artikler/[slug]`, `eksempler/[slug]`, `veiledning/[guide]`, `veiledning/[guide]/[step]`
 
 **Nøkkelfiler**
 - `src/lib/umbraco.ts` — all datahenting fra CMS. Interfaces, fetch-funksjoner, mapItem() som mapper content types til TypeScript-typer
 - `src/lib/aksel-icons.ts` — statisk SVG-map for Aksel-ikoner (React-only pakke, kan ikke brukes direkte i Astro)
 - `src/lib/seo.ts` — JSON-LD structured data
 - `src/middleware.ts` — caching, admin-tilgang (ki_admin cookie), kommer-snart-modus, security headers (CSP, HSTS osv.)
-- `src/components/shared/ArticleBlocksRenderer.astro` — **eneste** sted artikkelmoduler rendres. Brukt av artikler/[slug], caser/[slug], sandkasse/index. CSS i `src/styles/article-blocks.css`. Endre denne én filen → alle sidene oppdateres.
+- `src/components/shared/ArticleBlocksRenderer.astro` — **eneste** sted artikkelmoduler rendres. Brukt av artikler/[slug], eksempler/[slug], sandkasse/index. CSS i `src/styles/article-blocks.css`. Endre denne én filen → alle sidene oppdateres.
 - `src/components/shared/BlocksRenderer.astro` — eldre/enklere blocks renderer (tekst, advarsel, lenkeliste, faqInnhold). Brukes ikke for artikkelmoduler.
 - `src/components/shared/AkselIcon.astro` — rendrer Aksel-ikon etter navn
 - `src/components/shared/SearchDialog.tsx` — KI-søk dialog (React, client:load)

--- a/apps/cms-umbraco/content-routes.json
+++ b/apps/cms-umbraco/content-routes.json
@@ -6,7 +6,7 @@
   },
   "routes": {
     "artikkel": "/artikler/{slug}",
-    "eksempel": "/caser/{slug}",
+    "eksempel": "/eksempler/{slug}",
     "enkelVeiledning": "/veiledning/{slug}",
     "veiledningGuide": "/veiledning/{slug}",
     "veiledningSteg": "/veiledning/{veiledningGuide.slug}/{slug}",

--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -48,7 +48,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     .map((k) => {
       const ex = eksempler.find((e: any) => e.id === k.id);
       return ex
-        ? { href: `/caser/${ex.slug}`, title: ex.tittel, tag: 'Eksempel' as const, lead: k.ingress || ex.ingress || undefined }
+        ? { href: `/eksempler/${ex.slug}`, title: ex.tittel, tag: 'Eksempel' as const, lead: k.ingress || ex.ingress || undefined }
         : null;
     })
     .filter((c) => c !== null) as { href: string; title: string; tag: 'Eksempel'; lead?: string }[];

--- a/apps/frontend/src/lib/content-routes.test.ts
+++ b/apps/frontend/src/lib/content-routes.test.ts
@@ -17,7 +17,7 @@ describe('buildUrlForContent', () => {
   describe('flate content types (kun {slug} eller statisk)', () => {
     test.each([
       ['artikkel', 'min-artikkel', '/artikler/min-artikkel'],
-      ['eksempel', 'min-case', '/caser/min-case'],
+      ['eksempel', 'min-case', '/eksempler/min-case'],
       ['enkelVeiledning', 'kom-igang', '/veiledning/kom-igang'],
       ['veiledningGuide', 'sett-igang-med-ki', '/veiledning/sett-igang-med-ki'],
       ['side', 'kontakt', '/kontakt'],

--- a/apps/frontend/src/styles/article-blocks.css
+++ b/apps/frontend/src/styles/article-blocks.css
@@ -1,6 +1,6 @@
 /**
  * Styles for every artikkel block module rendered by <ArticleBlocksRenderer />.
- * Used by artikler/[slug], caser/[slug], sandkasse/index — anywhere we render
+ * Used by artikler/[slug], eksempler/[slug], sandkasse/index — anywhere we render
  * the artikkel block list.
  *
  * Keep all module styles here. The page-level layout (hero, "Flere artikler",

--- a/docs/lighthouse-baseline.json
+++ b/docs/lighthouse-baseline.json
@@ -6,7 +6,7 @@
     "forside": { "performance": 84, "accessibility": 100, "best-practices": 100, "seo": 100 },
     "artikler-list": { "performance": 85, "accessibility": 100, "best-practices": 100, "seo": 100 },
     "artikkel-detail": { "performance": 87, "accessibility": 100, "best-practices": 100, "seo": 100 },
-    "caser-list": { "performance": 86, "accessibility": 100, "best-practices": 100, "seo": 100 },
+    "eksempler-list": { "performance": 86, "accessibility": 100, "best-practices": 100, "seo": 100 },
     "veiledning": { "performance": 85, "accessibility": 100, "best-practices": 100, "seo": 100 },
     "sandkasse": { "performance": 69, "accessibility": 100, "best-practices": 100, "seo": 100, "note": "302 redirects to / because no Sandkasse content on prod yet (LAUNCH_MODE=production). Score reflects redirect chain. Re-baseline once Sara creates the prod Sandkasse." },
     "ki-ordbok": { "performance": 93, "accessibility": 100, "best-practices": 100, "seo": 100 },

--- a/docs/modules-to-test.md
+++ b/docs/modules-to-test.md
@@ -65,7 +65,7 @@ If it fails: inspect the diff (Playwright outputs to `test-results/`). If the ch
 
 - The CMS editor experience for adding blocks (use `tests/cms/artikkel-crud.spec.ts` for shallow coverage; comprehensive editor flow tests are deferred)
 - Mobile/responsive rendering (current tests run desktop only)
-- Modules used in `caser/[slug]` or `sandkasse/index` (same renderer, but page-level layout differs)
+- Modules used in `eksempler/[slug]` or `sandkasse/index` (same renderer, but page-level layout differs)
 - Legacy modules used in old prod content but not in our new templates (`artikkelInfoBoks`, `artikkelCallout`, `artikkelSitat`, `artikkelHero`) — they still render via the renderer's fallback paths, but no baseline screenshot exists. Add to the test article if you care.
 
 ## Maintenance

--- a/shared/content-routes.json
+++ b/shared/content-routes.json
@@ -6,7 +6,7 @@
   },
   "routes": {
     "artikkel": "/artikler/{slug}",
-    "eksempel": "/caser/{slug}",
+    "eksempel": "/eksempler/{slug}",
     "enkelVeiledning": "/veiledning/{slug}",
     "veiledningGuide": "/veiledning/{slug}",
     "veiledningSteg": "/veiledning/{veiledningGuide.slug}/{slug}",

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,7 +31,7 @@ Auth credentials come from env vars `CMS_USER` / `CMS_PASS` (defaults to unatten
 
 ### What's tested today
 - **frontend/smoke.spec.ts** — every public URL returns 200, header renders, sample artikkel + case detail pages render.
-- **cms/auth-and-tree.spec.ts** — admin can log in, content tree shows expected nodes (Forside, Artikler, Caser, Veiledning, Sider, Merkelapper), no Eksempler/Ikoner residue, /api/diagnostics reports valid state.
+- **cms/auth-and-tree.spec.ts** — admin can log in, content tree confirms pr-316 structural changes (no Caser/KI-ordbok/Ikoner residue), /api/diagnostics reports valid state.
 
 ### What's missing (TODO)
 - Create + edit + publish + delete artikkel via UI

--- a/tests/cms/artikkel-crud.spec.ts
+++ b/tests/cms/artikkel-crud.spec.ts
@@ -142,7 +142,7 @@ test.describe('Artikkel CRUD via backoffice UI', () => {
     await page.waitForLoadState('networkidle');
 
     // Tree shows expected top-level nodes
-    for (const name of ['Forside', 'Artikler', 'Caser', 'Veiledning', 'Sider']) {
+    for (const name of ['Forside', 'Artikler', 'Eksempler', 'Veiledning', 'Sider']) {
       await expect(page.locator(`text=${name}`).first())
         .toBeVisible({ timeout: 10_000 });
     }

--- a/tests/sql-migration/04-content-types-present.spec.ts
+++ b/tests/sql-migration/04-content-types-present.spec.ts
@@ -24,7 +24,7 @@ const REQUIRED_TYPES = [
   'artikkelBildeSeksjon',
   'omOssBlokk',
   // Containers
-  'artikler', 'caser', 'sider', 'veiledninger', 'faqSamling',
+  'artikler', 'eksempler', 'sider', 'veiledninger', 'faqSamling',
   'merkelapper', 'ordbokSamling',
 ];
 

--- a/tests/sql-migration/08-backoffice-login.spec.ts
+++ b/tests/sql-migration/08-backoffice-login.spec.ts
@@ -35,7 +35,7 @@ test('Content tree shows expected structure post-migration', async ({ page }) =>
   await page.goto('/umbraco/section/content');
   await page.waitForLoadState('networkidle');
 
-  for (const name of ['Forside', 'Artikler', 'Caser', 'Veiledning', 'Sider', 'Merkelapper']) {
+  for (const name of ['Forside', 'Artikler', 'Eksempler', 'Veiledning', 'Sider', 'Merkelapper']) {
     await expect(page.locator(`text=${name}`).first()).toBeVisible({ timeout: 15_000 });
   }
 });

--- a/tests/sql-migration/09-frontend-still-renders.spec.ts
+++ b/tests/sql-migration/09-frontend-still-renders.spec.ts
@@ -9,7 +9,7 @@ import { test, expect } from '@playwright/test';
 const PUBLIC_URLS = [
   { path: '/', label: 'Forside' },
   { path: '/artikler', label: 'Artikler list' },
-  { path: '/caser', label: 'Caser list' },
+  { path: '/eksempler', label: 'Eksempler list' },
   { path: '/veiledning', label: 'Veiledning' },
   { path: '/om-oss', label: 'Om oss' },
   { path: '/faq', label: 'FAQ' },


### PR DESCRIPTION
## Hva
`/caser/` er en død rute (404). Eksempel-sider ligger på `/eksempler/`, og det finnes verken caser-side eller redirect dit. Bytter caser til eksempler der det er en levende referanse.

- Route-map (`shared/content-routes.json` + CMS-mirror): `eksempel` til `/eksempler/{slug}`
- `ForsideSeksjonerRenderer`: redaktørvalgt eksempelKort-lenke til `/eksempler/`
- `CLAUDE.md`: ruteliste rettet, fjernet feilaktig notat om "eksempler til caser 301" (den redirecten finnes ikke)
- Stale `caser`-referanser i `content-routes.test.ts`, `artikkel-crud`, `sql-migration/*`, `tests/README`, `modules-to-test`, `article-blocks.css` og lighthouse-baseline

Urørt med vilje, siden caser fortsatt dukker opp i grep der: `MigrateCaserToEksempler` (funksjonell rename-migrasjon), historiske incident-notater (`seeder-content-write-audit`, anti-pattern-avsnittet i CLAUDE.md), og `auth-and-tree`-testen som korrekt sjekker at Caser er borte fra treet.

## Test
- vitest 68/68 (route + shared/CMS-mirror sync + interne lenker)
- `pnpm run build` grønt