### PR TITLE
fix(cms): la enkelVeiledning være opprettbar under Veiledning igjen

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -3124,19 +3124,12 @@ public class ContentTypeComponent : IAsyncComponent
             changed = true;
         }
 
-        // Remove veiledningOversikt from allowed children (only veiledningGuide stays)
-        var guideType = _contentTypeService.Get("veiledningGuide");
-        if (guideType != null)
-        {
-            var desired = new[] { new ContentTypeSort(guideType.Key, 0, guideType.Alias) };
-            var currentAliases = ct.AllowedContentTypes?.Select(a => a.Alias).OrderBy(a => a).ToArray() ?? Array.Empty<string>();
-            var wantAliases = new[] { "veiledningGuide" };
-            if (!currentAliases.SequenceEqual(wantAliases))
-            {
-                ct.AllowedContentTypes = desired;
-                changed = true;
-            }
-        }
+        // Allowed children for "veiledninger" eies av MigrateVeiledningerContainer (eget
+        // steg, kjorer for dette): den setter [veiledningGuide, enkelVeiledning] og fjerner
+        // dermed implisitt den gamle veiledningOversikt-typen. Tidligere satte denne metoden
+        // allowed children til KUN veiledningGuide og kastet enkelVeiledning ut igjen hver
+        // oppstart, slik at "Enkel veiledningsmal" forsvant fra Opprett-menyen. Vi rorer
+        // ikke allowed children her lenger.
 
         if (changed)
         {


### PR DESCRIPTION
## Hva
`enkelVeiledning` («Enkel veiledningsmal») er `AllowedAsRoot=false` og kan kun opprettes under Veiledning-containeren. To composer-steg kranglet om containerens allowed children:

- `migrateVeiledningerContainer` (steg 302) satte `[veiledningGuide, enkelVeiledning]`
- `addOversiktFieldsToVeiledninger` (steg 304) overskrev til kun `[veiledningGuide]`

Steg 304 kjører etter 302, så «Enkel veiledningsmal» forsvant fra Opprett-menyen. Innført i `7c8466d` (one-click oversikt), slo gjennom på prod da prod ble løftet fram.

Fjerner allowed-children-blokken fra steg 304. `migrateVeiledningerContainer` er nå eneste eier og fjerner fortsatt den gamle `veiledningOversikt`-typen implisitt (full replace).

## Test
- `dotnet build -c Release` grønt (0 errors)
- Ingen datatap, eksisterende enkel-veiledninger upåvirket