### PR TITLE
fix(veiledning): fjern hardkodet "Forstå regelverket"-default på seksjon3-overskrift

### DIFF
--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -128,7 +128,7 @@ const seoDesc = cmsData?.seoBeskrivelse || heroText;
   <!-- Forstå regelverket — Simple link list -->
   {simpleLinks.length > 0 && (
     <section class="veil-simple-links" data-layout-block="content">
-      <LinkList links={simpleLinks} heading={cmsData?.seksjon3Tittel || 'Forstå regelverket'} />
+      <LinkList links={simpleLinks} heading={cmsData?.seksjon3Tittel} />
     </section>
   )}
 


### PR DESCRIPTION
## Hva
«Forstå regelverket»-overskriften på /veiledning var en hardkodet frontend-default (`seksjon3Tittel || 'Forstå regelverket'`). Når CMS-feltet er tomt viste den defaulten, som redaktøren ikke kunne overstyre.

Nå: `heading={cmsData?.seksjon3Tittel}`. Tomt felt gir ingen overskrift (`LinkList` guarder allerede `{heading && <h2>}`). Lenkene under er uendret (ekte `seksjon3Kort`-data).

## Test
- `pnpm run build` grønt