### PR TITLE
feat: la redaktør endre merkelappen på eksempelkort

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -1087,6 +1087,7 @@ public class ContentTypeComponent : IAsyncComponent
         {
             ct.AddPropertyType(Prop($"eksempel{i}", $"Eksempel {i}", _contentPickerDt, description: i == 1 ? "Velg eksempel som vises i kortet." : "Valgfri, la stå tom hvis gruppen skal ha færre kort.", sortOrder: 2 + i), "innhold");
         }
+        ct.AddPropertyType(Prop("kortTag", "Merkelapp på kortene", _textStringDt, description: "Tekst på merkelappen øverst på hvert kort i gruppen. Standard: Eksempel", sortOrder: 9), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -2174,6 +2175,12 @@ public class ContentTypeComponent : IAsyncComponent
             feat.AddPropertyType(Prop("ingress", "Ingress (overstyr)", _textAreaDt, description: "Standard: eksemplets egen ingress. Skriv her for å overstyre.", sortOrder: 2), "innhold");
             _contentTypeService.Save(feat);
         }
+        var grp = _contentTypeService.Get("eksempelGruppe");
+        if (grp != null && !grp.PropertyTypeExists("kortTag"))
+        {
+            grp.AddPropertyType(Prop("kortTag", "Merkelapp på kortene", _textStringDt, description: "Tekst på merkelappen øverst på hvert kort i gruppen. Standard: Eksempel", sortOrder: 9), "innhold");
+            _contentTypeService.Save(grp);
+        }
         var rel = _contentTypeService.Get("eksempelRelatert");
         if (rel != null)
         {
@@ -2808,6 +2815,7 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyGroup("innhold", "Innhold");
         ct.AddPropertyType(Prop("overskrift", "Overskrift", _textStringDt, mandatory: true), "innhold");
         ct.AddPropertyType(Prop("kort", "Kort", _blockListForsideEksempelKortDt, description: "Velg eksempler. La stå tom for å vise nyeste automatisk."), "innhold");
+        ct.AddPropertyType(Prop("kortTag", "Merkelapp på kortene", _textStringDt, description: "Tekst på merkelappen øverst på hvert eksempelkort. Standard: Eksempel"), "innhold");
         ct.AddPropertyType(Prop("lenketekst", "Lenketekst", _textStringDt, description: "Standard: Se alle eksempler"), "innhold");
         ct.AddPropertyType(Prop("lenkeUrl", "Lenke-URL", _textStringDt, description: "Standard: /eksempler"), "innhold");
         _contentTypeService.Save(ct);
@@ -3109,6 +3117,16 @@ public class ContentTypeComponent : IAsyncComponent
             ct.PropertyGroups.Remove("verktoy");
             changed = true;
         }
+        // Lær av andre: redaksjonell merkelapp på eksempelkortene. Seksjonen bygges
+        // automatisk på frontend, så feltet ligger på siden (ikke på en modul). Guard på
+        // property, ikke gruppe (samme mønster som SEO under).
+        if (!ct.PropertyTypeExists("eksempelKortTag"))
+        {
+            if (!ct.PropertyGroups.Any(g => g.Alias == "laerAvAndre"))
+                ct.AddPropertyGroup("laerAvAndre", "Lær av andre");
+            ct.AddPropertyType(Prop("eksempelKortTag", "Merkelapp på eksempelkort", _textStringDt, description: "Tekst på merkelappen på eksempelkortene i \"Lær av andre\". Standard: Eksempel"), "laerAvAndre");
+            changed = true;
+        }
         // SEO. Guard på property, ikke gruppe: på prod var seo-gruppa lagret med en alias
         // som ikke matchet "seo", så gruppe-guarden bommet og AddPropertyGroup("seo") kastet
         // "An item with the same key has already been added. Key: seo" -> hele composeren
@@ -3251,6 +3269,11 @@ public class ContentTypeComponent : IAsyncComponent
             if (!laer.PropertyTypeExists("kort"))
             {
                 laer.AddPropertyType(Prop("kort", "Kort", _blockListForsideEksempelKortDt, description: "Velg eksempler. La stå tom for å vise nyeste automatisk."), "innhold");
+                changed = true;
+            }
+            if (!laer.PropertyTypeExists("kortTag"))
+            {
+                laer.AddPropertyType(Prop("kortTag", "Merkelapp på kortene", _textStringDt, description: "Tekst på merkelappen øverst på hvert eksempelkort. Standard: Eksempel"), "innhold");
                 changed = true;
             }
             if (!laer.PropertyTypeExists("lenketekst"))

--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -48,10 +48,10 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     .map((k) => {
       const ex = eksempler.find((e: any) => e.id === k.id);
       return ex
-        ? { href: `/eksempler/${ex.slug}`, title: ex.tittel, tag: 'Eksempel' as const, lead: k.ingress || ex.ingress || undefined }
+        ? { href: `/eksempler/${ex.slug}`, title: ex.tittel, tag: 'Eksempel', lead: k.ingress || ex.ingress || undefined }
         : null;
     })
-    .filter((c) => c !== null) as { href: string; title: string; tag: 'Eksempel'; lead?: string }[];
+    .filter((c) => c !== null) as { href: string; title: string; tag: string; lead?: string }[];
 ---
 
 {seksjoner.map((block) => {
@@ -153,10 +153,11 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     // Redaktørvalgte eksempler overstyrer auto-pool. Tomt → behold nåværende oppførsel.
     const valgte = block.kort?.length ? resolveEksempelKort(block.kort) : [];
     const kort = valgte.length > 0 ? valgte : eksempelKort;
+    const eksempelTag = block.kortTag || 'Eksempel';
     return (
       <section data-layout-block="content" class="examples-section">
         <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Lær av andre'}</h2>
-        <ExampleLinkCards cards={kort.filter((c): c is { href: string; title: string; tag: string } => 'href' in c && 'title' in c).map((c, i) => ({ ...c, variant: (i === 0 ? 'medium' : 'light') as 'dark' | 'medium' | 'light' }))} />
+        <ExampleLinkCards cards={kort.filter((c): c is { href: string; title: string; tag: string } => 'href' in c && 'title' in c).map((c, i) => ({ ...c, tag: eksempelTag, variant: (i === 0 ? 'medium' : 'light') as 'dark' | 'medium' | 'light' }))} />
         <ArrowLink href={block.lenkeUrl || '/eksempler'} text={block.lenketekst || 'Se alle eksempler'} />
       </section>
     );

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -273,8 +273,8 @@ export interface EksemplerSeksjon {
   navn?: string;
   epost?: string;
   stilling?: string;
-  // Redaksjonelle felt fra Figma-kommentarer. CMS-feltene finnes ikke ennå,
-  // så disse er undefined i dag og frontend faller tilbake på defaults.
+  // Redaksjonelle felt fra Figma-kommentarer. kortFarger har ennå ikke et CMS-felt
+  // og er undefined i dag (frontend faller tilbake på defaults).
   ingress?: string;                              // Featured: manuell ingress
   kortTag?: string;                              // Gruppe: tag på hvert kort (default "Eksempel")
   kortFarger?: Array<'dark' | 'light' | undefined>; // Gruppe: per-kort farge, justert mot eksempelIds
@@ -371,6 +371,7 @@ export interface ForsideSeksjon {
   fremhevetArtikkelId?: string;
   forstaLenkeIds?: string[];
   kort?: ForsideKort[];
+  kortTag?: string;
 }
 
 export interface Forside {
@@ -466,6 +467,7 @@ export interface VeiledningOversikt {
   seksjon2Kort?: VeiledningKort[];
   seksjon3Tittel?: string;
   seksjon3Kort?: VeiledningKort[];
+  eksempelKortTag?: string;
   seoTittel?: string;
   seoBeskrivelse?: string;
   seoBilde?: UmbracoMedia;
@@ -1139,6 +1141,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         seksjon2Kort: mapVeiledningKort(props.seksjon2Kort),
         seksjon3Tittel: props.seksjon3Tittel as string || undefined,
         seksjon3Kort: mapVeiledningKort(props.seksjon3Kort),
+        eksempelKortTag: props.eksempelKortTag as string || undefined,
         seoTittel: props.seoTittel as string || undefined,
         seoBeskrivelse: props.seoBeskrivelse as string || undefined,
         seoBilde: mapMedia(props.seoBilde),
@@ -1505,6 +1508,7 @@ function mapForsideSeksjoner(value: unknown): ForsideSeksjon[] | undefined {
       fremhevetArtikkelId: pickerId(props.fremhevetArtikkel),
       forstaLenkeIds: mapForstaLenker(props.lenker),
       kort: mapForsideKort(props.kort),
+      kortTag: (props.kortTag as string) || undefined,
     };
   });
 }

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -67,15 +67,16 @@ const simpleLinks = (cmsData?.seksjon3Kort?.length ?? 0) > 0
     ];
 
 // Case cards — "Lær av andre"
+const eksempelTag = cmsData?.eksempelKortTag || 'Eksempel';
 const caseCards = cases.data.length > 0
   ? cases.data.slice(0, 2).map(c => ({
       title: c.tittel,
       href: `/eksempler/${c.slug}`,
-      tag: 'Eksempel',
+      tag: eksempelTag,
     }))
   : [
-      { title: 'Raskere analyser av dokumenter med KI-chat i Digdir', href: '/eksempler/ki-chat-staten', tag: 'Eksempel' },
-      { title: 'Politiet - Fra tale til tekst på minutter', href: '/eksempler/politiet-tale-til-tekst', tag: 'Eksempel' },
+      { title: 'Raskere analyser av dokumenter med KI-chat i Digdir', href: '/eksempler/ki-chat-staten', tag: eksempelTag },
+      { title: 'Politiet - Fra tale til tekst på minutter', href: '/eksempler/politiet-tale-til-tekst', tag: eksempelTag },
     ];
 
 const seoTitle = cmsData?.seoTittel || 'Guider & veiledning';


### PR DESCRIPTION
## Hva
Merkelappen på eksempelkort har vært låst til "Eksempel". Nå kan redaktør sette teksten på oversiktssidene der kortene vises.

## Hvor redaktør setter den
- Eksempler: felt "Merkelapp på kortene" på hver eksempel-gruppe
- Forside: felt "Merkelapp på kortene" på "Lær av andre"-modulen
- Veiledning: felt "Merkelapp på eksempelkort" på siden (seksjonen "Lær av andre" bygges automatisk, så feltet ligger på selve siden)

Tomt felt faller tilbake på "Eksempel", så eksisterende sider er uendret.

## Endringer
- CMS: nye tekstfelt på `eksempelGruppe`, `forsideLaerAvAndre` og `veiledninger`, med additive migrasjoner for eksisterende noder
- Frontend: mapping i `umbraco.ts` og rendering på de tre sidene