### PR TITLE
Frontend: ES-søk-vars for tt02 (endpoint + index)

### DIFF
--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -16,6 +16,8 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+.env.development
+.env*.local
 
 # macOS-specific files
 .DS_Store

--- a/apps/frontend/wrangler.jsonc
+++ b/apps/frontend/wrangler.jsonc
@@ -19,6 +19,10 @@
 			"vars": {
 				"UMBRACO_URL": "https://kinorgeportal.tt02.dis-core.altinn.cloud",
 				"UMBRACO_PUBLIC_URL": "https://kinorgeportal.tt02.dis-core.altinn.cloud",
+				// Hybrid-søk (Elastic): endepunkt + indeks er offentlige (ikke hemmelige).
+				// ES_API_KEY settes som secret: wrangler secret put ES_API_KEY --env tt02
+				"ES_ENDPOINT": "https://kinorgeportal-elasticsearch-tt02-a61b24.es.germanywestcentral.azure.elastic.cloud",
+				"KI_INDEX": "ki-content",
 				// Holding page on ki.test.norge.no until launch. Flip to "live" to go public.
 				"LAUNCH_MODE": "coming-soon",
 			},


### PR DESCRIPTION
ES_ENDPOINT og KI_INDEX som offentlige vars i tt02-env, så den deployede tt02-frontenden kan nå hybrid-søket. ES_API_KEY er hemmelig og settes som wrangler secret, ikke i config.