### PR TITLE
fix: tre kilder til at CMS-endringer ikke vises i frontend

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -131,14 +131,14 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     const tittel = block.tittel || valgt?.tittel || 'Gjør dataene KI-klare';
     const ingress = block.ingress || valgt?.ingress || 'Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.';
     const href = block.lenkeUrl || (valgt ? `/veiledning/${valgt.slug}` : '/veiledning');
-    const image = block.illustrasjon ? getMediaUrl(block.illustrasjon) : (valgt?.seoBilde ? getMediaUrl(valgt.seoBilde) : '/woman-speaking.svg');
+    const image = (block.illustrasjon ? getMediaUrl(block.illustrasjon) : (valgt?.seoBilde ? getMediaUrl(valgt.seoBilde) : undefined)) ?? '/people-workshopping.svg';
     return (
       <section class="veiledning-section" data-layout-block="edge">
         <div data-layout-block="content">
           <TextWithImage
-            title={block.tittel || 'Gjør dataene KI-klare'}
-            href={block.lenkeUrl || '/veiledning'}
-            image={block.illustrasjon ? (getMediaUrl(block.illustrasjon) ?? '/people-workshopping.svg') : '/people-workshopping.svg'}
+            title={tittel}
+            href={href}
+            image={image}
             imageAlt="Illustrasjon"
             label={block.label || 'Veiledning'}
           >

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -685,9 +685,10 @@ async function fetchCollection<T>(
   if (options.sort) {
     params.set('sort', options.sort);
   }
-  if (options.take) {
-    params.set('take', String(options.take));
-  }
+  // Delivery API returnerer bare 10 elementer når take utelates. Sidene bruker
+  // disse samlingene som oppslags-pool for redaktørvalgte pickere, så en lav
+  // implisitt grense gjør at valgt innhold droppes stille. Hent rikelig.
+  params.set('take', String(options.take || 100));
   if (options.skip) {
     params.set('skip', String(options.skip));
   }

--- a/apps/frontend/src/pages/kalender/index.astro
+++ b/apps/frontend/src/pages/kalender/index.astro
@@ -27,11 +27,16 @@ const sortByStart = (a: Kalenderhendelse, b: Kalenderhendelse) =>
 // helt til siste dag er passert. Sortering bruker fortsatt startDato.
 const effectiveEnd = (h: Kalenderhendelse) => new Date(h.sluttDato || h.startDato);
 
-// Bruk CMS-felt hvis satt, ellers bruk første kommende hendelse som featured
+// Bruk CMS-felt hvis satt, ellers bruk første kommende hendelse som featured.
+// Picker-objektet fra Delivery API har tomme properties (ingen slug/dato), så
+// slå opp den fulle hendelsen i listen via id.
 const allKommende = hendelser
   .filter(h => effectiveEnd(h) >= now)
   .sort(sortByStart);
-const featured = kalender?.featuredHendelse || allKommende[0] || null;
+const featuredValgt = kalender?.featuredHendelse
+  ? hendelser.find(h => h.id === kalender!.featuredHendelse!.id)
+  : null;
+const featured = featuredValgt || allKommende[0] || null;
 const featuredId = featured?.id;
 
 const kommende = allKommende


### PR DESCRIPTION
Oppfølger til #455, samme klasse bugs funnet ved gjennomgang av CMS→frontend-flyten.

## 1. Implisitt take-grense på 10 dropper redaktørvalg stille

Delivery API returnerer maks 10 elementer når take utelates (verifisert empirisk). `fetchCollection` sendte bare take når kalleren satte den, og det gjorde verken `getArtikler(undefined)` (/artikler, /eksempler), `getVeiledningGuider()` (forside, /artikler, /eksempler, /veiledning) eller `getSider()`. Sidene bruker samlingene som oppslags-pool for redaktørvalgte pickere, så når innholdet vokser forbi 10 forsvinner valgt innhold stille fra seksjoner, relatert-kort og featured-oppslag. Nå sender `fetchCollection` alltid take (default 100).

## 2. Fremhevet veiledning på forsiden brukte ikke valgt veiledning

`forsideVeiledning`-blokken regnet ut tittel, lenke og bilde fra redaktørens valgte veiledning, men renderingen brukte aldri verdiene — bare ingressen fulgte valget. Tittel, lenke og bilde står nå også i stil med kommentaren «Redaktørvalgt veiledning gir standardverdier; tekstfeltene overstyrer».

## 3. Fremhevet arrangement i kalenderen ga død lenke

Picker-objekter fra Delivery API har tomme properties (ingen slug, dato eller ingress). /kalender brukte objektet direkte, så et redaktørvalgt fremhevet arrangement rendret med lenke til `/kalender/` og uten dato. Nå slås den fulle hendelsen opp via id i den allerede hentede hendelses-listen.

## Testet

Lokalt mot CMS: fremhevet arrangement satt i backoffice ga før lenke `/kalender/` uten dato, etter fiks korrekt slug og dato. /, /artikler, /eksempler og /veiledning bygger og rendrer som før. Frontend-bygget er grønt.