### PR TITLE
chore: oppdater utdaterte Container Apps-kommentarer i frontend

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -141,7 +141,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=(), usb=()');
   }
   if (!response.headers.has('Strict-Transport-Security')) {
-    // 1 year, include subdomains, preload-eligible. Container Apps already terminates TLS.
+    // 1 year, include subdomains, preload-eligible. Cloudflare terminates TLS at the edge.
     response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   }
   if (!response.headers.has('Content-Security-Policy')) {

--- a/apps/frontend/src/pages/api/health/ready.ts
+++ b/apps/frontend/src/pages/api/health/ready.ts
@@ -2,8 +2,8 @@ import type { APIRoute } from 'astro';
 
 /**
  * Readiness probe — process is alive AND can talk to CMS.
- * Used by Container Apps to decide whether to send traffic.
- * Returns 503 if CMS Delivery API isn't reachable.
+ * Available as a health/uptime check endpoint. Returns 503 if the CMS
+ * Delivery API isn't reachable.
  */
 
 const CMS_URL = import.meta.env.UMBRACO_PUBLIC_URL || import.meta.env.UMBRACO_URL || 'https://kinorgeportal.prod.dis-core.altinn.cloud';


### PR DESCRIPTION
## Hva
To utdaterte kommentarer i frontend pekte på Azure Container Apps, som er erstattet av Cloudflare Workers (frontend) og dis-core (CMS).

## Endringer
- `middleware.ts`: HSTS-kommentaren sa "Container Apps already terminates TLS" → Cloudflare terminerer TLS på edge.
- `api/health/ready.ts`: fjernet "Used by Container Apps" fra readiness-probe-kommentaren.

Kun kommentarer, ingen funksjonell endring.