### PR TITLE
style(forside): brun ramme rundt sandkasseboksen

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -309,7 +309,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     cursor: pointer;
     display: grid;
     grid-template-columns: 1fr 2fr;
-    border: 6px solid var(--ds-color-border-subtle);
+    border: 6px solid var(--ds-color-brand2-border-default);
     background-color: var(--ds-color-brand2-background-default);
 
     &:focus-within {


### PR DESCRIPTION
Rammen rundt sandkasseboksen på forsiden bruker nå brand 2 border default (brun) i stedet for nøytral border-subtle, som spesifisert i skissen.

Fixes #452