### PR TITLE
feat(kalender): redigerbart og valgfritt pris-felt på hendelse

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -2414,6 +2414,7 @@ public class ContentTypeComponent : IAsyncComponent
         ct.AddPropertyType(Prop("tid", "Tid", _textStringDt, description: "Klokkeslett, f.eks. \"09:00-11:00\" eller \"Hele dagen\".", sortOrder: 7), "innhold");
         ct.AddPropertyType(Prop("sted", "Sted", _textStringDt, description: "Fysisk adresse eller \"Digitalt\".", sortOrder: 8), "innhold");
         ct.AddPropertyType(Prop("lenke", "Lenke", _textStringDt, description: "URL til påmelding eller mer info.", sortOrder: 9), "innhold");
+        ct.AddPropertyType(Prop("pris", "Pris", _textStringDt, description: "F.eks. \"Gratis\" eller \"1 500 kr\". La stå tom for å skjule pris på siden.", sortOrder: 10), "innhold");
 
         ct.AddPropertyGroup("innstillinger", "Innstillinger");
         ct.AddPropertyType(Prop("slug", "Slug", _textStringDt, mandatory: true, description: "URL-vennlig identifikator.", sortOrder: 1), "innstillinger");
@@ -2423,6 +2424,7 @@ public class ContentTypeComponent : IAsyncComponent
     }
 
     // type -> Merkelapp (kommaseparert), og tagger droppes (slått sammen med merkelapp).
+    // pris lagt til i ettertid (valgfri, #460).
     private void MigrateKalenderhendelse()
     {
         var ct = _contentTypeService.Get("kalenderhendelse");
@@ -2431,6 +2433,11 @@ public class ContentTypeComponent : IAsyncComponent
         changed |= SetPropLabel(ct, "type", "Merkelapp");
         changed |= SetPropDescription(ct, "type", "Kommaseparert, f.eks. \"Frokostseminar, Offentlig\". Vises som merkelapp(er) på kortet.");
         changed |= RemoveProp(ct, "tagger");
+        if (!ct.PropertyTypeExists("pris"))
+        {
+            ct.AddPropertyType(Prop("pris", "Pris", _textStringDt, description: "F.eks. \"Gratis\" eller \"1 500 kr\". La stå tom for å skjule pris på siden.", sortOrder: 10), "innhold");
+            changed = true;
+        }
         if (changed) _contentTypeService.Save(ct);
     }
 

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -203,6 +203,8 @@ export interface Kalenderhendelse {
   tid?: string;
   sted?: string;
   lenke?: string;
+  /** Valgfri pris, f.eks. "Gratis" eller "1 500 kr". Tom = pris vises ikke. */
+  pris?: string;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
@@ -1036,6 +1038,7 @@ function mapItem<T>(item: UmbracoItem, contentType: string): T {
         tid: props.tid as string || undefined,
         sted: props.sted as string || undefined,
         lenke: props.lenke as string || undefined,
+        pris: props.pris as string || undefined,
       } as T;
 
     case 'kalender':
@@ -1659,6 +1662,7 @@ function mapFeaturedHendelse(value: unknown): Kalenderhendelse | null {
     tid: p.tid || undefined,
     sted: p.sted || undefined,
     lenke: p.lenke || undefined,
+    pris: p.pris || undefined,
     createdAt: node.createDate || '',
     updatedAt: node.updateDate || '',
     publishedAt: node.createDate || '',

--- a/apps/frontend/src/pages/kalender/[slug].astro
+++ b/apps/frontend/src/pages/kalender/[slug].astro
@@ -61,7 +61,7 @@ const timeDisplay = hendelse.tid || '';
 
 // Mock data for fields not yet in CMS
 const arrangør = 'Digdir';
-const pris = 'Gratis';
+const pris = hendelse.pris || '';
 const påmeldingUrl = hendelse.lenke || '#';
 ---
 
@@ -86,10 +86,12 @@ const påmeldingUrl = hendelse.lenke || '#';
         <AkselIcon name="HouseHeart" size={24} />
         <div><span class="event-meta-label">Arrangør:</span> <strong>{arrangør}</strong></div>
       </div>
-      <div class="event-meta-item">
-        <AkselIcon name="Receipt" size={24} />
-        <div><span class="event-meta-label">Pris:</span> <strong>{pris}</strong></div>
-      </div>
+      {pris && (
+        <div class="event-meta-item">
+          <AkselIcon name="Receipt" size={24} />
+          <div><span class="event-meta-label">Pris:</span> <strong>{pris}</strong></div>
+        </div>
+      )}
       {påmeldingUrl && (
         <a href={påmeldingUrl} class="ds-button">Påmelding</a>
       )}


### PR DESCRIPTION
Pris på hendelsessiden var hardkodet til "Gratis" og kunne ikke redigeres.

- Nytt valgfritt tekstfelt "Pris" på kalenderhendelse (additiv migrering)
- Frontend viser feltet fra CMS; tomt felt skjuler hele pris-raden

Fixes #460