### PR TITLE
fix(søk): ES_ENDPOINT + KI_INDEX i prod-vars (wrangler)

### DIFF
--- a/apps/frontend/wrangler.jsonc
+++ b/apps/frontend/wrangler.jsonc
@@ -33,6 +33,11 @@
 				// Media-URLer hentes av nettleseren, så de må peke på en offentlig host.
 				// Dis-core-hosten krever Altinn-nett; proxy-workeren (#350) er offentlig nåbar.
 				"UMBRACO_PUBLIC_URL": "https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev",
+				// Hybrid-søk (Elastic): endepunkt + indeks er offentlige (ikke hemmelige).
+				// Samme cluster/indeks som tt02 (holder prod-innhold). ES_API_KEY settes
+				// som secret: wrangler secret put ES_API_KEY --env prod
+				"ES_ENDPOINT": "https://kinorgeportal-elasticsearch-tt02-a61b24.es.germanywestcentral.azure.elastic.cloud",
+				"KI_INDEX": "ki-content",
 				// Holding page on ki.norge.no until launch. Flip to "live" to go public.
 				"LAUNCH_MODE": "coming-soon",
 			},


### PR DESCRIPTION
## Hva
Prod manglet `ES_ENDPOINT` + `KI_INDEX` i wrangler-vars, som tt02 allerede har. Prod-søk fungerte kun fordi verdiene ble baket inn fra lokal `.env` ved build - altså avhengig av at deploy skjer fra en maskin med riktig `.env`.

## Endring
La til `ES_ENDPOINT` + `KI_INDEX` som runtime-vars i prod-blokken (samme cluster og indeks som tt02 - clusteret holder prod-innhold). Da overlever søke-konfigurasjonen en deploy fra hvilken som helst maskin eller CI.

`ES_API_KEY` er fortsatt en worker-secret (`wrangler secret put ES_API_KEY --env prod`), ikke i fila.