### PR TITLE
style: icon and text alignments

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -12,6 +12,7 @@ import TextWithImage from '../shared/TextWithImage.astro';
 import AkselIcon from '../shared/AkselIcon.astro';
 import { getMediaUrl, MEDIA_WIDTH, type ForsideSeksjon, type Kalenderhendelse, type VeiledningGuide } from '../../lib/umbraco';
 import { hendelseTilEventCard } from '../../lib/kalender';
+import { splitLastWord } from '../../lib/text';
 
 interface Props {
   seksjoner: ForsideSeksjon[];
@@ -193,6 +194,8 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
 
   if (block.contentType === 'forsideSandkasse') {
     const sandkasseLinkId = `sandkasse-link-${block.id}`;
+    // Pilen limes til siste ord så den ikke brekker alene (#464)
+    const sandkasseTittel = splitLastWord(block.overskrift || 'Den regulatoriske sandkassen');
     return (
       <section class="sandkasse-section" data-layout-block="content">
         <div class="sandkasse-card" data-clickdelegatefor={sandkasseLinkId}>
@@ -202,8 +205,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
           <div class="sandkasse-card-text">
             <h2 class="sandkasse-title">
               <a id={sandkasseLinkId} href={block.lenkeUrl || '/sandkasse'}>
-                {block.overskrift || 'Den regulatoriske sandkassen'}
-                <span class="sandkasse-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span>
+                {sandkasseTittel.head}<span class="u-nowrap">{sandkasseTittel.last}<span class="sandkasse-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span></span>
               </a>
             </h2>
             <p class="sandkasse-desc ds-paragraph" data-size="lg">{block.tekst || 'Juridisk veiledning for deg som ønsker å utvikle et risikofylt KI-prosjekt.'}</p>

--- a/apps/frontend/src/components/landing/Hero.astro
+++ b/apps/frontend/src/components/landing/Hero.astro
@@ -2,6 +2,7 @@
 // Hero — tagline with illustration, "Kom i gang" CTA. Feltene er redaksjonelle
 // (forsideHero-modulen); defaults under brukes når feltet er tomt.
 import AkselIcon from '../shared/AkselIcon.astro';
+import { splitLastWord } from '../../lib/text';
 interface Props {
   overskrift?: string;
   komIGangTekst?: string;
@@ -16,6 +17,9 @@ const {
   lenkeUrl = '/veiledning/hva-er-ki',
   illustrasjon = '/people-working-on-computer.svg',
 } = Astro.props;
+
+// Pilen limes til siste ord så den ikke brekker alene (#464)
+const lenkeParts = splitLastWord(lenketekst);
 ---
 
 <section class="hero" data-layout-block="content">
@@ -24,7 +28,7 @@ const {
       <img src="/logo.svg" alt="KI Norge" class="hero-logo" />
       <div class="hero-tagline ds-heading" data-size="xl" set:html={overskrift} />
       <p class="hero-cta">
-        {komIGangTekst}: <a class="hero-cta-link ds-focus" href={lenkeUrl}>{lenketekst} <span class="hero-cta-arrow"><AkselIcon name="ArrowRight" size={24} /></span></a>
+        {komIGangTekst}: <a class="hero-cta-link ds-focus" href={lenkeUrl}>{lenkeParts.head}<span class="u-nowrap">{lenkeParts.last}<span class="hero-cta-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={24} /></span></span></a>
       </p>
     </div>
     <div class="hero-illustration">

--- a/apps/frontend/src/components/layout/header.css
+++ b/apps/frontend/src/components/layout/header.css
@@ -162,6 +162,7 @@
   box-sizing: border-box;
   background-color: var(--ds-color-background-default);
   padding: var(--ds-size-4);
+  max-height: 100dvh;
 
   &::backdrop {
     background-color: rgba(0, 0, 0, 0.5);

--- a/apps/frontend/src/components/shared/ArticleCardFeatured.astro
+++ b/apps/frontend/src/components/shared/ArticleCardFeatured.astro
@@ -1,5 +1,6 @@
 ---
 import AkselIcon from './AkselIcon.astro';
+import { splitLastWord } from '../../lib/text';
 
 interface Props {
   href: string;
@@ -11,6 +12,9 @@ interface Props {
 
 const { href, title, lead, image, imageAlt = '' } = Astro.props;
 const id = `featured-card-${crypto.randomUUID().slice(0, 8)}`;
+
+// Pilen limes til siste ord så den ikke brekker alene (#464)
+const titleParts = splitLastWord(title);
 ---
 
 <article class="featured-card" data-clickdelegatefor={id}>
@@ -18,8 +22,7 @@ const id = `featured-card-${crypto.randomUUID().slice(0, 8)}`;
     {image ? <img src={image} alt={imageAlt} loading="lazy" /> : <div class="featured-card-placeholder"></div>}
   </div>
   <div class="featured-card-body">
-    <h3 class="featured-card-title"><a id={id} href={href}>{title}</a><span class="featured-card-arrow "><AkselIcon name="ArrowRight" size={20} aria-hidden="true" /></span>
-    </h3>
+    <h3 class="featured-card-title"><a id={id} href={href}>{titleParts.head}<span class="u-nowrap">{titleParts.last}<span class="featured-card-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span></span></a></h3>
     {lead && <p class="featured-card-lead">{lead}</p>}
   </div>
 </article>
@@ -80,9 +83,6 @@ const id = `featured-card-${crypto.randomUUID().slice(0, 8)}`;
     font-weight: 400;
     margin: 0;
     text-decoration: underline;
-    display: inline-flex;
-    align-items: center;
-    gap: var(--ds-size-2);
   }
 
   .featured-card-lead {
@@ -100,5 +100,7 @@ const id = `featured-card-${crypto.randomUUID().slice(0, 8)}`;
   height: 32px;
   border-radius: 50%;
   background-color: var(--ds-color-surface-tinted);
+  vertical-align: middle;
+  margin-left: var(--ds-size-2);
 }
 </style>

--- a/apps/frontend/src/components/shared/ExampleCard.astro
+++ b/apps/frontend/src/components/shared/ExampleCard.astro
@@ -1,5 +1,6 @@
 ---
 import AkselIcon from './AkselIcon.astro';
+import { splitLastWord } from '../../lib/text';
 
 interface Props {
   href: string;
@@ -16,15 +17,15 @@ const {
 } = Astro.props;
 
 const id = `example-card-${crypto.randomUUID().slice(0, 8)}`;
+
+// Pilen limes til siste ord så den ikke brekker alene (#464)
+const titleParts = splitLastWord(title);
 ---
 
 <article class="example-card" data-variant={variant} data-clickdelegatefor={id}>
   <h3 class="ds-heading example-card-title" data-size="md">
     <a id={id} href={href}>
-      {title}
-      <span class="example-card-arrow" aria-hidden="true">
-        <AkselIcon name="ArrowRight" size={20} />
-      </span>
+      {titleParts.head}<span class="u-nowrap">{titleParts.last}<span class="example-card-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span></span>
     </a>
   </h3>
   {tag && <span class="ds-tag" data-size="sm">{tag}</span>}

--- a/apps/frontend/src/components/shared/LinkList.astro
+++ b/apps/frontend/src/components/shared/LinkList.astro
@@ -1,5 +1,6 @@
 ---
 import AkselIcon from './AkselIcon.astro';
+import { splitLastWord } from '../../lib/text';
 
 interface LinkItem {
   title: string;
@@ -19,13 +20,12 @@ const { links, heading } = Astro.props;
   <ul class="link-list-items">
     {links.map((link) => {
       const id = `link-list-${crypto.randomUUID().slice(0, 8)}`;
+      // Pilen limes til siste ord så den ikke brekker alene (#464)
+      const titleParts = splitLastWord(link.title);
       return (
         <li class="link-list-item" data-clickdelegatefor={id}>
           <a id={id} href={link.href}>
-            {link.title}
-            <span class="link-list-arrow" aria-hidden="true">
-              <AkselIcon name="ArrowRight" size={16} />
-            </span>
+            {titleParts.head}<span class="u-nowrap">{titleParts.last}<span class="link-list-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={16} /></span></span>
           </a>
         </li>
       );

--- a/apps/frontend/src/components/shared/NewsCard.astro
+++ b/apps/frontend/src/components/shared/NewsCard.astro
@@ -1,5 +1,6 @@
 ---
 import AkselIcon from './AkselIcon.astro';
+import { splitLastWord } from '../../lib/text';
 
 interface Props {
   href: string;
@@ -25,6 +26,9 @@ const {
 } = Astro.props;
 
 const id = `news-card-${crypto.randomUUID().slice(0, 8)}`;
+
+// Pilen i featured-varianten limes til siste ord så den ikke brekker alene (#464)
+const titleParts = splitLastWord(title);
 
 const formattedDate = date
   ? new Date(date).toLocaleDateString('nb-NO', { day: 'numeric', month: 'long', year: 'numeric' })
@@ -56,11 +60,10 @@ const formattedDate = date
     {tag && <span class="ds-tag" data-variant="outline" data-size="sm">{tag.toUpperCase()}</span>}
     <h3 class="ds-heading news-card-title" data-size={variant === 'featured' ? 'lg' : 'sm'}>
       <a id={id} href={href}>
-        {title}
-        {variant === 'featured' && (
-          <span class="news-card-title-arrow" aria-hidden="true">
-            <AkselIcon name="ArrowRight" size={24} />
-          </span>
+        {variant === 'featured' ? (
+          <Fragment>{titleParts.head}<span class="u-nowrap">{titleParts.last}<span class="news-card-title-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={24} /></span></span></Fragment>
+        ) : (
+          title
         )}
       </a>
     </h3>

--- a/apps/frontend/src/components/shared/TextWithImage.astro
+++ b/apps/frontend/src/components/shared/TextWithImage.astro
@@ -1,5 +1,6 @@
 ---
 import AkselIcon from './AkselIcon.astro';
+import { splitLastWord } from '../../lib/text';
 
 interface Props {
   title: string;
@@ -11,6 +12,9 @@ interface Props {
 }
 
 const { title, href, image, imageAlt = '', imagePosition = 'right', label } = Astro.props;
+
+// Pilen limes til siste ord så den ikke brekker alene (#464)
+const titleParts = splitLastWord(title);
 ---
 
 <div class="text-with-image" data-image-position={imagePosition}>
@@ -18,7 +22,7 @@ const { title, href, image, imageAlt = '', imagePosition = 'right', label } = As
     {label && <p class="ds-paragraph" data-size="xl">{label}</p>}
     <slot />
     <h2 class="ds-heading" data-size="lg">
-      <a href={href} class="ds-focus">{title} <span aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span></a>
+      <a href={href} class="ds-focus">{titleParts.head}<span class="u-nowrap">{titleParts.last}<span class="text-with-image-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={20} /></span></span></a>
     </h2>
     <div class="body ds-paragraph" data-size="lg">
       <slot name="body" />
@@ -68,7 +72,7 @@ const { title, href, image, imageAlt = '', imagePosition = 'right', label } = As
           text-underline-offset: 4px;
           text-decoration-thickness: 2px;
 
-          & span {
+          & .text-with-image-arrow {
             display: inline-flex;
             align-items: center;
             justify-content: center;
@@ -78,6 +82,7 @@ const { title, href, image, imageAlt = '', imagePosition = 'right', label } = As
             background-color: var(--ds-color-accent-surface-tinted);
             color: var(--ds-color-accent-text-default);
             margin-left: var(--ds-size-2);
+            vertical-align: middle;
           }
         }
       }

--- a/apps/frontend/src/components/shared/VeiledningBlocksRenderer.astro
+++ b/apps/frontend/src/components/shared/VeiledningBlocksRenderer.astro
@@ -76,8 +76,13 @@ const moduleIcons: Record<string, string> = {
     return (
       <div class="ds-card veiledning-modul" data-variant="tinted" data-type={variantType}>
         <div class="veiledning-modul-head">
-          <AkselIcon name={ikon} size={24} class="veiledning-modul-ikon" />
-          {tittel && <h3 class="ds-heading veiledning-modul-tittel" data-size="xs">{tittel}</h3>}
+          {tittel ? (
+            <h3 class="ds-heading veiledning-modul-tittel" data-size="xs">
+              <AkselIcon name={ikon} class="veiledning-modul-ikon" />{tittel}
+            </h3>
+          ) : (
+            <AkselIcon name={ikon} class="veiledning-modul-ikon" />
+          )}
         </div>
         <div class="veiledning-modul-body" set:html={tekst} />
         {trekkspill && trekkspill.length > 0 && (
@@ -155,13 +160,12 @@ const moduleIcons: Record<string, string> = {
     background-color: #FFFDE1;
   }
 
-  .veiledning-modul-head {
-    display: flex;
-    align-items: center;
-    gap: var(--ds-size-2);
-  }
-  .veiledning-modul-ikon {
-    flex-shrink: 0;
+
+  .veiledning-modul-head :global(.veiledning-modul-ikon) {
+    width: 1em;
+    height: 1em;
+    vertical-align: -0.125em;
+    margin-inline-end: var(--ds-size-2);
   }
   .veiledning-modul-tittel {
     margin: 0;

--- a/apps/frontend/src/lib/text.test.ts
+++ b/apps/frontend/src/lib/text.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { splitLastWord } from './text';
+
+describe('splitLastWord', () => {
+  it('deler ved siste mellomrom og beholder mellomrommet i head', () => {
+    expect(splitLastWord('Hva er KI og hva kan du bruke det til?')).toEqual({
+      head: 'Hva er KI og hva kan du bruke det ',
+      last: 'til?',
+    });
+  });
+
+  it('gir tomt head for ett ord', () => {
+    expect(splitLastWord('Eksempler')).toEqual({ head: '', last: 'Eksempler' });
+  });
+
+  it('tåler tom og undefined-aktig input', () => {
+    expect(splitLastWord('')).toEqual({ head: '', last: '' });
+    expect(splitLastWord('   ')).toEqual({ head: '', last: '' });
+  });
+
+  it('trimmer ytterkanter', () => {
+    expect(splitLastWord('  Kom i gang  ')).toEqual({ head: 'Kom i ', last: 'gang' });
+  });
+});

--- a/apps/frontend/src/lib/text.ts
+++ b/apps/frontend/src/lib/text.ts
@@ -1,0 +1,14 @@
+/**
+ * Deler en tekst i «alt før siste ord» og «siste ord», slik at pil-ikoner
+ * kan limes til siste ord med en white-space: nowrap-wrapper (.u-nowrap).
+ * Uten dette brekker pilen alene ned på egen linje ved smale bredder (#464).
+ *
+ * `head` beholder mellomrommet på slutten, så rendering blir
+ * `{head}<span class="u-nowrap">{last}<ikon /></span>`.
+ */
+export function splitLastWord(text: string): { head: string; last: string } {
+  const trimmed = (text ?? '').trim();
+  const i = trimmed.lastIndexOf(' ');
+  if (i === -1) return { head: '', last: trimmed };
+  return { head: trimmed.slice(0, i + 1), last: trimmed.slice(i + 1) };
+}

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -10,6 +10,7 @@ import ExampleLinkCards from '../../components/shared/ExampleLinkCards.astro';
 import AkselIcon from '../../components/shared/AkselIcon.astro';
 import LinkList from '../../components/shared/LinkList.astro';
 import { getVeiledningOversikt, getVeiledningGuider, getEksempler, getMediaUrl, MEDIA_WIDTH } from '../../lib/umbraco';
+import { splitLastWord } from '../../lib/text';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
@@ -105,15 +106,14 @@ const seoDesc = cmsData?.seoBeskrivelse || heroText;
         <ul class="veil-rich-list">
           {richLinks.map((link) => {
             const id = `rich-link-${crypto.randomUUID().slice(0, 8)}`;
+            // Pilen limes til siste ord så den ikke brekker alene (#464)
+            const titleParts = splitLastWord(link.title);
             return (
               <li class="veil-rich-item" data-clickdelegatefor={id}>
                 <div class="veil-rich-link-heading">
                   <h3 class="ds-heading" data-size="lg">
                     <a id={id} href={link.href} class="ds-focus">
-                      {link.title}
-                      <span class="veil-rich-link-arrow" aria-hidden="true">
-                        <AkselIcon name="ArrowRight" size={18} />
-                      </span>
+                      {titleParts.head}<span class="u-nowrap">{titleParts.last}<span class="veil-rich-link-arrow" aria-hidden="true"><AkselIcon name="ArrowRight" size={18} /></span></span>
                     </a>
                   </h3>
                 </div>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -50,6 +50,18 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* Utility classes */
+/* Binder siste ord og pil-ikon sammen så pilen ikke brekker alene (#464).
+   Brukes med splitLastWord() fra lib/text.ts. */
+.u-nowrap {
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  .u-nowrap {
+    white-space: wrap;
+  }
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

resolves #464

Also fixes our last a11y issue with the mobile menu not being scrollable

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
