### PR TITLE
fix(cms): bruk cms.ki.norge.no som BackOfficeHost i stedet for workers.dev

### DIFF
--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -25,12 +25,12 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev
+          value: https://cms.ki.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev
+          value: https://cms.ki.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -25,12 +25,12 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev
+          value: https://cms.ki.test.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__Security__BackOfficeHost
-          value: https://cms-kinorgeportal-tt02.digitaliseringsdirektoratet.workers.dev
+          value: https://cms.ki.test.norge.no
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:


### PR DESCRIPTION
Innlogging på cms.ki.norge.no/umbraco sendte brukeren videre til workers.dev-proxyen. Årsaken er at `BackOfficeHost` og `UmbracoApplicationUrl` pekte på workers.dev, og Umbraco bygger absolutte URL-er i OAuth-flyten ut fra disse (Program.cs normaliserer i tillegg Request.Host til BackOfficeHost).

Endring
- prod: `https://cms.ki.norge.no`
- tt02: `https://cms.ki.test.norge.no`

Begge hostnavn ligger allerede i HTTPRoute og svarer med gyldig TLS. Etter deploy blir effekten speilvendt: innlogging via workers.dev-URL-en havner på cms.ki.norge.no.