### PR TITLE
test: fjern /sok fra smoke-testen, ruten er fjernet

### DIFF
--- a/tests/frontend/smoke.spec.ts
+++ b/tests/frontend/smoke.spec.ts
@@ -14,7 +14,6 @@ const PUBLIC_URLS = [
   { path: '/veiledning', label: 'Veiledning' },
   { path: '/om-oss', label: 'Om oss' },
   { path: '/sandkasse', label: 'Sandkasse' },
-  { path: '/sok', label: 'Søk' },
 ];
 
 for (const { path, label } of PUBLIC_URLS) {


### PR DESCRIPTION
Oppfølging av #484 som fjernet /sok-ruten men overså smoke-testen i rot-tests/. Smoke-suiten feilet på main fordi den fortsatt besøkte /sok.