### PR TITLE
chore: set lang to "no"

### DIFF
--- a/apps/frontend/src/components/layout/Layout.astro
+++ b/apps/frontend/src/components/layout/Layout.astro
@@ -48,7 +48,7 @@ const ogImageUrl = resolvedOg
 ---
 
 <!doctype html>
-<html lang="nb" data-ds-color-mode="light" data-color-scheme="light">
+<html lang="no" data-ds-color-mode="light" data-color-scheme="light">
   <head>
     <meta charset="UTF-8" />
     <style>@layer ds, layout, site, article-layout;</style>

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -48,7 +48,7 @@ const PUBLIC_ASSET_PATHS = new Set([
 ]);
 
 const COMING_SOON_HTML = `<!doctype html>
-<html lang="nb">
+<html lang="no">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -251,7 +251,7 @@ Rich content supports these block types:
 - Keyboard navigable
 - Focus indicators on all interactive elements
 - Alt text for images
-- Language attribute: `lang="nb"`
+- Language attribute: `lang="no"`
 
 ---
 

--- a/docs/technical-review.md
+++ b/docs/technical-review.md
@@ -27,7 +27,7 @@ Last updated: 2026-02-13
 | **SEO — Meta** | OG, Twitter Card, canonical, JSON-LD | Good | Open Graph, Twitter Card, canonical URL on all pages. JSON-LD: FAQPage, Article, WebSite+SearchAction. OG image can be added when designed. |
 | **SEO — Sitemap** | @astrojs/sitemap | Good | N/A — auto-generated, referenced in robots.txt |
 | **SEO — robots.txt** | Allow all + sitemap | Good | N/A |
-| **Accessibility** | ARIA, skip link, focus mgmt | Excellent | N/A — skip links, aria-current, aria-expanded, Escape key handling, lang="nb" all present. Designsystemet is WCAG AA compliant |
+| **Accessibility** | ARIA, skip link, focus mgmt | Excellent | N/A — skip links, aria-current, aria-expanded, Escape key handling, lang="no" all present. Designsystemet is WCAG AA compliant |
 | **Accessibility Testing** | axe-core/playwright | Good | N/A — integrated into test suite |
 | **Performance — Images** | CSS background-image | **Weak** | No `<img>` tags with width/height (causes layout shift), no `loading="lazy"`, no responsive `srcset`, no image optimization. Switch to `<img>` or Astro's `<Image>` component |
 | **Performance — Fonts** | Preconnect + display=swap | Good | N/A — proper preconnect to Google Fonts, swap prevents blocking |


### PR DESCRIPTION
<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

Me vil ha bytting mellom bokmål og nynorsk på sidene våre. Sia dette ikkje kan styrast redaksjonelt via CMS for å markere språk er det betre at me sette `lang="no"` for å markere språk som norsk, men ikkje spesifisere bokmål eller nynorsk

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
