### PR TITLE
Edge cache 10 min

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -22,7 +22,7 @@ import { defineMiddleware } from 'astro:middleware';
  * som har gjeldende asset-hasher.
  */
 
-const CACHE_MAX_AGE = 60 * 60; // 1 hour edge cache (s-maxage)
+const CACHE_MAX_AGE = 60 * 10; // 10 minutes edge cache (s-maxage)
 
 // Public hostnames that sit behind the holding page until launch. The
 // *.workers.dev preview URLs and localhost are intentionally NOT listed, so


### PR DESCRIPTION
As a compromise between protecting CMS from overload and the need to see updates, the edge cache time is adjusted to 10 min.
