### PR TITLE
feat: update robots.txt to allow all crawlers and optimize for SEO

### DIFF
--- a/apps/frontend/src/pages/robots.txt.ts
+++ b/apps/frontend/src/pages/robots.txt.ts
@@ -10,18 +10,33 @@ export const GET: APIRoute = ({ url }) => {
   const isProd = PROD_HOSTS.has(url.hostname);
 
   const body = isProd
-    ? `# Allows Siteimprove only (todo: allow at launch)
-User-agent: SiteimproveBot
-User-agent: SiteimproveBot-Crawler
-Allow: /
+    ? `# Robots.txt for https://ki.norge.no/
+# Updated: 2026-06-11 — optimized for SEO, security and AI search
+
+User-agent: *
+
+# Allow resources required for correct rendering and Core Web Vitals measurements
+Allow: /*.css$
+Allow: /*.js$
+Allow: /*.png$
+Allow: /*.jpg$
+Allow: /*.jpeg$
+Allow: /*.webp$
+Allow: /*.svg$
+
+# --- Search (should not appear in search results) ---
+Disallow: /sok/
+
+# --- Media library (Umbraco media files) ---
+Disallow: /media/
+
+# --- Admin and internal routes ---
 Disallow: /admin-tilgang
 Disallow: /preview-tilgang
 Disallow: /status
 Disallow: /api/
 Disallow: /503
-
-User-agent: *
-Disallow: /
+Disallow: /404
 
 Sitemap: https://ki.norge.no/sitemap.xml
 


### PR DESCRIPTION
<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

This pull request updates the `robots.txt` generation logic for production environments to improve SEO, security, and support for AI search. The new configuration allows essential resources for rendering and Core Web Vitals, while explicitly disallowing search, media, and admin/internal routes from indexing.

Key updates to robots.txt generation:

* Updated the `robots.txt` template to allow all user agents access to CSS, JS, and image resources required for proper rendering and performance measurement.
* Added explicit disallow rules for search pages (`/sok/`), media library files (`/media/`), and various admin/internal routes to prevent them from appearing in search results.
* Removed previous restriction that only allowed Siteimprove bots, opening up access for all user agents with the new rules.
* Updated comments and metadata in the `robots.txt` for clarity and documentation purposes.

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
