### PR TITLE
chore: add temporary domain verification asset for Google Search Console

### DIFF
--- a/apps/frontend/public/google9d550b55098c3fbc.html
+++ b/apps/frontend/public/google9d550b55098c3fbc.html
@@ -1,0 +1,1 @@
+google-site-verification: google9d550b55098c3fbc.html


### PR DESCRIPTION
Temporary verification of site ownership in Google Search Console, to be replaced when an alternative GSC account is ready.