### PR TITLE
feat(lansering): flipp prod LAUNCH_MODE til live

### DIFF
--- a/apps/frontend/wrangler.jsonc
+++ b/apps/frontend/wrangler.jsonc
@@ -39,7 +39,7 @@
 				"ES_ENDPOINT": "https://kinorgeportal-elasticsearch-tt02-a61b24.es.germanywestcentral.azure.elastic.cloud",
 				"KI_INDEX": "ki-content",
 				// Holding page on ki.norge.no until launch. Flip to "live" to go public.
-				"LAUNCH_MODE": "coming-soon",
+				"LAUNCH_MODE": "live",
 			},
 		},
 	},


### PR DESCRIPTION
Lanserings-flippen for ki.norge.no. Én endring: `LAUNCH_MODE` → `live` for prod i `wrangler.jsonc`. Fjerner ventesiden (gating styres av `LAUNCH_MODE` i middleware, fail-safe: gated med mindre `live`).

tt02 forblir gated (egen beslutning om når test åpnes).

robots.txt-åpning ble gjort separat i #498, og sitemap virker etter #492, så denne PR-en gjør kun selve flippen.

Etter merge: `pnpm run frontend:deploy:prod` + purge Cloudflare-cache.