### PR TITLE
fix: Added CANONICAL_SITE_URL for sitemap to use

### DIFF
--- a/apps/frontend/src/lib/prod-hosts.ts
+++ b/apps/frontend/src/lib/prod-hosts.ts
@@ -1,3 +1,11 @@
+// Kanonisk produksjons-URL for portalen. Brukes som loc-base i sitemap og
+// som canonical-pekepinn i strukturert data.
+//
+// Hardkodet med vilje. SITE_URL fra .env settes til http://localhost:4321 i
+// dev, og blir bakt inn i prod-byggene hvis vi leser den derfra. Det
+// kanoniske domenet er ki.norge.no uansett miljø, så det hører hjemme her.
+export const CANONICAL_SITE_URL = 'https://ki.norge.no';
+
 // Verter som regnes som "produksjon" når en innkommende request skal vurderes.
 // Brukes til å bestemme om responser (robots.txt, sitemap.xml) skal peke på det
 // kanoniske domenet eller på request-origin (lokal dev, tt02-preview osv.).

--- a/apps/frontend/src/pages/sitemap.xml.ts
+++ b/apps/frontend/src/pages/sitemap.xml.ts
@@ -1,13 +1,11 @@
 import type { APIRoute } from 'astro';
 import { generateSitemapXml } from '../lib/sitemap';
-import { isProdHost } from '../lib/prod-hosts';
-
-const PUBLIC_BASE_URL = import.meta.env.SITE_URL || 'https://ki.norge.no';
+import { isProdHost, CANONICAL_SITE_URL } from '../lib/prod-hosts';
 
 export const GET: APIRoute = async ({ url }) => {
   // I produksjon brukes alltid det kanoniske domenet, slik at sitemap-URLer
   // som leses fra workers.dev-hosten fortsatt peker til ki.norge.no.
-  const base = isProdHost(url.hostname) ? PUBLIC_BASE_URL : url.origin;
+  const base = isProdHost(url.hostname) ? CANONICAL_SITE_URL : url.origin;
 
   try {
     const xml = await generateSitemapXml(base);


### PR DESCRIPTION
Fix:
- Added CANONICAL_SITE_URL = 'https://ki.norge.no' to src/lib/prod-hosts.ts (hardcoded, not env-driven)
- sitemap.xml.ts now uses that constant when isProdHost returns true