### PR TITLE
fix(riktekst): løs interne lenker i cookie-banner og globale felt

### DIFF
--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -939,19 +939,19 @@ export function collectRteFields(root: unknown): RteField[] {
 }
 
 /**
- * Walks a UmbracoBlock[] tree mutating HTML fields in-place, replacing internal
- * link placeholders (emitted by richTextToHtml) with resolved frontend URLs.
- * Uses an optional shared cache so repeated targets across an article cost a
- * single Delivery API round-trip.
+ * Resolves internal-link placeholders (href="#" + data-internal-link-id, emitted
+ * by richTextToHtml) to real frontend URLs in every RTE string field found
+ * anywhere under `root`, mutating in-place. Works on any shape — a block tree, a
+ * mapped settings object, nested arrays — via collectRteFields. Uses an optional
+ * shared cache so repeated targets cost a single Delivery API round-trip.
  */
-export async function enrichBlocksInternalLinks(
-  blocks: UmbracoBlock[] | undefined,
+export async function enrichRteInternalLinks(
+  root: unknown,
   options: FetchOptions = {},
   cache: Map<string, string> = new Map(),
 ): Promise<void> {
-  if (!blocks || blocks.length === 0) return;
-
-  const fields = collectRteFields(blocks);
+  const fields = collectRteFields(root);
+  if (fields.length === 0) return;
 
   const ids = new Set<string>();
   for (const f of fields) {
@@ -966,6 +966,20 @@ export async function enrichBlocksInternalLinks(
       f.set(replaceInternalLinks(html, cache));
     }
   }
+}
+
+/**
+ * Walks a UmbracoBlock[] tree mutating HTML fields in-place, replacing internal
+ * link placeholders with resolved frontend URLs. Thin wrapper over
+ * enrichRteInternalLinks for the article/veiledning call sites.
+ */
+export async function enrichBlocksInternalLinks(
+  blocks: UmbracoBlock[] | undefined,
+  options: FetchOptions = {},
+  cache: Map<string, string> = new Map(),
+): Promise<void> {
+  if (!blocks || blocks.length === 0) return;
+  await enrichRteInternalLinks(blocks, options, cache);
 }
 
 // ── Map Umbraco item to our content type interfaces ─────────────
@@ -1862,7 +1876,12 @@ export async function getForside(options: FetchOptions = {}): Promise<Forside | 
 
 export async function getGlobaleInnstillinger(options: FetchOptions = {}): Promise<GlobaleInnstillinger | null> {
   const result = await fetchCollection<GlobaleInnstillinger>('globaleInnstillinger', { ...options, take: 1 });
-  return result.data[0] || null;
+  const gi = result.data[0] || null;
+  // Cookie-banner og footer kan ha interne riktekst-lenker. De rendres som
+  // placeholder (href="#" + data-internal-link-id) og må resolves her, slik
+  // artikkelinnhold gjør — ellers peker lenken bare til "#".
+  if (gi) await enrichRteInternalLinks(gi, options);
+  return gi;
 }
 
 // ── Veiledning Guide/Step API functions ─────────────────────────


### PR DESCRIPTION
Interne innholdslenker i riktekst rendres som placeholder (`href="#"` + `data-internal-link-id`) og resolves via `destinationId` til riktig frontend-URL. Resolveren (`enrichBlocksInternalLinks`) kjørte bare på artikkelinnhold, ikke på `globaleInnstillinger`, så den interne lenken i cookie-banneret ("Se oversikt over nødvendig informasjon") ble stående med `href="#"` og navigerte til `/#`.

`enrichRteInternalLinks` generaliserer resolveren til vilkårlige objekter via `collectRteFields`. `getGlobaleInnstillinger` kjører den nå på cookie- og footer-riktekstfeltene. `enrichBlocksInternalLinks` er beholdt som tynn wrapper.

Løser også at manuell sti ikke holder her: nodens tre-segment er nynorsk (`/informasjonskapslar/`, 404) mens slugen er bokmål (`/informasjonskapsler`, 200) — `destinationId`-veien treffer riktig slug uansett.