### PR TITLE
Clean up README by removing obsolete information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Portal for kunstig intelligens i norsk offentlig sektor.
 
 - **Live**: https://ki.norge.no
-- **CMS**: https://cms.ki.norge.no/umbraco
 - **Repo**: https://github.com/digdir/ki.norge.no
 - **Project board**: https://github.com/orgs/digdir/projects/58
 
@@ -20,19 +19,6 @@ Portal for kunstig intelligens i norsk offentlig sektor.
 - **React 19** for islands (search dialog, etc.)
 - **`@digdir/designsystemet-react`** + **`@digdir/designsystemet-css`** design tokens
 - **`@navikt/aksel-icons`** (extracted to static SVG map for Astro compatibility)
-
-### Hosting
-- **Frontend:** Cloudflare Workers (`ki-norge-frontend-prod` / `-tt02`)
-- **CMS:** Altinn dis-core (Kubernetes), database Azure SQL
-- Legacy Azure Container Apps (resource group `ki-norge`, registry `kinorgeacr.azurecr.io`, storage `kinorgestorage`) is retired, kept for reference
-
-### Testing
-- **`scripts/smoke-test.sh`** — bash + curl smoke check (~10s, 21 checks). Run after every deploy.
-- **Playwright** in `tests/` — frontend smoke + CMS auth/tree state. See `tests/README.md`.
-
-### Testing
-- **Playwright 1.44** — E2E tests (functional, visual regression, accessibility)
-- **axe-core** — WCAG accessibility checks
 
 ## Project Structure
 
@@ -68,10 +54,11 @@ ki.norge.no/
 ```bash
 # Frontend (Astro, runs on Node locally)
 pnpm run frontend:dev         # http://localhost:4321
-
+AND
 # CMS (Umbraco 17 / .NET 10)
 pnpm run cms:dev              # http://localhost:5000/umbraco
-                              # admin@ki.norge.no / KiNorge2025!
+
+OR
 
 # Frontend pointing at prod CMS (no local CMS needed)
 pnpm run frontend:dev:prod
@@ -99,16 +86,6 @@ pnpm run dev
 ```
 - Frontend: http://localhost:4321
 
-### Rendering Strategy
-
-The frontend uses **hybrid rendering**:
-
-- **SSG (prerendered at build)** — all content pages. Content is fetched from Umbraco at build time.
-- **SSR (server-rendered)** — `/sok` (search) and `/api/preview` (preview mode endpoints).
-
-In development, the Astro dev server re-fetches from Umbraco on each page load, so CMS changes appear on refresh.
-
-In production, run `pnpm run build` to rebuild with latest content. Consider webhook-triggered rebuilds when CMS content changes.
 
 ## Content Types
 
@@ -118,8 +95,6 @@ In production, run `pnpm run build` to rebuild with latest content. Consider web
 | Side | `side` | Static pages (om-oss, kontakt, sandkasse) |
 | Eksempel | `eksempel` | AI case studies |
 | Veiledning | `veiledning` | Guidance documents |
-| FAQ | `faq` | Frequently asked questions |
-| Merkelapp | `merkelapp` | Tags/categories |
 
 Content is fetched via the Umbraco Content Delivery API v2 at `/umbraco/delivery/api/v2/content`.
 
@@ -139,44 +114,9 @@ Content is fetched via the Umbraco Content Delivery API v2 at `/umbraco/delivery
 | `/kontakt` | Page content (blocks) | Page template |
 | `/om-oss` | Page content (blocks) | Partner cards, offerings grid |
 | `/sandkasse` | Optional page content | Feature cards, process steps |
-| `/sok` | Search results (SSR) | Search UI |
 | `/404` | — | Entire page |
 
 **Principle:** Editorial content lives in the CMS. Page structure, navigation, and design live in code.
-
-## Environment Variables
-
-### CMS (`apps/cms-umbraco/appsettings.Development.json`)
-
-Copy from `appsettings.Development.json.example` and fill in:
-
-| Key | Description |
-|-----|-------------|
-| `Umbraco:CMS:DeliveryApi:ApiKey` | Random key for authenticated API access (preview/draft content) |
-| `HeadlessPreview:FrontendUrl` | Frontend URL, default `http://localhost:4321` |
-| `HeadlessPreview:PreviewSecret` | Shared secret for preview mode (must match frontend) |
-
-### Frontend (`apps/frontend/.env`)
-
-Copy from `.env.example` and fill in:
-
-| Key | Description |
-|-----|-------------|
-| `UMBRACO_URL` | CMS URL, default `http://localhost:5000` |
-| `UMBRACO_API_KEY` | Must match `Umbraco:CMS:DeliveryApi:ApiKey` in CMS config |
-| `SITE_URL` | Frontend URL, default `http://localhost:4321` |
-| `PREVIEW_SECRET` | Must match `HeadlessPreview:PreviewSecret` in CMS config |
-
-## Preview Mode
-
-Editors can preview draft content before publishing:
-
-1. In Umbraco admin, click "Save and Preview" on any content item
-2. Umbraco redirects to the Astro frontend via `/api/preview`
-3. A preview banner appears showing draft content
-4. Click "Avslutt forhåndsvisning" to exit preview mode
-
-The preview flow: Umbraco → Razor template redirect → `/api/preview?secret=...&type=...&id=...` → sets cookie → renders page with draft content from Delivery API.
 
 ## Testing
 
@@ -192,5 +132,3 @@ pnpm run test:e2e:update
 # Run tests with UI
 pnpm run test:e2e:ui
 ```
-
-81 tests across 6 browser configurations (Chrome, Firefox, Safari, Chrome Dark, Mobile Chrome, Mobile Safari).


### PR DESCRIPTION
Removed outdated sections on hosting, testing, and environment variables from the README.

<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
