### PR TITLE
fix(layout): update favicon link and add secure URL for Open Graph image

### DIFF
--- a/apps/frontend/src/components/layout/Layout.astro
+++ b/apps/frontend/src/components/layout/Layout.astro
@@ -55,7 +55,7 @@ const ogImageUrl = resolvedOg
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#1a2a6d" />
@@ -70,6 +70,7 @@ const ogImageUrl = resolvedOg
     <meta property="og:site_name" content="KI Norge" />
     <meta property="og:locale" content="nb_NO" />
     <meta property="og:image" content={ogImageUrl} />
+    <meta property="og:image:secure_url" content={ogImageUrl} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     {publishedAt && <meta property="article:published_time" content={publishedAt} />}


### PR DESCRIPTION
<!-- Quick PR template — keep it short. Replace the placeholders. -->

## Summary

This pull request makes minor updates to the metadata in the `Layout.astro` component to improve favicon handling and Open Graph image support.

- **Favicon improvements:**
  * Changed the favicon link relation from `alternate icon` to `icon` for the `.ico` file, ensuring better browser compatibility.

- **Open Graph metadata enhancements:**
  * Added the `og:image:secure_url` meta tag to provide a secure (HTTPS) image URL for social sharing platforms.
## Test plan

- [ ] `dotnet build` (CMS) passes
- [ ] `npx astro build` (frontend) passes
- [ ] `bash scripts/smoke-test.sh --local` passes (or noted why not)
- [ ] Manual check in browser if UI changed

## Notes for reviewer

<!-- Anything non-obvious: migrations, breaking changes, follow-ups -->
