### PR TITLE
fix(logo): unngå at rammen rundt løven klippes

### DIFF
--- a/apps/frontend/src/components/layout/Logo.tsx
+++ b/apps/frontend/src/components/layout/Logo.tsx
@@ -7,7 +7,7 @@ export default function Logo({ className }: LogoProps) {
     <svg
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 2312 438"
+      viewBox="-8 -8 2328 454"
       className={className}
     >
       <path


### PR DESCRIPTION
Hjørne-brakettene i logoen tegnes med strokeWidth 12, og bunn- og venstrekanten lå med ytterkanten nøyaktig på viewBox-grensen (y=438, x=0). SVG-en klipper innholdet til viewBox, så ved 28px header-størrelse mistet de nederste brakettene antialiasing-kanten og ble synlig tynnere enn de øverste.

Utvider viewBox med 8 enheters luft på alle sider, så ingen strek ligger på klippekanten. Logoen deles av Header, Footer og Hero.

Fixes #521