### PR TITLE
fix: preview thumbnail

### DIFF
--- a/apps/frontend/src/components/layout/Layout.astro
+++ b/apps/frontend/src/components/layout/Layout.astro
@@ -37,7 +37,8 @@ const currentPath = Astro.url.pathname;
 const siteUrl = Astro.site?.href.replace(/\/$/, '') || 'https://ki.norge.no';
 const canonicalUrl = `${siteUrl}${currentPath}`;
 const fullTitle = `${title} | KI Norge`;
-const DEFAULT_OG_IMAGE = '/og-image.png';
+// Version query busts stale link-preview thumbnail caches without changing the asset path.
+const DEFAULT_OG_IMAGE = '/og-image.png?v=3c5667a2';
 // CMS-media (/media/...) gjores absolutt mot CMS-hosten; ellers prefikses
 // site-hosten. Uten dette ble og:image til ki.norge.no/media/... (feil host),
 // som ga utdatert/odelagt delingsbilde.
@@ -71,6 +72,7 @@ const ogImageUrl = resolvedOg
     <meta property="og:locale" content="nb_NO" />
     <meta property="og:image" content={ogImageUrl} />
     <meta property="og:image:secure_url" content={ogImageUrl} />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     {publishedAt && <meta property="article:published_time" content={publishedAt} />}
@@ -80,6 +82,7 @@ const ogImageUrl = resolvedOg
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
+    <meta name="twitter:image:alt" content="KI Norge" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Fixes the thumbnail issue, where the thumbnail was not displayed after pasting the URL into the Microsoft Teams app. 

<img width="577" height="383" alt="Screenshot 2026-06-12 at 14 03 57" src="https://github.com/user-attachments/assets/16231a12-da20-4b2a-99e7-f9b2c04b13a4" />

