### PR TITLE
feat(cms): regenerer content-routes-speil automatisk ved build

### DIFF
--- a/apps/cms-umbraco/KiNorge.Cms.csproj
+++ b/apps/cms-umbraco/KiNorge.Cms.csproj
@@ -35,4 +35,18 @@
     </None>
   </ItemGroup>
 
+  <!--
+    Regenererer det git-ignorerte speilet av /shared/content-routes.json fra
+    kilden før build/publish, slik at `dotnet run`/`dotnet build` alltid er i
+    synk uten et eget pre-steg. Condition-en skrur targeten av når /shared ikke
+    er nåbar (Docker-build-konteksten er apps/cms-umbraco/ alene, der
+    GitHub-actionen allerede har staget speilet inn), og når man bevisst vil ha
+    lokal drift: `dotnet run -p:SkipContentRoutesSync=true`.
+  -->
+  <Target Name="SyncContentRoutes" BeforeTargets="BeforeBuild;BeforePublish"
+          Condition="Exists('$(MSBuildProjectDirectory)/../../shared/content-routes.json')
+                     AND '$(SkipContentRoutesSync)' != 'true'">
+    <Exec Command="node &quot;$(MSBuildProjectDirectory)/../../scripts/sync-content-routes.js&quot;" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Hva
Pre-build MSBuild-target i `KiNorge.Cms.csproj` som regenererer det git-ignorerte speilet av `/shared/content-routes.json` fra kilden før build/publish.

## Hvorfor
Etter #529 er CMS-speilet `apps/cms-umbraco/content-routes.json` git-ignorert og generert av `scripts/sync-content-routes.js`. `pnpm cms:*` og CI kjører scriptet, men `dotnet run`/`dotnet build` direkte gjorde det ikke. Da ble speilet manglende (på fresh checkout) eller stale (etter endring i `/shared`), og CMS-en serverte gamle ruter stille. Targeten lukker det hullet, så `dotnet run` alltid er i synk uten et eget pre-steg.

## Detaljer
- `Condition` skrur targeten av når `/shared` ikke er nåbar. Det er nøyaktig Docker-build-konteksten (`apps/cms-umbraco/` alene), der GitHub-actionen allerede stager speilet inn før `docker build` — så ingen avhengighet til `node` inni SDK-imaget.
- Opt-out for bevisst lokal drift: `dotnet run -p:SkipContentRoutesSync=true`.
- Den eksisterende runtime-error-loggen i `ContentRouteResolver` står igjen som backstop.

## Verifisert lokalt
- Fresh worktree uten speil → `dotnet build -t:SyncContentRoutes` genererer det.
- `-p:SkipContentRoutesSync=true` hopper over regenerering.
- `git status` viser kun csproj-endringen, speilet forblir ignorert.