### PR TITLE
feat(cms): import umulig i prod (uSync eksport-only som standard)

### DIFF
--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -85,14 +85,28 @@
       "ExportAtStartup": "None",
       "ExportOnSave": "None",
       "ImportOnFirstBoot": false,
-      "UIEnabledGroups": "Content"
+      "UIEnabledGroups": "Content",
+      "DefaultSet": "Default"
     },
     "Sets": {
+      // Standard for ALLE miljø (inkl. prod): KUN eksport. Import-handlingen er
+      // skrudd av (Actions: ["Export"]), så Import-knappen i prod blir en død
+      // no-op og selv API-import blokkeres. Fail-safe: et miljø kan bare
+      // importere hvis det eksplisitt peker DefaultSet til "Speiling".
       "Default": {
         "HandlerDefaults": { "Enabled": false },
         "Handlers": {
-          "ContentHandler": { "Enabled": true },
-          "MediaHandler": { "Enabled": true }
+          "ContentHandler": { "Enabled": true, "Actions": [ "Export" ] },
+          "MediaHandler": { "Enabled": true, "Actions": [ "Export" ] }
+        }
+      },
+      // Import + eksport. Brukes KUN av tt02 via env-var
+      // uSync__Settings__DefaultSet=Speiling (syncroot/tt02/kustomization.yaml).
+      "Speiling": {
+        "HandlerDefaults": { "Enabled": false },
+        "Handlers": {
+          "ContentHandler": { "Enabled": true, "Actions": [ "All" ] },
+          "MediaHandler": { "Enabled": true, "Actions": [ "All" ] }
         }
       }
     }

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -46,6 +46,11 @@ patches:
         value:
           name: HeadlessPreview__FrontendUrl
           value: https://ki-norge-frontend-tt02.digitaliseringsdirektoratet.workers.dev
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: uSync__Settings__DefaultSet
+          value: Speiling
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
Import er den eneste uSync-handlingen som kan overskrive innhold. Dette gjør import umulig i prod, fail-safe.

- uSync sitt standard-sett (`Default`) er nå eksport-only: `Content`/`Media` har `Actions: ["Export"]`. Da er Import-handlingen ugyldig (`IsValidAction(Import, ["Export"])` = false), så Import-knappen i prod blir en død no-op og API-import blokkeres òg.
- Fail-safe: et miljø kan kun importere hvis det eksplisitt peker `DefaultSet` til `Speiling`. Et nytt miljø er trygt som standard.
- Kun tt02 bruker import-settet, via env-var `uSync__Settings__DefaultSet=Speiling` i `syncroot/tt02/kustomization.yaml`.

Eksport (kilden for speiling) virker fortsatt i alle miljø.