### PR TITLE
fix(cache): ikke cache degraderte/no-store-svar på edgen

### DIFF
--- a/apps/cache-kinorgeportal/src/index.ts
+++ b/apps/cache-kinorgeportal/src/index.ts
@@ -31,7 +31,14 @@ export default {
 				throw new Error(`Failed to fetch GET-request from origin: ${error}`);
 			}
 
-			if (response.ok) {
+			// Respekter no-store/private fra origin. Preview og degraderte/feilede
+			// renders (CMS-henting feilet) sender disse direktivene, og de skal aldri
+			// lagres på edgen — ellers serveres ett uheldig svar til ALLE besøkende,
+			// ikke bare den som utløste det. Gjelder hver bruker likt.
+			const cacheControl = response.headers.get("Cache-Control") || "";
+			const mayCache = !/\b(no-store|private)\b/i.test(cacheControl);
+
+			if (response.ok && mayCache) {
 				try {
 					ctx.waitUntil(cache.put(cacheKey, response.clone()));
 				} catch (error) {

--- a/apps/cache-kinorgeportal/test/index.spec.ts
+++ b/apps/cache-kinorgeportal/test/index.spec.ts
@@ -40,17 +40,15 @@ describe("frontend-cache", () => {
 		expect(fetcher.fetch).toHaveBeenCalledTimes(2);
 	});
 
-	it("ki_admin cookie bypasses cache: admin requests always reach origin", async () => {
-		const { env, fetcher } = mockEnv(() => new Response("admin-view", { status: 200, headers: { "Cache-Control": "public, s-maxage=3600" } }));
-
-		const headers = new Headers({ Cookie: "session=abc; ki_admin=1; other=x" });
+	it("no-store/private responses are not cached: preview and degraded renders always reach origin", async () => {
+		const { env, fetcher } = mockEnv(() => new Response("draft-or-degraded", { status: 200, headers: { "Cache-Control": "private, no-store" } }));
 
 		const ctx1 = createExecutionContext();
-		await worker.fetch(new Request("https://test.local/status", { headers }), env, ctx1);
+		await worker.fetch(new Request("https://test.local/no-store-1"), env, ctx1);
 		await waitOnExecutionContext(ctx1);
 
 		const ctx2 = createExecutionContext();
-		await worker.fetch(new Request("https://test.local/status", { headers }), env, ctx2);
+		await worker.fetch(new Request("https://test.local/no-store-1"), env, ctx2);
 		await waitOnExecutionContext(ctx2);
 
 		expect(fetcher.fetch).toHaveBeenCalledTimes(2);

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -170,8 +170,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
     );
   }
 
-  // Don't cache preview, API, or admin routes
-  if (isPreview || isApiRoute || isAdminRoute) {
+  // Don't cache preview, API, or admin routes — eller sider som selv har bedt om
+  // å ikke caches. En side setter `no-store` i sin egen catch når CMS-henting
+  // feilet, slik at en degradert render (manglende hero/innhold) aldri caches på
+  // edgen og serveres til alle. Uten dette ville et transient CMS-blaff bli
+  // fanget i edge-cachen i opptil s-maxage og vist til alle besøkende.
+  const pageOptedOutOfCache = response.headers.get('Cache-Control')?.includes('no-store');
+  if (isPreview || isApiRoute || isAdminRoute || pageOptedOutOfCache) {
     response.headers.set('Cache-Control', 'private, no-store');
     return response;
   }

--- a/apps/frontend/src/pages/artikler/index.astro
+++ b/apps/frontend/src/pages/artikler/index.astro
@@ -19,6 +19,8 @@ try {
   guider = guiderRes.data;
 } catch (e) {
   console.error('Failed to fetch artikler:', e);
+  // CMS-henting feilet: ikke cache den degraderte renderen (se middleware).
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
 const heroTittel = oversikt?.heroTittel || 'Aktuelt';

--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -25,6 +25,8 @@ try {
   guider = guiderRes.data;
 } catch (e) {
   console.error('Failed to fetch eksempler:', e);
+  // CMS-henting feilet: ikke cache den degraderte renderen (se middleware).
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
 const heroTittel = oversikt?.heroTittel || 'Eksempler';

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -35,6 +35,9 @@ try {
   veiledninger = veiledningerRes.data;
 } catch (e) {
   console.error('Failed to fetch frontpage CMS data:', e);
+  // CMS-henting feilet: ikke cache den degraderte renderen (tom forside uten
+  // hero) på edgen. Se middleware – den respekterer denne no-store.
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
 const title = forside?.seoTittel || 'Hjem';

--- a/apps/frontend/src/pages/kalender/[slug].astro
+++ b/apps/frontend/src/pages/kalender/[slug].astro
@@ -23,6 +23,9 @@ try {
 }
 
 if (!hendelse) {
+  // Ingen hendelse funnet (CMS-feil eller ukjent slug): vis fallback, men ikke
+  // cache den på edgen — ellers serveres en mock til alle på en ekte URL.
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
   hendelse = {
     id: 'mock',
     documentId: 'mock',

--- a/apps/frontend/src/pages/kalender/index.astro
+++ b/apps/frontend/src/pages/kalender/index.astro
@@ -12,6 +12,8 @@ try {
   hendelser = h.data;
 } catch (e) {
   console.error('Failed to fetch kalender:', e);
+  // CMS-henting feilet: ikke cache den degraderte renderen (se middleware).
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
 const tittel = kalender?.tittel || 'Kalender';

--- a/apps/frontend/src/pages/om-oss.astro
+++ b/apps/frontend/src/pages/om-oss.astro
@@ -16,6 +16,8 @@ try {
   latestArticles = artiklerRes.data;
 } catch (e) {
   console.error('Failed to fetch om-oss articles:', e);
+  // CMS-henting feilet: ikke cache den degraderte renderen (se middleware).
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
 const tittel = omOss?.tittel || 'Om KI Norge';

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -26,6 +26,8 @@ try {
   ]);
 } catch (e) {
   console.error('Failed to fetch veiledning page data:', e);
+  // CMS-henting feilet: ikke cache den degraderte renderen (se middleware).
+  Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
 const heroTitle = cmsData?.heroTittel || 'Veiledning og guider';


### PR DESCRIPTION
## Hva

Forsiden og oversiktssidene (artikler, eksempler, kalender, veiledning, om-oss) rendrer en degradert 200 med fallback-innhold når CMS-henting feiler. Middleware cachet den med `s-maxage`, så et transient CMS-blaff ble fanget i edge-cachen og servert til alle besøkende til TTL gikk ut (manglende hero, feil/tomt innhold).

## Endringer

- Sidene setter `no-store` i sin egen catch når CMS-henting feiler
- Middleware respekterer `no-store` satt av siden (cacher den ikke med `s-maxage`)
- `kalender/[slug]` setter `no-store` på mock-fallbacken (ukjent slug eller CMS-feil)
- `cache-kinorgeportal`-workeren cacher ikke lenger `no-store`/`private`-svar (preview og degraderte renders), så ett uheldig svar aldri havner på edgen og serveres til alle. Utdatert ki_admin-bypass-test fjernet (bypass ble fjernet i #496); ny test dekker no-store

Gjelder alle brukere likt, ikke bare innloggede.