### PR TITLE
feat(cms): purge Cloudflare edge cache ved publisering

### DIFF
--- a/apps/cms-umbraco/CachePurge/CachePurgeComposer.cs
+++ b/apps/cms-umbraco/CachePurge/CachePurgeComposer.cs
@@ -1,0 +1,61 @@
+using KiNorge.Cms.CachePurge.Cloudflare;
+using KiNorge.Cms.CachePurge.EventHandlers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
+
+namespace KiNorge.Cms.CachePurge;
+
+/// <summary>
+/// Kobler opp edge-cache-purge: Cloudflare-adapteren, URL-resolveren, dispatcheren og
+/// publiser/avpubliser/papirkurv-handlerne som purger ki.norge.no-edgen ved innholdsendringer.
+/// No-op til ZoneId + ApiToken er satt (Key Vault), så trygg å deploye nå.
+/// </summary>
+public class CachePurgeComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddCloudflareCachePurge(builder.Config);
+        builder.Services.AddSingleton<FrontendUrlResolver>();
+        builder.Services.AddSingleton<CachePurgeDispatcher>();
+
+        builder.AddNotificationHandler<ContentPublishedNotification, CachePurgeOnPublishHandler>();
+        builder.AddNotificationHandler<ContentUnpublishedNotification, CachePurgeOnUnpublishHandler>();
+        builder.AddNotificationHandler<ContentMovedToRecycleBinNotification, CachePurgeOnTrashHandler>();
+
+        builder.Services.AddHostedService<CachePurgeStartupLogger>();
+    }
+}
+
+/// <summary>Logger purge-konfigurasjonen ved oppstart, så det er lett å verifisere at
+/// secreten er på plass uten å publisere noe.</summary>
+internal sealed class CachePurgeStartupLogger : IHostedService
+{
+    private readonly IOptions<CloudflareOptions> _options;
+    private readonly ILogger<CachePurgeStartupLogger> _logger;
+
+    public CachePurgeStartupLogger(IOptions<CloudflareOptions> options, ILogger<CachePurgeStartupLogger> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        CloudflareOptions o = _options.Value;
+        _logger.LogInformation(
+            "Cloudflare cache-purge: Enabled={Enabled}, ZoneId={Zone}, ApiToken={Token}, SiteBaseUrl={Site}, Threshold={Threshold}",
+            o.Enabled,
+            string.IsNullOrWhiteSpace(o.ZoneId) ? "<tom>" : "<satt>",
+            string.IsNullOrWhiteSpace(o.ApiToken) ? "<tom>" : "<satt>",
+            string.IsNullOrWhiteSpace(o.SiteBaseUrl) ? "<tom>" : o.SiteBaseUrl,
+            o.AffectedUrlThreshold);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/apps/cms-umbraco/CachePurge/CachePurgeDispatcher.cs
+++ b/apps/cms-umbraco/CachePurge/CachePurgeDispatcher.cs
@@ -1,0 +1,91 @@
+using KiNorge.Cms.CachePurge.Cloudflare;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models;
+
+namespace KiNorge.Cms.CachePurge;
+
+/// <summary>
+/// Samler påvirkede URLer for en innholdsendring og purger dem på Cloudflare-edgen.
+/// Fire-and-forget: et purge-kall kan ta sekunder og ville ellers frosset "Lagrer…"-
+/// spinneren i backoffice. Mister vi et purge (pod-restart midt i), dekker s-maxage (10 min) det.
+/// </summary>
+public class CachePurgeDispatcher
+{
+    private readonly FrontendUrlResolver _resolver;
+    private readonly IOptionsMonitor<CloudflareOptions> _options;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<CachePurgeDispatcher> _logger;
+
+    public CachePurgeDispatcher(
+        FrontendUrlResolver resolver,
+        IOptionsMonitor<CloudflareOptions> options,
+        IServiceScopeFactory scopeFactory,
+        ILogger<CachePurgeDispatcher> logger)
+    {
+        _resolver = resolver;
+        _options = options;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public void Dispatch(IEnumerable<IContent> entities, string reason)
+    {
+        if (!_options.CurrentValue.Enabled) return;
+
+        var urls = new HashSet<string>(StringComparer.Ordinal);
+        bool purgeEverything = false;
+
+        foreach (IContent content in entities)
+        {
+            try
+            {
+                AffectedUrls affected = _resolver.Resolve(content);
+                if (affected.PurgeEverything) purgeEverything = true;
+                foreach (string url in affected.Urls) urls.Add(url);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Klarte ikke løse URLer for content {ContentId} (reason={Reason}) — eskalerer", content.Id, reason);
+                purgeEverything = true; // trygt: heller for mye enn stale
+            }
+        }
+
+        if (urls.Count > _options.CurrentValue.AffectedUrlThreshold) purgeEverything = true;
+        if (urls.Count == 0 && !purgeEverything) return;
+
+        SchedulePurge(urls.ToArray(), purgeEverything, reason);
+    }
+
+    private void SchedulePurge(string[] urls, bool purgeEverything, string reason)
+    {
+        _ = Task.Run(async () =>
+        {
+            // Frisk scope — notifikasjons-scopen kan være disposet når denne kjører.
+            using IServiceScope scope = _scopeFactory.CreateScope();
+            ICloudflareCachePurgeService purge =
+                scope.ServiceProvider.GetRequiredService<ICloudflareCachePurgeService>();
+            try
+            {
+                if (purgeEverything)
+                {
+                    await purge.PurgeEverythingAsync();
+                    _logger.LogInformation("Cloudflare purge_everything (reason={Reason})", reason);
+                }
+                else
+                {
+                    await purge.PurgeUrlsAsync(urls);
+                    _logger.LogInformation(
+                        "Cloudflare purget {Count} URLer (reason={Reason}): {Urls}",
+                        urls.Length, reason, string.Join(", ", urls));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Cloudflare-purge feilet (reason={Reason})", reason);
+            }
+        });
+    }
+}

--- a/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareCachePurgeService.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareCachePurgeService.cs
@@ -1,0 +1,86 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace KiNorge.Cms.CachePurge.Cloudflare;
+
+/// <summary>
+/// Tynn klient mot Cloudflares purge_cache-API. Purger per URL (`files`), som virker på
+/// Business-planen (purge per hostname/tag er Enterprise-only). purge_everything brukes kun
+/// for globale endringer (header/footer) og masse-publisering. No-op når ZoneId eller
+/// ApiToken mangler, så koden er trygg å deploye før secreten er satt opp.
+/// </summary>
+public class CloudflareCachePurgeService : ICloudflareCachePurgeService
+{
+    private readonly HttpClient _http;
+    private readonly IOptionsMonitor<CloudflareOptions> _options;
+    private readonly ILogger<CloudflareCachePurgeService> _logger;
+
+    public CloudflareCachePurgeService(
+        HttpClient http,
+        IOptionsMonitor<CloudflareOptions> options,
+        ILogger<CloudflareCachePurgeService> logger)
+    {
+        _http = http;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task PurgeUrlsAsync(IReadOnlyCollection<string> absoluteUrls, CancellationToken ct = default)
+    {
+        CloudflareOptions opts = _options.CurrentValue;
+        if (!IsConfigured(opts) || absoluteUrls.Count == 0) return;
+
+        foreach (string[] batch in absoluteUrls.Chunk(Math.Max(1, opts.MaxUrlsPerRequest)))
+        {
+            await PostPurgeAsync(opts, new { files = batch }, ct);
+        }
+    }
+
+    public async Task PurgeEverythingAsync(CancellationToken ct = default)
+    {
+        CloudflareOptions opts = _options.CurrentValue;
+        if (!IsConfigured(opts)) return;
+        await PostPurgeAsync(opts, new { purge_everything = true }, ct);
+    }
+
+    private bool IsConfigured(CloudflareOptions opts)
+    {
+        if (opts.Enabled
+            && !string.IsNullOrWhiteSpace(opts.ApiToken)
+            && !string.IsNullOrWhiteSpace(opts.ZoneId))
+        {
+            return true;
+        }
+
+        _logger.LogDebug(
+            "Cloudflare purge hoppet over — Enabled={Enabled}, ApiToken {TokenState}, ZoneId {ZoneState}",
+            opts.Enabled,
+            string.IsNullOrWhiteSpace(opts.ApiToken) ? "tom" : "satt",
+            string.IsNullOrWhiteSpace(opts.ZoneId) ? "tom" : "satt");
+        return false;
+    }
+
+    private async Task PostPurgeAsync(CloudflareOptions opts, object body, CancellationToken ct)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Post, $"client/v4/zones/{opts.ZoneId}/purge_cache")
+        {
+            // Per-request-header, ikke DefaultRequestHeaders, så token aldri lekker inn i
+            // delt klient-state eller traces.
+            Headers = { Authorization = new AuthenticationHeaderValue("Bearer", opts.ApiToken.Trim()) },
+            Content = JsonContent.Create(body),
+        };
+
+        using HttpResponseMessage response = await _http.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            string detail = await response.Content.ReadAsStringAsync(ct);
+            _logger.LogError(
+                "Cloudflare purge_cache feilet for sone {ZoneId}: {Status} {Detail}",
+                opts.ZoneId, (int)response.StatusCode, detail);
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareOptions.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareOptions.cs
@@ -1,0 +1,31 @@
+namespace KiNorge.Cms.CachePurge.Cloudflare;
+
+/// <summary>
+/// Bundet til config-seksjonen "Cloudflare". ZoneId + ApiToken injiseres i cloud via Azure
+/// Key Vault (Cloudflare--ZoneId / Cloudflare--ApiToken). SiteBaseUrl settes per miljø som
+/// env-var i syncroot. Når ApiToken eller ZoneId er tom no-op-er purge rent (se
+/// CloudflareCachePurgeService), så koden er trygg å deploye før secreten finnes.
+/// </summary>
+public class CloudflareOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>norge.no-sonens Zone ID. Ikke hemmelig, men hentes fra Key Vault for enkelhet.</summary>
+    public string ZoneId { get; set; } = "";
+
+    /// <summary>API-token med kun "Zone.Cache Purge" på norge.no-sonen. Hemmelig (Key Vault).</summary>
+    public string ApiToken { get; set; } = "";
+
+    public string ApiHost { get; set; } = "api.cloudflare.com";
+
+    /// <summary>Offentlig frontend-URL for dette miljøet, f.eks. https://ki.norge.no (prod).</summary>
+    public string SiteBaseUrl { get; set; } = "";
+
+    /// <summary>Cloudflare tar maks 30 URLer per purge-kall utenfor Enterprise.</summary>
+    public int MaxUrlsPerRequest { get; set; } = 30;
+
+    public int TimeoutSeconds { get; set; } = 5;
+
+    /// <summary>Flere påvirkede URLer enn dette eskalerer til purge_everything (masse-publisering).</summary>
+    public int AffectedUrlThreshold { get; set; } = 30;
+}

--- a/apps/cms-umbraco/CachePurge/Cloudflare/ConfigureCloudflare.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/ConfigureCloudflare.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace KiNorge.Cms.CachePurge.Cloudflare;
+
+public static class ConfigureCloudflare
+{
+    /// <summary>
+    /// Registrerer Cloudflare-purge-adapteren: options bundet til "Cloudflare"-seksjonen og
+    /// en typed HttpClient mot purge_cache-API-et.
+    /// </summary>
+    public static IServiceCollection AddCloudflareCachePurge(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<CloudflareOptions>(configuration.GetSection("Cloudflare"));
+
+        services.AddHttpClient<ICloudflareCachePurgeService, CloudflareCachePurgeService>((sp, http) =>
+        {
+            CloudflareOptions opts = sp.GetRequiredService<IOptions<CloudflareOptions>>().Value;
+            string host = string.IsNullOrWhiteSpace(opts.ApiHost) ? "api.cloudflare.com" : opts.ApiHost;
+            http.BaseAddress = new Uri($"https://{host}/");
+            http.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds > 0 ? opts.TimeoutSeconds : 5);
+        });
+
+        return services;
+    }
+}

--- a/apps/cms-umbraco/CachePurge/Cloudflare/ICloudflareCachePurgeService.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/ICloudflareCachePurgeService.cs
@@ -1,0 +1,10 @@
+namespace KiNorge.Cms.CachePurge.Cloudflare;
+
+public interface ICloudflareCachePurgeService
+{
+    /// <summary>Purger en konkret liste absolutte URLer (Cloudflare `files`). No-op uten config.</summary>
+    Task PurgeUrlsAsync(IReadOnlyCollection<string> absoluteUrls, CancellationToken ct = default);
+
+    /// <summary>Purger hele sonen (`purge_everything`). Kun for globale endringer / eskalering.</summary>
+    Task PurgeEverythingAsync(CancellationToken ct = default);
+}

--- a/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnPublishHandler.cs
+++ b/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnPublishHandler.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace KiNorge.Cms.CachePurge.EventHandlers;
+
+/// <summary>Purger påvirkede frontend-URLer når innhold publiseres.</summary>
+public class CachePurgeOnPublishHandler : INotificationHandler<ContentPublishedNotification>
+{
+    private readonly CachePurgeDispatcher _dispatcher;
+
+    public CachePurgeOnPublishHandler(CachePurgeDispatcher dispatcher) => _dispatcher = dispatcher;
+
+    public void Handle(ContentPublishedNotification notification) =>
+        _dispatcher.Dispatch(notification.PublishedEntities, "publish");
+}

--- a/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnTrashHandler.cs
+++ b/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnTrashHandler.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace KiNorge.Cms.CachePurge.EventHandlers;
+
+/// <summary>Purger påvirkede frontend-URLer når innhold flyttes til papirkurven.</summary>
+public class CachePurgeOnTrashHandler : INotificationHandler<ContentMovedToRecycleBinNotification>
+{
+    private readonly CachePurgeDispatcher _dispatcher;
+
+    public CachePurgeOnTrashHandler(CachePurgeDispatcher dispatcher) => _dispatcher = dispatcher;
+
+    public void Handle(ContentMovedToRecycleBinNotification notification) =>
+        _dispatcher.Dispatch(notification.MoveInfoCollection.Select(m => m.Entity), "trash");
+}

--- a/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnUnpublishHandler.cs
+++ b/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnUnpublishHandler.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace KiNorge.Cms.CachePurge.EventHandlers;
+
+/// <summary>Purger påvirkede frontend-URLer når innhold avpubliseres.</summary>
+public class CachePurgeOnUnpublishHandler : INotificationHandler<ContentUnpublishedNotification>
+{
+    private readonly CachePurgeDispatcher _dispatcher;
+
+    public CachePurgeOnUnpublishHandler(CachePurgeDispatcher dispatcher) => _dispatcher = dispatcher;
+
+    public void Handle(ContentUnpublishedNotification notification) =>
+        _dispatcher.Dispatch(notification.UnpublishedEntities, "unpublish");
+}

--- a/apps/cms-umbraco/CachePurge/FrontendUrlResolver.cs
+++ b/apps/cms-umbraco/CachePurge/FrontendUrlResolver.cs
@@ -1,0 +1,130 @@
+using KiNorge.Cms.CachePurge.Cloudflare;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+
+namespace KiNorge.Cms.CachePurge;
+
+/// <summary>URLer som må purges for en innholdsendring. PurgeEverything overstyrer Urls.</summary>
+public record AffectedUrls(IReadOnlyCollection<string> Urls, bool PurgeEverything);
+
+/// <summary>
+/// Mapper en innholdsnode til de offentlige frontend-URLene den påvirker. Frontend ruter på
+/// innholdets `slug`-felt (ikke Umbracos tre-URL), så vi bygger URLene fra content type +
+/// slug, ikke fra IPublishedContent.Url(). Listesider og forsiden tas med der innholdet
+/// vises der. Ukjente typer og globale innstillinger eskalerer til purge_everything
+/// (trygt: heller for mye enn stale).
+/// </summary>
+public class FrontendUrlResolver
+{
+    private readonly IOptionsMonitor<CloudflareOptions> _options;
+    private readonly ILogger<FrontendUrlResolver> _logger;
+
+    public FrontendUrlResolver(IOptionsMonitor<CloudflareOptions> options, ILogger<FrontendUrlResolver> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public AffectedUrls Resolve(IContent content)
+    {
+        string baseUrl = (_options.CurrentValue.SiteBaseUrl ?? "").TrimEnd('/');
+        if (string.IsNullOrEmpty(baseUrl))
+            return new AffectedUrls([], PurgeEverything: false);
+
+        string alias = content.ContentType.Alias;
+        string? slug = content.GetValue<string>("slug");
+        var paths = new List<string>();
+
+        switch (alias)
+        {
+            // Header/footer/cookie-tekst rendres på hver side.
+            case "globaleInnstillinger":
+                return new AffectedUrls([], PurgeEverything: true);
+
+            case "forside":
+                paths.Add("/");
+                break;
+
+            case "artikkel":
+                AddItem(paths, "/artikler", slug, alsoHome: true);
+                break;
+            case "eksempel":
+                AddItem(paths, "/eksempler", slug, alsoHome: true);
+                break;
+            case "kalenderhendelse":
+                AddItem(paths, "/kalender", slug, alsoHome: true);
+                break;
+
+            // Guide og enkel veiledning deler /veiledning/{slug}-ruten.
+            case "veiledningGuide":
+            case "enkelVeiledning":
+                AddItem(paths, "/veiledning", slug, alsoHome: true);
+                break;
+
+            // Steg rendres på guide-siden (+ egen steg-URL under guiden).
+            case "veiledningSteg":
+            {
+                string? guideSlug = content.GetValue<string>("guideSlug");
+                if (string.IsNullOrWhiteSpace(guideSlug))
+                    return Escalate(alias, content.Id);
+                paths.Add($"/veiledning/{guideSlug}");
+                if (!string.IsNullOrWhiteSpace(slug))
+                    paths.Add($"/veiledning/{guideSlug}/{slug}");
+                break;
+            }
+
+            case "side":
+                if (string.IsNullOrWhiteSpace(slug)) return Escalate(alias, content.Id);
+                paths.Add($"/{slug}");
+                break;
+
+            case "omOss":
+                paths.Add("/om-oss");
+                break;
+            case "sandkasse":
+                paths.Add("/sandkasse");
+                break;
+
+            // Oversiktssidene (egne content types, jf. umbraco.ts).
+            case "artikler":
+                paths.Add("/artikler"); paths.Add("/");
+                break;
+            case "eksempler":
+                paths.Add("/eksempler"); paths.Add("/");
+                break;
+            case "veiledninger":
+                paths.Add("/veiledning"); paths.Add("/");
+                break;
+            case "kalender":
+                paths.Add("/kalender"); paths.Add("/");
+                break;
+
+            default:
+                return Escalate(alias, content.Id);
+        }
+
+        List<string> urls = paths
+            .Distinct()
+            .Select(p => baseUrl + p)
+            .ToList();
+        return new AffectedUrls(urls, PurgeEverything: false);
+    }
+
+    // Egen URL (hvis slug finnes) + listeside + eventuelt forsiden (der innholdet løftes).
+    private static void AddItem(List<string> paths, string listing, string? slug, bool alsoHome)
+    {
+        if (!string.IsNullOrWhiteSpace(slug)) paths.Add($"{listing}/{slug}");
+        paths.Add(listing);
+        if (alsoHome) paths.Add("/");
+    }
+
+    private AffectedUrls Escalate(string alias, int contentId)
+    {
+        _logger.LogInformation(
+            "Ingen URL-regel for content type '{Alias}' (id {Id}) — eskalerer til purge_everything",
+            alias, contentId);
+        return new AffectedUrls([], PurgeEverything: true);
+    }
+}

--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -75,6 +75,19 @@
     "Endpoint": "",
     "IndexName": "ki-content"
   },
+  // Edge-cache-purge ved publisering. ZoneId + ApiToken hentes fra Key Vault
+  // (Cloudflare--ZoneId / Cloudflare--ApiToken). SiteBaseUrl settes per miljø som
+  // env-var i syncroot. Tom ApiToken/ZoneId => purge no-op (trygt før oppsett).
+  "Cloudflare": {
+    "Enabled": true,
+    "ApiHost": "api.cloudflare.com",
+    "ZoneId": "",
+    "ApiToken": "",
+    "SiteBaseUrl": "",
+    "MaxUrlsPerRequest": 30,
+    "TimeoutSeconds": 5,
+    "AffectedUrlThreshold": 30
+  },
   // uSync brukes kun til manuell innholdsspeiling fra prod til tt02.
   // Skjema eies av ContentTypeComposer, derfor er alle handlers av som
   // standard og kun innhold og media slått på. All automatikk er av, uSync

--- a/docs/cloudflare-cache-purge.md
+++ b/docs/cloudflare-cache-purge.md
@@ -1,0 +1,52 @@
+# Cloudflare edge-cache purge ved publisering
+
+Purger Cloudflare-edgen for ki.norge.no automatisk når en redaktør publiserer,
+avpubliserer eller sletter innhold, slik at endringer vises med en gang i stedet for
+å vente på at edge-TTL-en (`s-maxage`, 10 min) går ut.
+
+## Hvordan det virker
+
+- Notifikasjons-handlere (`CachePurge/EventHandlers/`) fanger
+  `ContentPublished` / `ContentUnpublished` / `ContentMovedToRecycleBin`.
+- `FrontendUrlResolver` mapper innholdsnoden til de offentlige frontend-URLene den
+  påvirker (egen URL fra `slug` + listeside + forsiden der innholdet løftes). Frontend
+  ruter på `slug`-feltet, ikke Umbracos tre-URL, derfor en eksplisitt type→rute-tabell.
+- `CachePurgeDispatcher` samler URLene og purger dem **fire-and-forget** (blokkerer ikke
+  "Lagrer…"-spinneren). Mistes et purge (pod-restart), dekker `s-maxage` det innen 10 min.
+- `CloudflareCachePurgeService` purger **per URL** (`files`), som virker på Business-planen.
+  Globale endringer (`globaleInnstillinger` = header/footer) og masse-publisering over
+  `AffectedUrlThreshold` eskalerer til `purge_everything`.
+
+No-op til `ZoneId` **og** `ApiToken` er satt — trygt å deploye før secreten finnes.
+
+## Oppsett (gjenstår: API-token)
+
+Config-seksjon `Cloudflare` (se `appsettings.json`). Per miljø:
+
+| Verdi | Hvor | Status |
+|-------|------|--------|
+| `Cloudflare__SiteBaseUrl` | env-var i `syncroot/{prod,tt02}/kustomization.yaml` | satt (prod `https://ki.norge.no`, tt02 `https://ki.test.norge.no`) |
+| `Cloudflare--ZoneId` | Azure Key Vault (per miljø) | **gjenstår** (ikke hemmelig, men legges i vault for enkelhet) |
+| `Cloudflare--ApiToken` | Azure Key Vault (per miljø) | **gjenstår** (krever superadmin på Cloudflare) |
+
+### Lage API-token (Cloudflare)
+
+1. Cloudflare dashboard → øverst til høyre (profil) → **My Profile → API Tokens → Create Token**.
+2. Velg **Create Custom Token**.
+3. **Permissions:** `Zone` → `Cache Purge` → `Purge` (kun denne, minste privilegium).
+4. **Zone Resources:** `Include` → `Specific zone` → `norge.no`.
+5. Create → kopier token (vises kun én gang).
+
+### Hente Zone ID
+
+`norge.no`-sonen → **Overview** → høyre sidemeny → **Zone ID** (ikke hemmelig).
+
+### Legge inn
+
+For hvert miljø (prod + tt02), legg secretene i miljøets Key Vault:
+
+- `Cloudflare--ApiToken` = token fra steget over
+- `Cloudflare--ZoneId` = norge.no Zone ID (samme verdi for prod og tt02)
+
+Redeploy CMS. Verifiser i oppstartsloggen:
+`Cloudflare cache-purge: Enabled=True, ZoneId=<satt>, ApiToken=<satt>, SiteBaseUrl=https://ki.norge.no`.

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -46,6 +46,11 @@ patches:
         value:
           name: HeadlessPreview__FrontendUrl
           value: https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Cloudflare__SiteBaseUrl
+          value: https://ki.norge.no
   - target:
       kind: HTTPRoute
       name: umbraco

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -49,6 +49,11 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Cloudflare__SiteBaseUrl
+          value: https://ki.test.norge.no
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: uSync__Settings__DefaultSet
           value: Speiling
   - target:


### PR DESCRIPTION
## Hva

Purger Cloudflare-edgen for ki.norge.no automatisk når innhold publiseres, avpubliseres eller slettes, så endringer vises umiddelbart i stedet for å vente på edge-TTL (`s-maxage`, 10 min).

## Hvordan

- Notifikasjons-handlere (`ContentPublished` / `ContentUnpublished` / `ContentMovedToRecycleBin`) → `CachePurgeDispatcher` → `CloudflareCachePurgeService`
- `FrontendUrlResolver` mapper content type + `slug` til frontend-rutene (egen URL + listeside + forside der innholdet løftes). Frontend ruter på `slug`, ikke Umbracos tre-URL, derfor en eksplisitt type→rute-tabell.
- Purger **per URL** (`files`) — virker på Business-planen. Globale endringer (`globaleInnstillinger`) og masse-publisering over terskel eskalerer til `purge_everything`.
- Fire-and-forget, så backoffice-lagring ikke blokkeres.
- Speiler `Search/`-strukturen (composer + EventHandlers + adapter).
