### PR TITLE
chore(deps): fjern overflødig vite-override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,6 @@ settings:
 overrides:
   devalue: ^5.8.1
   esbuild: ^0.28.1
-  vite: 7.3.5
   ws: ^8.21.0
 
 importers:
@@ -278,7 +277,7 @@ packages:
   '@cloudflare/vite-plugin@1.39.0':
     resolution: {integrity: sha512-AHC+KSR+3dtGu7Ab7I0Ode4Whx12TxMEmiZt7w+Fc3/2wYNByIzbb6cndWZ78tnveFdO1xhNLv1YaNngxGtOPg==}
     peerDependencies:
-      vite: 7.3.5
+      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.95.0
 
   '@cloudflare/vitest-pool-workers@0.16.15':
@@ -1225,7 +1224,7 @@ packages:
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: 7.3.5
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -1234,7 +1233,7 @@ packages:
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.5
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2786,7 +2785,7 @@ packages:
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
-      vite: 7.3.5
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -2807,7 +2806,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
-      vite: 7.3.5
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,10 @@ overrides:
   # Sikkerhetspinninger for transitive deps Trivy flagger (HIGH). Fjern når
   # vite/astro drar inn fiksede versjoner selv.
   esbuild: "^0.28.1" # GHSA-gv7w-rqvm-qjhr
-  vite: "7.3.5" # CVE-2026-53571 (innenfor astro 6.4.6 sin ^7.3.2)
   ws: "^8.21.0" # CVE-2026-48779
+  # vite-override fjernet: astro 6.4 sin ^7.3.2 drar nå inn en fikset 7.x selv
+  # (CVE-2026-53571 fikset i 7.3.5), så pinningen var overflødig og hindret
+  # Renovate i å la vite flyte. Lar den være transitiv til astro 7 (drar inn vite 8).
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
## Hva

Fjerner den overflødige `vite`-override-en i `pnpm-workspace.yaml`.

Override-en (`vite: "7.3.5"`) ble lagt inn i #534 for CVE-2026-53571, men astro 6.4.7 sin `^7.3.2` drar nå inn 7.3.5 helt selv — det resolvede treet er uendret (vite forblir 7.3.5, bygg + 151 enhetstester grønne). Ved å fjerne override-en slutter Renovate å foreslå vite v8 (jf. lukket #553), siden vite da kun er en transitiv avhengighet astro styrer.

`esbuild`- og `ws`-pinningene beholdes (egne CVE-er).