### PR TITLE
chore(cms): diagnose-endepunkt for Cloudflare cache-purge

### DIFF
--- a/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareCachePurgeService.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareCachePurgeService.cs
@@ -45,6 +45,32 @@ public class CloudflareCachePurgeService : ICloudflareCachePurgeService
         await PostPurgeAsync(opts, new { purge_everything = true }, ct);
     }
 
+    public async Task<CloudflarePurgeProbe> SelfTestAsync(CancellationToken ct = default)
+    {
+        CloudflareOptions opts = _options.CurrentValue;
+        if (!IsConfigured(opts))
+            return new CloudflarePurgeProbe(false, null, false, "Enabled/ApiToken/ZoneId mangler (ikke lastet)");
+
+        string url = (opts.SiteBaseUrl?.TrimEnd('/') ?? "") + "/__cf-purge-selftest";
+        try
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Post, $"client/v4/zones/{opts.ZoneId}/purge_cache")
+            {
+                Headers = { Authorization = new AuthenticationHeaderValue("Bearer", opts.ApiToken.Trim()) },
+                Content = JsonContent.Create(new { files = new[] { url } }),
+            };
+            using HttpResponseMessage response = await _http.SendAsync(request, ct);
+            string body = await response.Content.ReadAsStringAsync(ct);
+            if (body.Length > 400) body = body[..400];
+            return new CloudflarePurgeProbe(true, (int)response.StatusCode, response.IsSuccessStatusCode, body);
+        }
+        catch (Exception ex)
+        {
+            return new CloudflarePurgeProbe(true, null, false, ex.Message);
+        }
+    }
+
     private bool IsConfigured(CloudflareOptions opts)
     {
         if (opts.Enabled

--- a/apps/cms-umbraco/CachePurge/Cloudflare/ICloudflareCachePurgeService.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/ICloudflareCachePurgeService.cs
@@ -1,5 +1,8 @@
 namespace KiNorge.Cms.CachePurge.Cloudflare;
 
+/// <summary>Resultat av en live purge-selvtest (diagnose). Eksponerer ALDRI secret-verdier.</summary>
+public record CloudflarePurgeProbe(bool Configured, int? HttpStatus, bool Ok, string? Detail);
+
 public interface ICloudflareCachePurgeService
 {
     /// <summary>Purger en konkret liste absolutte URLer (Cloudflare `files`). No-op uten config.</summary>
@@ -7,4 +10,8 @@ public interface ICloudflareCachePurgeService
 
     /// <summary>Purger hele sonen (`purge_everything`). Kun for globale endringer / eskalering.</summary>
     Task PurgeEverythingAsync(CancellationToken ct = default);
+
+    /// <summary>Diagnose: purger en ufarlig test-URL og returnerer Cloudflare-svaret (status + body).
+    /// Kaster ikke. Lar /api/diagnostics/cloudflare se 401/403/404 uten å lese pod-loggen.</summary>
+    Task<CloudflarePurgeProbe> SelfTestAsync(CancellationToken ct = default);
 }

--- a/apps/cms-umbraco/Program.cs
+++ b/apps/cms-umbraco/Program.cs
@@ -146,6 +146,35 @@ app.MapGet("/api/diagnostics", (Umbraco.Cms.Core.Services.IContentTypeService ct
     });
 });
 
+// Diagnose: Cloudflare cache-purge-config + valgfri live purge-selvtest.
+// Config-status (kun booleans/lengder, ALDRI verdier) er åpen; selve purge-testen
+// gates på Delivery API-nøkkelen (Api-Key-header) så den ikke kan misbrukes.
+app.MapGet("/api/diagnostics/cloudflare", async (
+    HttpContext http,
+    Microsoft.Extensions.Options.IOptionsMonitor<KiNorge.Cms.CachePurge.Cloudflare.CloudflareOptions> cfOpts,
+    KiNorge.Cms.CachePurge.Cloudflare.ICloudflareCachePurgeService cfPurge) =>
+{
+    var o = cfOpts.CurrentValue;
+    string? deliveryKey = app.Configuration["Umbraco:CMS:DeliveryApi:ApiKey"];
+    string providedKey = http.Request.Headers["Api-Key"].ToString();
+    bool authed = !string.IsNullOrEmpty(deliveryKey) && providedKey == deliveryKey;
+
+    object selfTest = authed
+        ? await cfPurge.SelfTestAsync()
+        : new { skipped = "send 'Api-Key'-header (Delivery API-nøkkel) for å kjøre live purge-test" };
+
+    return Results.Ok(new
+    {
+        enabled = o.Enabled,
+        zoneIdSet = !string.IsNullOrWhiteSpace(o.ZoneId),
+        zoneIdLength = o.ZoneId?.Length ?? 0,
+        apiTokenSet = !string.IsNullOrWhiteSpace(o.ApiToken),
+        apiTokenLength = o.ApiToken?.Length ?? 0,
+        siteBaseUrl = o.SiteBaseUrl,
+        selfTest,
+    });
+});
+
 app.UseUmbraco()
     .WithMiddleware(u =>
     {


### PR DESCRIPTION
## Hva

`/api/diagnostics/cloudflare` for å feilsøke hvorfor purge-on-publish (#554) ikke slår gjennom på prod, når pod-loggen ikke er lesbar (Altinn ruter stdout vekk fra kubectl).

Rapporterer:
- om `Cloudflare:ZoneId` / `Cloudflare:ApiToken` faktisk lastet fra Key Vault — kun `set`-boolean + lengde, **aldri verdier** — pluss `SiteBaseUrl` og `Enabled`
- valgfri live **purge-selvtest** mot en ufarlig test-URL (`/__cf-purge-selftest`) som returnerer Cloudflare-svarkoden (401 token / 403 perm / 404 zone). Gated på Delivery API-nøkkelen (`Api-Key`-header) så den ikke kan misbrukes.