### PR TITLE
chore(cms): rydd kommentarer i CachePurge

### DIFF
--- a/apps/cms-umbraco/CachePurge/CachePurgeComposer.cs
+++ b/apps/cms-umbraco/CachePurge/CachePurgeComposer.cs
@@ -10,11 +10,6 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace KiNorge.Cms.CachePurge;
 
-/// <summary>
-/// Kobler opp edge-cache-purge: Cloudflare-adapteren, URL-resolveren, dispatcheren og
-/// publiser/avpubliser/papirkurv-handlerne som purger ki.norge.no-edgen ved innholdsendringer.
-/// No-op til ZoneId + ApiToken er satt (Key Vault), så trygg å deploye nå.
-/// </summary>
 public class CachePurgeComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
@@ -31,8 +26,6 @@ public class CachePurgeComposer : IComposer
     }
 }
 
-/// <summary>Logger purge-konfigurasjonen ved oppstart, så det er lett å verifisere at
-/// secreten er på plass uten å publisere noe.</summary>
 internal sealed class CachePurgeStartupLogger : IHostedService
 {
     private readonly IOptions<CloudflareOptions> _options;

--- a/apps/cms-umbraco/CachePurge/CachePurgeDispatcher.cs
+++ b/apps/cms-umbraco/CachePurge/CachePurgeDispatcher.cs
@@ -6,11 +6,6 @@ using Umbraco.Cms.Core.Models;
 
 namespace KiNorge.Cms.CachePurge;
 
-/// <summary>
-/// Samler påvirkede URLer for en innholdsendring og purger dem på Cloudflare-edgen.
-/// Fire-and-forget: et purge-kall kan ta sekunder og ville ellers frosset "Lagrer…"-
-/// spinneren i backoffice. Mister vi et purge (pod-restart midt i), dekker s-maxage (10 min) det.
-/// </summary>
 public class CachePurgeDispatcher
 {
     private readonly FrontendUrlResolver _resolver;
@@ -48,8 +43,8 @@ public class CachePurgeDispatcher
             catch (Exception ex)
             {
                 _logger.LogError(ex,
-                    "Klarte ikke løse URLer for content {ContentId} (reason={Reason}) — eskalerer", content.Id, reason);
-                purgeEverything = true; // trygt: heller for mye enn stale
+                    "Klarte ikke løse URLer for content {ContentId} (reason={Reason})", content.Id, reason);
+                purgeEverything = true;
             }
         }
 
@@ -59,11 +54,11 @@ public class CachePurgeDispatcher
         SchedulePurge(urls.ToArray(), purgeEverything, reason);
     }
 
+    // Fire-and-forget så backoffice-lagring ikke blokkeres.
     private void SchedulePurge(string[] urls, bool purgeEverything, string reason)
     {
         _ = Task.Run(async () =>
         {
-            // Frisk scope — notifikasjons-scopen kan være disposet når denne kjører.
             using IServiceScope scope = _scopeFactory.CreateScope();
             ICloudflareCachePurgeService purge =
                 scope.ServiceProvider.GetRequiredService<ICloudflareCachePurgeService>();

--- a/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareCachePurgeService.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareCachePurgeService.cs
@@ -5,12 +5,6 @@ using Microsoft.Extensions.Options;
 
 namespace KiNorge.Cms.CachePurge.Cloudflare;
 
-/// <summary>
-/// Tynn klient mot Cloudflares purge_cache-API. Purger per URL (`files`), som virker på
-/// Business-planen (purge per hostname/tag er Enterprise-only). purge_everything brukes kun
-/// for globale endringer (header/footer) og masse-publisering. No-op når ZoneId eller
-/// ApiToken mangler, så koden er trygg å deploye før secreten er satt opp.
-/// </summary>
 public class CloudflareCachePurgeService : ICloudflareCachePurgeService
 {
     private readonly HttpClient _http;
@@ -93,8 +87,6 @@ public class CloudflareCachePurgeService : ICloudflareCachePurgeService
         using HttpRequestMessage request = new(
             HttpMethod.Post, $"client/v4/zones/{opts.ZoneId}/purge_cache")
         {
-            // Per-request-header, ikke DefaultRequestHeaders, så token aldri lekker inn i
-            // delt klient-state eller traces.
             Headers = { Authorization = new AuthenticationHeaderValue("Bearer", opts.ApiToken.Trim()) },
             Content = JsonContent.Create(body),
         };

--- a/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareOptions.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/CloudflareOptions.cs
@@ -1,31 +1,13 @@
 namespace KiNorge.Cms.CachePurge.Cloudflare;
 
-/// <summary>
-/// Bundet til config-seksjonen "Cloudflare". ZoneId + ApiToken injiseres i cloud via Azure
-/// Key Vault (Cloudflare--ZoneId / Cloudflare--ApiToken). SiteBaseUrl settes per miljø som
-/// env-var i syncroot. Når ApiToken eller ZoneId er tom no-op-er purge rent (se
-/// CloudflareCachePurgeService), så koden er trygg å deploye før secreten finnes.
-/// </summary>
 public class CloudflareOptions
 {
     public bool Enabled { get; set; } = true;
-
-    /// <summary>norge.no-sonens Zone ID. Ikke hemmelig, men hentes fra Key Vault for enkelhet.</summary>
     public string ZoneId { get; set; } = "";
-
-    /// <summary>API-token med kun "Zone.Cache Purge" på norge.no-sonen. Hemmelig (Key Vault).</summary>
     public string ApiToken { get; set; } = "";
-
     public string ApiHost { get; set; } = "api.cloudflare.com";
-
-    /// <summary>Offentlig frontend-URL for dette miljøet, f.eks. https://ki.norge.no (prod).</summary>
     public string SiteBaseUrl { get; set; } = "";
-
-    /// <summary>Cloudflare tar maks 30 URLer per purge-kall utenfor Enterprise.</summary>
     public int MaxUrlsPerRequest { get; set; } = 30;
-
     public int TimeoutSeconds { get; set; } = 5;
-
-    /// <summary>Flere påvirkede URLer enn dette eskalerer til purge_everything (masse-publisering).</summary>
     public int AffectedUrlThreshold { get; set; } = 30;
 }

--- a/apps/cms-umbraco/CachePurge/Cloudflare/ConfigureCloudflare.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/ConfigureCloudflare.cs
@@ -6,10 +6,6 @@ namespace KiNorge.Cms.CachePurge.Cloudflare;
 
 public static class ConfigureCloudflare
 {
-    /// <summary>
-    /// Registrerer Cloudflare-purge-adapteren: options bundet til "Cloudflare"-seksjonen og
-    /// en typed HttpClient mot purge_cache-API-et.
-    /// </summary>
     public static IServiceCollection AddCloudflareCachePurge(
         this IServiceCollection services, IConfiguration configuration)
     {

--- a/apps/cms-umbraco/CachePurge/Cloudflare/ICloudflareCachePurgeService.cs
+++ b/apps/cms-umbraco/CachePurge/Cloudflare/ICloudflareCachePurgeService.cs
@@ -1,17 +1,10 @@
 namespace KiNorge.Cms.CachePurge.Cloudflare;
 
-/// <summary>Resultat av en live purge-selvtest (diagnose). Eksponerer ALDRI secret-verdier.</summary>
 public record CloudflarePurgeProbe(bool Configured, int? HttpStatus, bool Ok, string? Detail);
 
 public interface ICloudflareCachePurgeService
 {
-    /// <summary>Purger en konkret liste absolutte URLer (Cloudflare `files`). No-op uten config.</summary>
     Task PurgeUrlsAsync(IReadOnlyCollection<string> absoluteUrls, CancellationToken ct = default);
-
-    /// <summary>Purger hele sonen (`purge_everything`). Kun for globale endringer / eskalering.</summary>
     Task PurgeEverythingAsync(CancellationToken ct = default);
-
-    /// <summary>Diagnose: purger en ufarlig test-URL og returnerer Cloudflare-svaret (status + body).
-    /// Kaster ikke. Lar /api/diagnostics/cloudflare se 401/403/404 uten å lese pod-loggen.</summary>
     Task<CloudflarePurgeProbe> SelfTestAsync(CancellationToken ct = default);
 }

--- a/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnPublishHandler.cs
+++ b/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnPublishHandler.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace KiNorge.Cms.CachePurge.EventHandlers;
 
-/// <summary>Purger påvirkede frontend-URLer når innhold publiseres.</summary>
 public class CachePurgeOnPublishHandler : INotificationHandler<ContentPublishedNotification>
 {
     private readonly CachePurgeDispatcher _dispatcher;

--- a/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnTrashHandler.cs
+++ b/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnTrashHandler.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace KiNorge.Cms.CachePurge.EventHandlers;
 
-/// <summary>Purger påvirkede frontend-URLer når innhold flyttes til papirkurven.</summary>
 public class CachePurgeOnTrashHandler : INotificationHandler<ContentMovedToRecycleBinNotification>
 {
     private readonly CachePurgeDispatcher _dispatcher;

--- a/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnUnpublishHandler.cs
+++ b/apps/cms-umbraco/CachePurge/EventHandlers/CachePurgeOnUnpublishHandler.cs
@@ -3,7 +3,6 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace KiNorge.Cms.CachePurge.EventHandlers;
 
-/// <summary>Purger påvirkede frontend-URLer når innhold avpubliseres.</summary>
 public class CachePurgeOnUnpublishHandler : INotificationHandler<ContentUnpublishedNotification>
 {
     private readonly CachePurgeDispatcher _dispatcher;

--- a/apps/cms-umbraco/CachePurge/FrontendUrlResolver.cs
+++ b/apps/cms-umbraco/CachePurge/FrontendUrlResolver.cs
@@ -6,16 +6,9 @@ using Umbraco.Extensions;
 
 namespace KiNorge.Cms.CachePurge;
 
-/// <summary>URLer som må purges for en innholdsendring. PurgeEverything overstyrer Urls.</summary>
 public record AffectedUrls(IReadOnlyCollection<string> Urls, bool PurgeEverything);
 
-/// <summary>
-/// Mapper en innholdsnode til de offentlige frontend-URLene den påvirker. Frontend ruter på
-/// innholdets `slug`-felt (ikke Umbracos tre-URL), så vi bygger URLene fra content type +
-/// slug, ikke fra IPublishedContent.Url(). Listesider og forsiden tas med der innholdet
-/// vises der. Ukjente typer og globale innstillinger eskalerer til purge_everything
-/// (trygt: heller for mye enn stale).
-/// </summary>
+// Frontend ruter på slug-feltet, ikke Umbraco-treet, så URLene bygges fra content type + slug.
 public class FrontendUrlResolver
 {
     private readonly IOptionsMonitor<CloudflareOptions> _options;
@@ -39,7 +32,6 @@ public class FrontendUrlResolver
 
         switch (alias)
         {
-            // Header/footer/cookie-tekst rendres på hver side.
             case "globaleInnstillinger":
                 return new AffectedUrls([], PurgeEverything: true);
 
@@ -57,13 +49,11 @@ public class FrontendUrlResolver
                 AddItem(paths, "/kalender", slug, alsoHome: true);
                 break;
 
-            // Guide og enkel veiledning deler /veiledning/{slug}-ruten.
             case "veiledningGuide":
             case "enkelVeiledning":
                 AddItem(paths, "/veiledning", slug, alsoHome: true);
                 break;
 
-            // Steg rendres på guide-siden (+ egen steg-URL under guiden).
             case "veiledningSteg":
             {
                 string? guideSlug = content.GetValue<string>("guideSlug");
@@ -87,7 +77,6 @@ public class FrontendUrlResolver
                 paths.Add("/sandkasse");
                 break;
 
-            // Oversiktssidene (egne content types, jf. umbraco.ts).
             case "artikler":
                 paths.Add("/artikler"); paths.Add("/");
                 break;
@@ -112,7 +101,6 @@ public class FrontendUrlResolver
         return new AffectedUrls(urls, PurgeEverything: false);
     }
 
-    // Egen URL (hvis slug finnes) + listeside + eventuelt forsiden (der innholdet løftes).
     private static void AddItem(List<string> paths, string listing, string? slug, bool alsoHome)
     {
         if (!string.IsNullOrWhiteSpace(slug)) paths.Add($"{listing}/{slug}");

--- a/apps/cms-umbraco/Program.cs
+++ b/apps/cms-umbraco/Program.cs
@@ -146,9 +146,7 @@ app.MapGet("/api/diagnostics", (Umbraco.Cms.Core.Services.IContentTypeService ct
     });
 });
 
-// Diagnose: Cloudflare cache-purge-config + valgfri live purge-selvtest.
-// Config-status (kun booleans/lengder, ALDRI verdier) er åpen; selve purge-testen
-// gates på Delivery API-nøkkelen (Api-Key-header) så den ikke kan misbrukes.
+// Cloudflare-config-status; live purge-test gates på Delivery API-nøkkelen.
 app.MapGet("/api/diagnostics/cloudflare", async (
     HttpContext http,
     Microsoft.Extensions.Options.IOptionsMonitor<KiNorge.Cms.CachePurge.Cloudflare.CloudflareOptions> cfOpts,

--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -75,9 +75,7 @@
     "Endpoint": "",
     "IndexName": "ki-content"
   },
-  // Edge-cache-purge ved publisering. ZoneId + ApiToken hentes fra Key Vault
-  // (Cloudflare--ZoneId / Cloudflare--ApiToken). SiteBaseUrl settes per miljø som
-  // env-var i syncroot. Tom ApiToken/ZoneId => purge no-op (trygt før oppsett).
+  // ZoneId + ApiToken fra Key Vault, SiteBaseUrl per miljø i syncroot.
   "Cloudflare": {
     "Enabled": true,
     "ApiHost": "api.cloudflare.com",


### PR DESCRIPTION
Rydder kommentarer i CachePurge-koden (#554/#556) — fjerner verbose XML-docs og WHAT-kommentarer, beholder kun et par korte WHY-linjer. Ingen funksjonsendring.