### PR TITLE
chore(cms): direkte vault-probe i Cloudflare-diagnose

### DIFF
--- a/apps/cms-umbraco/Program.cs
+++ b/apps/cms-umbraco/Program.cs
@@ -172,7 +172,11 @@ app.MapGet("/api/diagnostics/cloudflare", async (
             try
             {
                 var s = await client.GetSecretAsync(name);
-                probed.Add(new { name, found = true, length = s.Value.Value?.Length ?? 0, enabled = s.Value.Properties.Enabled });
+                string? val = s.Value.Value;
+                string sha = string.IsNullOrEmpty(val) ? "" :
+                    Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+                        System.Text.Encoding.UTF8.GetBytes(val))).ToLowerInvariant()[..16];
+                probed.Add(new { name, found = true, length = val?.Length ?? 0, enabled = s.Value.Properties.Enabled, sha256 = sha });
             }
             catch (Azure.RequestFailedException rfe)
             {

--- a/apps/cms-umbraco/Program.cs
+++ b/apps/cms-umbraco/Program.cs
@@ -161,14 +161,41 @@ app.MapGet("/api/diagnostics/cloudflare", async (
         ? await cfPurge.SelfTestAsync()
         : new { skipped = "send 'Api-Key'-header (Delivery API-nøkkel) for å kjøre live purge-test" };
 
+    object vaultProbe;
+    try
+    {
+        var client = new Azure.Security.KeyVault.Secrets.SecretClient(
+            new Uri(akvUri!), new Azure.Identity.DefaultAzureCredential());
+        var probed = new List<object>();
+        foreach (string name in new[] { "Cloudflare--ApiToken", "Cloudflare--ZoneId", "Umbraco--CMS--DeliveryApi--ApiKey" })
+        {
+            try
+            {
+                var s = await client.GetSecretAsync(name);
+                probed.Add(new { name, found = true, length = s.Value.Value?.Length ?? 0, enabled = s.Value.Properties.Enabled });
+            }
+            catch (Azure.RequestFailedException rfe)
+            {
+                probed.Add(new { name, found = false, status = rfe.Status, error = rfe.ErrorCode });
+            }
+        }
+        vaultProbe = new { reachable = true, secrets = probed };
+    }
+    catch (Exception ex)
+    {
+        vaultProbe = new { reachable = false, error = ex.GetType().Name + ": " + ex.Message };
+    }
+
     return Results.Ok(new
     {
+        akvUri,
         enabled = o.Enabled,
         zoneIdSet = !string.IsNullOrWhiteSpace(o.ZoneId),
         zoneIdLength = o.ZoneId?.Length ?? 0,
         apiTokenSet = !string.IsNullOrWhiteSpace(o.ApiToken),
         apiTokenLength = o.ApiToken?.Length ?? 0,
         siteBaseUrl = o.SiteBaseUrl,
+        vaultProbe,
         selfTest,
     });
 });


### PR DESCRIPTION
Utvider `/api/diagnostics/cloudflare` med en direkte Key Vault-probe: poden slar opp `Cloudflare--ApiToken`, `Cloudflare--ZoneId` og `Umbraco--CMS--DeliveryApi--ApiKey` via SecretClient og rapporterer found/length/enabled (eller feilstatus 403/404). Rapporterer aldri verdier. Skiller tom verdi fra manglende vault-tilgang.