### PR TITLE
feat(cms): la uSync eie skjema på tt02 (tt02-pilot)

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -110,6 +110,15 @@ public class ContentTypeComponent : IAsyncComponent
     {
         if (_runtimeState.Level < RuntimeLevel.Run) return Task.CompletedTask;
 
+        // Når uSync eier skjemaet (kun tt02-piloten) må composeren ikke asserte content-typer,
+        // ellers racer den uSync-importen og gir typene tilfeldige nøkler. Fraværende env-var =
+        // uendret oppførsel, så prod er urørt.
+        if (string.Equals(Environment.GetEnvironmentVariable("USYNC_OWNS_SCHEMA"), "true", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("ContentTypeComposer: USYNC_OWNS_SCHEMA=true, hopper over skjema-asserting (uSync eier skjemaet).");
+            return Task.CompletedTask;
+        }
+
         try
         {
             Step("resolveDataTypes", () => ResolveDataTypes());

--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -103,7 +103,11 @@
       "ExportAtStartup": "None",
       "ExportOnSave": "None",
       "ImportOnFirstBoot": false,
-      "UIEnabledGroups": "Content",
+      // Skjema-handlerne ligger i Settings-gruppa. Uten den her vises bare
+      // innholds-handlerne i uSync-dashbordet, og skjema kan ikke eksporteres
+      // fra backoffice. Trygt i prod: Default-settet er eksport-only, så
+      // Import-knappen er en død no-op også for skjema.
+      "UIEnabledGroups": "Content,Settings",
       "DefaultSet": "Default"
     },
     "Sets": {

--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -92,10 +92,11 @@
     "TimeoutSeconds": 5,
     "AffectedUrlThreshold": 30
   },
-  // uSync brukes kun til manuell innholdsspeiling fra prod til tt02.
-  // Skjema eies av ContentTypeComposer, derfor er alle handlers av som
-  // standard og kun innhold og media slått på. All automatikk er av, uSync
-  // gjør ingenting før en admin kjører eksport eller import i backoffice.
+  // uSync speiler innhold, media og skjema fra prod til tt02. Prod eier skjemaet
+  // via ContentTypeComposer (Default-settet er read-only). tt02 kan la uSync eie
+  // skjemaet (Speiling-settet + env USYNC_OWNS_SCHEMA=true, se kustomization).
+  // All automatikk er av, uSync gjør ingenting før en admin kjører eksport eller
+  // import i backoffice.
   "uSync": {
     "Settings": {
       "ImportAtStartup": "None",
@@ -106,24 +107,32 @@
       "DefaultSet": "Default"
     },
     "Sets": {
-      // Standard for ALLE miljø (inkl. prod): KUN eksport. Import-handlingen er
-      // skrudd av (Actions: ["Export"]), så Import-knappen i prod blir en død
-      // no-op og selv API-import blokkeres. Fail-safe: et miljø kan bare
-      // importere hvis det eksplisitt peker DefaultSet til "Speiling".
+      // Standard for ALLE miljø (inkl. prod): KUN eksport, også for skjema.
+      // Import er av (Actions: ["Export"]), så Import-knappen i prod er en død
+      // no-op og selv API-import blokkeres, også om en import-trigger skulle
+      // lekke. Skjema-eksport er read-only (skriver filer, rører ikke databasen)
+      // og brukes til å fange prod sine content-type-nøkler for speiling til tt02.
       "Default": {
         "HandlerDefaults": { "Enabled": false },
         "Handlers": {
           "ContentHandler": { "Enabled": true, "Actions": [ "Export" ] },
-          "MediaHandler": { "Enabled": true, "Actions": [ "Export" ] }
+          "MediaHandler": { "Enabled": true, "Actions": [ "Export" ] },
+          "ContentTypeHandler": { "Enabled": true, "Actions": [ "Export" ] },
+          "DataTypeHandler": { "Enabled": true, "Actions": [ "Export" ] }
         }
       },
-      // Import + eksport. Brukes KUN av tt02 via env-var
+      // Import + eksport, også skjema. Brukes KUN av tt02 via env-var
       // uSync__Settings__DefaultSet=Speiling (syncroot/tt02/kustomization.yaml).
+      // Sammen med USYNC_OWNS_SCHEMA=true lar dette uSync opprette content-typene
+      // fra prod-eksportens filer med prod sine nøkler, så artikkelmodulene løser
+      // seg i speilet innhold.
       "Speiling": {
         "HandlerDefaults": { "Enabled": false },
         "Handlers": {
           "ContentHandler": { "Enabled": true, "Actions": [ "All" ] },
-          "MediaHandler": { "Enabled": true, "Actions": [ "All" ] }
+          "MediaHandler": { "Enabled": true, "Actions": [ "All" ] },
+          "ContentTypeHandler": { "Enabled": true, "Actions": [ "All" ] },
+          "DataTypeHandler": { "Enabled": true, "Actions": [ "All" ] }
         }
       }
     }

--- a/docs/usync-tt02-pilot.md
+++ b/docs/usync-tt02-pilot.md
@@ -1,0 +1,58 @@
+# uSync tt02-pilot (uSync eier skjema på tt02, composer på prod)
+
+Lar tt02 speile prod sitt skjema i tillegg til innhold og media, så
+artikkelmodulene løser seg i speilet innhold. Prod er urørt og eier fortsatt
+skjemaet via `ContentTypeComposer`.
+
+## Bakgrunn
+
+`ContentTypeComposer` lager content-typer uten fast `.Key`, så Umbraco gir dem
+tilfeldige nøkler per miljø. Speilet prod-innhold refererer blokker via nøkkel,
+og prod-nøklene finnes ikke på tt02, så modulene vises som «Unsupported».
+
+uSync bruker fil-nøkkelen kun når den selv oppretter typen. Skrur vi av
+composer-skjemaet på tt02 (`USYNC_OWNS_SCHEMA=true`) og lar uSync importere
+prod-eksporten, opprettes typene med prod sine nøkler og modulene løser seg.
+
+## Hva PR-en endrer
+
+- `ContentTypeComponent`: hopper over skjema-asserting når
+  `USYNC_OWNS_SCHEMA=true`. Fraværende env-var = composeren kjører som før.
+- `appsettings.json`: `ContentTypeHandler` + `DataTypeHandler` lagt til begge
+  uSync-sett. `Default` er eksport-only (read-only), `Speiling` har import.
+- `syncroot/tt02/kustomization.yaml`: setter `USYNC_OWNS_SCHEMA=true`. Prod sin
+  kustomization er urørt.
+
+## Prod-sikkerhet
+
+- Skjema-bryteren er env-gated til tt02. Prod mangler env-varen, så composeren
+  asserter skjema som i dag.
+- Prod sitt `Default`-sett er eksport-only for alle handlers. Import er
+  strukturelt blokkert (`IsValidAction(Import, ["Export"])` = false), også om en
+  import-trigger skulle lekke inn.
+- Skjema-eksport er read-only. Den skriver filer, rører ikke databasen.
+- Ingen oppstarts-triggere. uSync gjør ingenting før en admin kjører eksport
+  eller import i backoffice.
+
+## Kjøre piloten (manuelt, tt02)
+
+1. Deploy imaget til tt02 (composer-skjema av der via kustomization).
+2. Tøm tt02 sitt composer-skjema, ellers blokkerer de gamle tt02-nøklene
+   importen. Fersk database eller slett content-typene i tt02-backoffice.
+3. Prod backoffice, Settings, uSync, Export. Gir skjema + innhold + media som
+   filer under `/app/uSync`.
+4. `scripts/sync-prod-til-tt02.sh innhold` (eller `alt` for media også).
+   Transporterer hele `/app/uSync` inkludert ContentTypes og DataTypes.
+5. tt02 backoffice, Settings, uSync, Import (aldri clean). Speiling-settet
+   oppretter typene med prod sine nøkler og importerer innholdet.
+
+Bruk Import-knappen, ikke en oppstarts-import. `ImportAtStartup` respekterer ikke
+`DefaultSet=Speiling` og kjører mot det eksport-only Default-settet.
+
+## Kjente forbehold
+
+- tt02-skjemaet blir et snapshot av prod sitt composer-skjema. Endrer composeren
+  skjema i en ny prod-deploy, må prod re-eksporteres og tt02 re-importeres.
+- Noen noder med `bakgrunn`-felt publiseres ikke ved import (blir kladd) fordi
+  verdien ikke validerer mot datatype-configen. Egen content-sak, gjelder også
+  dagens innholdsspeiling.

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
         value:
           name: uSync__Settings__DefaultSet
           value: Speiling
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USYNC_OWNS_SCHEMA
+          value: "true"
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
Lar tt02 speile prod sitt skjema i tillegg til innhold og media, så artikkelmodulene løser seg i speilet innhold. I dag blir de «Unsupported» fordi ContentTypeComposer gir content-typene tilfeldige nøkler per miljø, og speilet prod-innhold refererer prod sine nøkler.

Med `USYNC_OWNS_SCHEMA=true` på tt02 står composer-skjemaet av der, og uSync oppretter typene fra prod-eksporten med prod sine nøkler.

## Endringer
- `ContentTypeComponent` hopper over skjema-asserting når `USYNC_OWNS_SCHEMA=true`
- `ContentTypeHandler` + `DataTypeHandler` lagt til begge uSync-sett (Default eksport-only, Speiling import)
- tt02-kustomization setter `USYNC_OWNS_SCHEMA=true`
- `docs/usync-tt02-pilot.md` med kjøre-runbook

## Prod-sikkerhet
- Skjema-bryteren er env-gated til tt02. Prod mangler env-varen, så composeren asserter skjema som i dag.
- Eneste prod-endring er at Default-settet kan eksportere skjema. Det er read-only, skriver filer og rører ikke databasen.
- Import er strukturelt blokkert i prod (Default er eksport-only), også om en import-trigger skulle lekke.
- Ingen oppstarts-triggere. Speiling skjer manuelt i backoffice.