### PR TITLE
docs: rett omtaler av ruter som ikke finnes (/kontakt /faq /sok)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ Frontend henter innhold via Umbraco Delivery API v2. Prod-databasen er Azure SQL
 **Stack:** Astro (server mode) + React (islands) + @digdir/designsystemet-react + @digdir/designsystemet-css
 
 **Sider** (`apps/frontend/src/pages/`)
-- Forsiden, artikler, eksempler, veiledning (guide + steg), sandkasse, FAQ, kontakt, om-oss, ki-ordbok, søk, status (admin-only)
-- Dynamiske ruter: `artikler/[slug]`, `eksempler/[slug]`, `veiledning/[guide]`, `veiledning/[guide]/[step]`
+- Forsiden, artikler, eksempler, kalender, veiledning (guide + steg), sandkasse, om-oss, status (admin-only)
+- Dynamiske ruter: `artikler/[slug]`, `eksempler/[slug]`, `kalender/[slug]`, `veiledning/[guide]`, `veiledning/[guide]/[step]`, og toppnivå `[slug]` (CMS `side`-noder)
+- Søk er en modal (`SearchDialog`, kaller `/api/search`), ikke en egen side. Det finnes IKKE en `/kontakt`-, `/faq`-, `/sok`- eller `/ki-ordbok`-side i koden. Footer har en "Kontakt oss"-seksjon, men ingen kontaktside.
 
 **Nøkkelfiler**
 - `src/lib/umbraco.ts` — all datahenting fra CMS. Interfaces, fetch-funksjoner, mapItem() som mapper content types til TypeScript-typer

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pnpm run dev
 | Type | Content Type Alias | Description |
 |------|-------------------|-------------|
 | Artikkel | `artikkel` | News articles |
-| Side | `side` | Static pages (om-oss, kontakt, sandkasse) |
+| Side | `side` | Static pages (om-oss, sandkasse) |
 | Eksempel | `eksempel` | AI case studies |
 | Veiledning | `veiledning` | Guidance documents |
 
@@ -110,8 +110,6 @@ Content is fetched via the Umbraco Content Delivery API v2 at `/umbraco/delivery
 | `/eksempler/send-inn` | — | Entire page (submission form) |
 | `/veiledning` | Veiledning list, categories | Page layout, category icons |
 | `/veiledning/[slug]` | Veiledning content (blocks) | Page template |
-| `/faq` | FAQ items, categories | Page layout, accordion, filter pills |
-| `/kontakt` | Page content (blocks) | Page template |
 | `/om-oss` | Page content (blocks) | Partner cards, offerings grid |
 | `/sandkasse` | Optional page content | Feature cards, process steps |
 | `/404` | — | Entire page |

--- a/dokumentasjon/hybrid-search.md
+++ b/dokumentasjon/hybrid-search.md
@@ -11,8 +11,8 @@ apps/cms-umbraco (Umbraco) ──publish/unpublish/trash──▶  Elastic index
    extractor + event handlers      push                  (semantic_text + norwegian analyzer)
    + /search/reindex (backfill)                                   │
                                                                   │
-/sok  ──hybridSearch()──▶ /ki-content/_search  ───────────────────┘
-(SSR, apps/frontend)      linear 0.4 bm25 / 0.6 dense (no reranker)
+/api/search ──hybridSearch()──▶ /ki-content/_search  ─────────────┘
+(SearchDialog modal)      linear 0.4 bm25 / 0.6 dense (no reranker)
 ```
 
 ### Ingestion (push) — `apps/cms-umbraco/Search/`
@@ -31,9 +31,9 @@ The index mapping is an Elasticsearch **component + index template** (versioned 
 
 ### Retrieval + surface — `apps/frontend/`
 - **`src/lib/search.ts`** — `hybridSearch(query)`: the `linear` 0.4/0.6 retriever, **no reranker** (golden-set Hit@3 ≈ 87% / MRR 0.838 — see `infrastructure/elasticsearch/eval/BASELINE.md`), via `fetch` (Workers-safe). Falls back to Umbraco search when ES is unconfigured.
-- **`src/pages/sok.astro`** — search page (SSR): reads `?q=`, calls `hybridSearch`, shows ranked hits (type badge + title + excerpt), links via the `url` (made relative for same-host nav).
-- **`src/pages/api/search.ts`** — `POST { query } → { results }` for optional client use.
-- **Header** — a search icon linking to `/sok`.
+- **`src/pages/api/search.ts`** — `POST { query } → { results }`: calls `hybridSearch`, the search surface's only entry point.
+- **`src/components/shared/SearchDialog.tsx`** — search modal (React island, `client:load`): opened from the Header (search icon + Ctrl/Cmd+K), POSTs to `/api/search`, shows ranked hits (type badge + title + excerpt), links via the `url` (made relative for same-host nav). There is no `/sok` page.
+- **Header** — a search icon (+ Ctrl/Cmd+K) that opens the modal.
 
 ## Configuration (env)
 | Var | Where | Default |
@@ -49,7 +49,7 @@ Secrets stay out of git: the CMS reads them from Azure Key Vault (`Elasticsearch
 1. **Templates:** `apply-templates.mjs` → `POST {ES}/_index_template/_simulate_index/ki-content` resolves `body_semantic` to `semantic_text` via `e5-large-incluster` (in-cluster). ✓ (verified)
 2. **CMS compiles:** `dotnet build apps/cms-umbraco`. ✓ (verified — 0 errors)
 3. **Push E2E (staging):** publish a node in the CMS → it appears in `ki-content` (`GET {ES}/ki-content/_count` increments; the doc embeds `body_semantic`). Needs a CMS instance with content — the local dev DB is empty.
-4. **Retrieval:** `apps/frontend` `pnpm dev` → `/sok?q=…` returns ranked hits; keyword + paraphrase both hit the right page.
+4. **Retrieval:** `apps/frontend` `pnpm dev` → open the search modal (Ctrl/Cmd+K) and query; keyword + paraphrase both hit the right page.
 
 ## Production notes
 - **Keys:** scoped, read-only ES key for the frontend (retrieval); a write-capable key for the CMS. Rotate the spike admin key before non-demo use.


### PR DESCRIPTION
`/kontakt`, `/faq` og `/sok` finnes ikke i koden (ingen sidefiler, alle 404 live, søk er en modal). Omtaler i dokumentasjonen fikk Claude Code til å tro at de var ekte sider.

- **CLAUDE.md**: korrekt sideliste + eksplisitt note om at rutene ikke finnes og at søk er en modal (`SearchDialog` → `/api/search`)
- **README.md**: fjernet `/faq`- og `/kontakt`-radene fra rutetabellen
- **hybrid-search.md**: oppdatert "Retrieval + surface" til `SearchDialog`-modal mot `/api/search` (beskrev en `sok.astro`-side som ikke finnes)

Oppfølger til #575 (som fjernet de crawler-vendte omtalene i llm.txt/robots/sitemap).