### PR TITLE
chore: fjern gjenværende omtaler av ruter som ikke finnes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Content is fetched via the Umbraco Content Delivery API v2 at `/umbraco/delivery
 | `/artikler/[slug]` | Article content (rich text blocks) | Page template, TOC |
 | `/eksempler` | Example list, status, tools | Page layout, status badges, filters |
 | `/eksempler/[slug]` | Example content, metadata | Page template, related cases |
-| `/eksempler/send-inn` | — | Entire page (submission form) |
 | `/veiledning` | Veiledning list, categories | Page layout, category icons |
 | `/veiledning/[slug]` | Veiledning content (blocks) | Page template |
 | `/om-oss` | Page content (blocks) | Partner cards, offerings grid |

--- a/apps/frontend/public/llm.txt
+++ b/apps/frontend/public/llm.txt
@@ -53,11 +53,6 @@ Mange sider henter innhold fra Strapi CMS. Hvis CMS ikke er tilgjengelig eller i
 - Type: Dynamisk generert fra Strapi CMS
 - Krever publisert innhold i CMS for å fungere
 
-### /eksempler/send-inn
-- Forventet:
-  - H1: "Send inn eksempel"
-  - Skjema med obligatoriske felt
-
 ### /artikler
 - Forventet:
   - H1: "Siste nytt"

--- a/apps/frontend/src/lib/content-routes.test.ts
+++ b/apps/frontend/src/lib/content-routes.test.ts
@@ -21,7 +21,7 @@ describe('buildUrlForContent', () => {
       ['eksempel', 'min-case', '/eksempler/min-case'],
       ['enkelVeiledning', 'kom-igang', '/veiledning/kom-igang'],
       ['veiledningGuide', 'sett-igang-med-ki', '/veiledning/sett-igang-med-ki'],
-      ['side', 'kontakt', '/kontakt'],
+      ['side', 'en-side', '/en-side'],
       ['kalenderhendelse', 'markedsdialog', '/kalender/markedsdialog'],
     ])('%s med slug %s → %s', (type, slug, expected) => {
       expect(buildUrlForContent(item(type, slug), [])).toBe(expected);

--- a/apps/frontend/src/lib/sitemap.test.ts
+++ b/apps/frontend/src/lib/sitemap.test.ts
@@ -128,7 +128,7 @@ describe('collectSitemapUrls via generateSitemapXml', () => {
   test('output er velformet sitemap 0.9 med absolutte loc-er', async () => {
     const nodes: RawContentNode[] = [
       { id: '1', contentType: 'artikkel', updateDate: '2026-02-01T10:00:00Z', properties: { slug: 'a' } },
-      { id: '2', contentType: 'side', properties: { slug: 'kontakt' } },
+      { id: '2', contentType: 'side', properties: { slug: 'en-side' } },
     ];
     const { xml } = await sitemapFor(nodes);
 

--- a/apps/frontend/tests/workflow.spec.ts
+++ b/apps/frontend/tests/workflow.spec.ts
@@ -467,7 +467,7 @@ test.describe('Seeded content', () => {
     );
   });
 
-  test('3 pages are published (Om oss, Kontakt, Sandkasse)', async ({
+  test('2 pages are published (Om oss, Sandkasse)', async ({
     request,
   }) => {
     const res = await request.get(api, {
@@ -475,11 +475,10 @@ test.describe('Seeded content', () => {
       ignoreHTTPSErrors: true,
     });
     const { total, items } = await res.json();
-    expect(total).toBe(3);
+    expect(total).toBe(2);
 
     const slugs = items.map((i: any) => i.properties.slug);
     expect(slugs).toContain('om-oss');
-    expect(slugs).toContain('kontakt');
     expect(slugs).toContain('sandkasse');
   });
 

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -91,13 +91,10 @@ ki.norge.no/
 ├── /sandkasse (Regulatory sandbox)
 │   └── /sandkasse/prosjekter (Sandbox projects)
 ├── /eksempler (Case studies)
-│   ├── /eksempler/[slug] (Individual cases)
-│   └── /eksempler/send-inn (Submit form)
+│   └── /eksempler/[slug] (Individual cases)
 ├── /artikler (News/articles)
 │   └── /artikler/[slug] (Individual articles)
-├── /faq (FAQ)
-├── /om-oss (About)
-└── /kontakt (Contact)
+└── /om-oss (About)
 ```
 
 ---
@@ -160,7 +157,7 @@ ki.norge.no/
 ### Navigation Header
 - Sticky positioning
 - Logo (left): "KI Norge" linking to homepage
-- Navigation links (right): Veiledning, Sandkasse, Eksempler, Artikler, Om oss, Kontakt
+- Navigation links (right): Veiledning, Sandkasse, Eksempler, Artikler, Om oss
 - Active state: underline or accent color
 - Mobile: hamburger menu (collapsible)
 
@@ -169,7 +166,7 @@ ki.norge.no/
 - 4 columns:
   1. About KI Norge (brief)
   2. Partners (Nkom, Datatilsynet, Digdir logos/links)
-  3. Quick links (FAQ, Contact)
+  3. Quick links
   4. Legal (Privacy, Accessibility statement)
 - Copyright at bottom
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -148,7 +148,7 @@ Disse er allerede satt i `appsettings.Production.json`:
 
 ## Cloudflare Pages — Frontend
 
-Frontenden (Astro) deployes til Cloudflare Pages. Statiske sider serveres fra CDN, SSR-sider (`/sok`, `/api/preview`) kjører som Cloudflare Workers.
+Frontenden (Astro) deployes til Cloudflare Pages. Statiske sider serveres fra CDN, SSR-sider (`/api/search`, `/api/preview`) kjører som Cloudflare Workers.
 
 ### Alternativ A: Koble til GitHub (anbefalt)
 
@@ -187,7 +187,7 @@ Etter første deploy, legg til custom domain i Cloudflare Pages → Custom domai
 Cloudflare Pages Free inkluderer:
 - 500 bygg per måned
 - Ubegrenset båndbredde for statiske sider
-- 100 000 Worker-requests per dag (for `/sok` og `/api/preview`)
+- 100 000 Worker-requests per dag (for `/api/search` og `/api/preview`)
 - DDoS-beskyttelse og CDN
 
 ---

--- a/docs/technical-review.md
+++ b/docs/technical-review.md
@@ -22,7 +22,7 @@ Last updated: 2026-02-13
 | **CSS** | Scoped CSS + DS tokens | Good | N/A — clean pattern, dark mode overrides eliminated |
 | **Dark Mode** | CSS custom properties | Good | N/A — auto-switching via DS tokens, localStorage persistence, prefers-color-scheme respect |
 | **Rendering (SSG)** | Prerendered pages | Good | N/A — correct for a content site |
-| **Rendering (SSR)** | `/sok` + `/api/preview` | Good | N/A — only dynamic where needed |
+| **Rendering (SSR)** | `/api/search` + `/api/preview` | Good | N/A — only dynamic where needed |
 | **API Client** | umbraco.ts | Needs work | No fetch timeouts, no retries, no caching. `fetchBySlug` fetches ALL items then filters client-side (O(n)). Add `AbortSignal.timeout(5000)`, retry with backoff, and server-side slug filtering |
 | **SEO — Meta** | OG, Twitter Card, canonical, JSON-LD | Good | Open Graph, Twitter Card, canonical URL on all pages. JSON-LD: FAQPage, Article, WebSite+SearchAction. OG image can be added when designed. |
 | **SEO — Sitemap** | @astrojs/sitemap | Good | N/A — auto-generated, referenced in robots.txt |
@@ -32,7 +32,7 @@ Last updated: 2026-02-13
 | **Performance — Images** | CSS background-image | **Weak** | No `<img>` tags with width/height (causes layout shift), no `loading="lazy"`, no responsive `srcset`, no image optimization. Switch to `<img>` or Astro's `<Image>` component |
 | **Performance — Fonts** | Preconnect + display=swap | Good | N/A — proper preconnect to Google Fonts, swap prevents blocking |
 | **Performance — JS** | Astro islands | Good | N/A — minimal client JS, most components are server-rendered |
-| **Testing** | Playwright 1.44 | Good | 81 tests passing. Consider adding tests for `/sok` search results and 404 page |
+| **Testing** | Playwright 1.44 | Good | 81 tests passing. Consider adding tests for search results and 404 page |
 | **Test Browsers** | 6 projects | Good | N/A — Chrome/Firefox/Safari + dark + mobile variants |
 | **Frontend Hosting** | Cloudflare Pages | OK | No `wrangler.toml` in repo — deployment config is cloud-only. Add config to git for reproducible deploys |
 | **CMS Hosting** | Azure (planned) | Not started | No Azure config, no Dockerfile, no deployment pipeline. Needs setup before production |
@@ -58,7 +58,7 @@ Tasks we can do right now, ordered by impact and urgency.
 
 3. ~~**Add SEO meta tags to Layout.astro**~~ — DONE. Added Open Graph, Twitter Card, canonical URL. Article pages pass `ogType="article"` and `publishedAt`.
 
-4. ~~**Add JSON-LD structured data**~~ — DONE. FAQPage schema on `/faq`, Article schema on `/artikler/[slug]`, WebSite+SearchAction on homepage.
+4. ~~**Add JSON-LD structured data**~~ — DONE. Article schema on `/artikler/[slug]`, WebSite+SearchAction on homepage.
 
 5. ~~**CMS-editable SEO fields**~~ — DONE. Added `seoTittel`, `seoBeskrivelse`, `seoBilde` to Artikkel, Eksempel, Veiledning, Side. Mapped in `umbraco.ts`, used in all page templates with auto-generated fallbacks. Note: existing databases need a fresh install to pick up the new content type fields.
 
@@ -76,7 +76,7 @@ Tasks we can do right now, ordered by impact and urgency.
 
 ### P3 — Low (nice to have)
 
-11. **Add Playwright tests for /sok and /404** — These pages exist but aren't covered by visual regression tests. Quick wins for test coverage.
+11. **Add Playwright tests for /404** — Not covered by visual regression tests. Quick win for test coverage.
 
 12. **Self-host Material Symbols font** — Currently loaded from Google Fonts CDN. Self-hosting removes the external dependency and the DNS lookup, slightly improving first paint.
 


### PR DESCRIPTION
Oppfølger til #575/#576. Fjerner de siste omtalene av `/kontakt`, `/faq`, `/sok` og `/eksempler/send-inn` som fikk Claude Code til å tro at de var ekte sider. Ingen av dem finnes i koden (ingen sidefiler; alle gir 404 eller redirect).

- **llm.txt + README**: fjernet `/eksempler/send-inn` (redirecter til `/eksempler`, det finnes ingen innsendingsside)
- **DESIGN_SPEC.md**: fjernet `/faq`, `/kontakt`, `send-inn` fra sidetre, nav og footer
- **azure-deployment.md, technical-review.md**: `/sok` → `/api/search` (faktisk SSR-rute), fjernet `/faq`-ruteomtaler
- **tester**: nøytral eksempel-slug i stedet for `kontakt` (content-routes, sitemap), fjernet kontakt-forventning i workflow.spec

Beholdt bevisst: `faq`-innholdstypen, footer "Kontakt oss", `eksempelKontakt`-CTA, og `seeder-content-write-audit.md` (historisk logg over fjernet seeder-kode).

Full vitest-suite grønn lokalt (149).