### PR TITLE
chore(syncroot): add OTEL environment variables for umbraco

### DIFF
--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -40,6 +40,19 @@ spec:
               value: "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True"
             - name: ConnectionStrings__umbracoDbDSN_ProviderName
               value: "Microsoft.Data.Sqlite"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector.monitoring.svc.cluster.local:4317
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: grpc
+            - name: OTEL_SERVICE_NAME
+              value: kinorgeportal
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Adds OTEL environment variables to the umbraco deployment (`syncroot/base`) so the CMS exports telemetry to the cluster's otel-collector. Mirrors the infoportal setup.

### Changes
- `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` (grpc), `OTEL_SERVICE_NAME` (`kinorgeportal`)
- `POD_UID` via downward API and `OTEL_RESOURCE_ATTRIBUTES`
- Placed in `base`, so it is identical for all environments (prod and tt02)

### Verification
- `kustomize build prod` and `kustomize build tt02` build without errors
- The variables render in both environments

Part of #569 (monitoring/alerting, make it like infoportal).
