### PR TITLE
fix(cms): sett UpgradeUnattended slik at migreringer kjører ved oppstart

### DIFF
--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -57,6 +57,11 @@
       "Hosting": {
         "Debug": false
       },
+      "Unattended": {
+        // Uten denne hopper Umbraco over ventende databasemigreringer ved
+        // oppstart, og Delivery API svarer 200 OK med tom liste.
+        "UpgradeUnattended": true
+      },
       "Runtime": {
         "MaxRequestLength": 102400
       },

--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -31,6 +31,10 @@ spec:
           env:
             - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
               value: "true"
+            # Uten denne hopper Umbraco over ventende databasemigreringer ved
+            # oppstart, og Delivery API svarer 200 OK med tom liste.
+            - name: Umbraco__CMS__Unattended__UpgradeUnattended
+              value: "true"
             - name: KeyVault__AkvUri
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Umbraco kjører ventende databasemigreringer ved oppstart kun når
`Umbraco:CMS:Unattended:UpgradeUnattended` er `true`. Flagget er ikke satt noe
sted i dis-core-oppsettet i dag.

Uten flagget starter containeren normalt, men migreringene hoppes over. Delivery
API svarer da 200 OK med tom liste i stedet for å feile, så frontend rendrer
tomt innhold uten at noe logges som feil.

Flagget ble satt av `scripts/deploy-azure.sh` på det gamle Container Apps-oppsettet.
Det skriptet er fjernet, og verdien ble aldri flyttet over til dis-core.

Satt i `appsettings.json`, samme mønster som info.altinn.no (som har hatt
flagget der hele tiden). Da følger verdien imaget uansett deploy-mekanisme,
i stedet for å ligge i plattform-config som kan falle bort ved omlegginger.