### PR TITLE
chore(cms): pin Microsoft.OpenApi over sårbar transitiv 2.4.1

### DIFF
--- a/apps/cms-umbraco/KiNorge.Cms.csproj
+++ b/apps/cms-umbraco/KiNorge.Cms.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Kjac.HeadlessPreview" Version="3.0.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+    <!-- Transitiv via Umbraco. Pinnet over sårbar 2.4.1 (GHSA-v5pm-xwqc-g5wc);
+         fjern når Umbraco selv drar >= 2.7.5. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Umbraco.Cms" Version="17.5.3" />
     <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.5.3" />
     <PackageReference Include="uSync" Version="17.3.5" />


### PR DESCRIPTION
Umbraco 17.5.3 drar inn Microsoft.OpenApi 2.4.1 transitivt. Den har en kjent
høy-alvorlighets sårbarhet (GHSA-v5pm-xwqc-g5wc): sirkulære skjemareferanser
kan terminere OpenAPI-parsing. Fikset i 2.7.5, samme major, så pinnen er en
minor-oppgradering av en transitiv avhengighet.

Pinnen fjernes når Umbraco selv drar >= 2.7.5 (kommentar i csproj).

Verifisert lokalt med pin: CMS booter, swagger-dokumentene for både delivery
(8 paths) og management (378 paths) genereres som gyldig OpenAPI 3.0.4, og
Delivery API svarer 200.

Det andre NU1903-varselet (SQLitePCLRaw.lib.e_sqlite3, GHSA-2m69-gcr7-jv3q)
står igjen med vilje: ingen fikset versjon finnes ennå. SQLite brukes kun
lokalt; prod kjører Azure SQL.