### PR TITLE
fix(cms-proxy): rot-URL videresender til /umbraco

### DIFF
--- a/apps/cms-kinorgeportal/src/index.ts
+++ b/apps/cms-kinorgeportal/src/index.ts
@@ -6,6 +6,12 @@ export default {
   async fetch(request, env, ctx) {
     const targetBase = env.ORIGIN;
     const url = new URL(request.url);
+
+    // CMS-et er headless og har ingenting på rot; send folk til backoffice.
+    if (url.pathname === "/") {
+      return Response.redirect(`${url.origin}/umbraco`, 302);
+    }
+
     const targetUrl = targetBase + url.pathname + url.search;
     const incomingUrl = new URL(request.url);
 
@@ -13,8 +19,6 @@ export default {
     headers.set("Host", incomingUrl.host);
     headers.set("X-Forwarded-Host", incomingUrl.host);
     headers.set("X-Forwarded-Proto", incomingUrl.protocol.replace(":", ""));
-
-    const originRequest: Request = new Request(targetUrl, request);
 
     const proxyRequest = new Request(targetUrl.toString(), {
       method: request.method,

--- a/apps/cms-kinorgeportal/wrangler.jsonc
+++ b/apps/cms-kinorgeportal/wrangler.jsonc
@@ -4,16 +4,21 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-05-07",
   "compatibility_flags": ["nodejs_compat"],
-  "workers_dev": false,
+  // workers.dev-hostene MÅ være på: frontendens UMBRACO_PUBLIC_URL (media-URLer
+  // i nettleser) peker på cms-kinorgeportal-prod...workers.dev. De var skrudd på
+  // i dashboardet (drift); "false" her slo dem av ved neste deploy (2026-07-15).
+  "workers_dev": true,
   "env": {
     "tt02": {
       "name": "cms-kinorgeportal-tt02",
+      "workers_dev": true,
       "vars": {
         "ORIGIN": "https://kinorgeportal.tt02.dis-core.altinn.cloud",
       },
     },
     "prod": {
       "name": "cms-kinorgeportal-prod",
+      "workers_dev": true,
       "vars": {
         "ORIGIN": "https://kinorgeportal.prod.dis-core.altinn.cloud",
       },


### PR DESCRIPTION
CMS-et er headless og har ikke innhold på rot, så `cms.ki.norge.no/` traff
Umbracos "Page Not Found". Proxy-workeren svarer nå `302 -> /umbraco` på
eksakt rot-sti. Alle andre stier (backoffice, Delivery API, media) passerer
urørt. Fjernet også en ubrukt variabel i samme funksjon.

Verifisert på tt02 (worker deployd): `/` gir 302 til `/umbraco` som svarer
200; `/umbraco` og Delivery API svarer 200 som før.