### PR TITLE
fix(frontend): skjul tom arrangement-seksjon + la redaktør fjerne veiledningstitler

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -113,6 +113,8 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
   if (block.contentType === 'forsideArrangementer') {
     // Redaktørvalgt arrangement overstyrer auto. Tomt → neste kommende.
     const valgt = (block.arrangementId && upcomingEvents.find((e) => e.id === block.arrangementId)) || upcomingEvents[0] || null;
+    // Ingen kommende arrangementer → skjul hele seksjonen (ikke en tom overskrift + lenke).
+    if (!valgt) return null;
     return (
       <section class="arrangementer" data-layout-block="edge">
         <div class="arrangementer-section" data-layout-block="content">

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -38,7 +38,9 @@ const heroImageUrl = cmsData?.heroBilde ? getMediaUrl(cmsData.heroBilde, MEDIA_W
 const featuredTitle = cmsData?.seksjon1Kort?.[0]?.tittel || 'Hva er KI og hva kan du bruke det til?';
 const featuredDesc = cmsData?.seksjon1Kort?.[0]?.beskrivelse || 'Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.';
 const featuredHref = cmsData?.seksjon1Kort?.[0]?.url || '/veiledning/kom-i-gang';
-const featuredLabel = cmsData?.seksjon1Tittel || 'Kom i gang';
+// Ingen hardkodet fallback: redaktøren skal kunne fjerne tittelen helt (#494).
+// TextWithImage skjuler label-feltet når det er tomt.
+const featuredLabel = cmsData?.seksjon1Tittel;
 const featuredImage = heroImageUrl || '/woman-speaking.svg';
 
 // Rich link list — "Steg for steg"
@@ -104,7 +106,7 @@ const seoDesc = cmsData?.seoBeskrivelse || heroText;
   {richLinks.length > 0 && (
     <section class="veil-rich-links" data-layout-block="edge">
       <div data-layout-block="content">
-        <h2 class="ds-heading veil-section-heading" data-size="xs">{cmsData?.seksjon2Tittel || 'Steg for steg'}</h2>
+        {cmsData?.seksjon2Tittel && <h2 class="ds-heading veil-section-heading" data-size="xs">{cmsData.seksjon2Tittel}</h2>}
         <ul class="veil-rich-list">
           {richLinks.map((link) => {
             const id = `rich-link-${crypto.randomUUID().slice(0, 8)}`;


### PR DESCRIPTION
To små renderingsfikser fra bug-lista etter lansering (#539).

### Skjul tomt arrangement på forsiden (#564)
Arrangement-seksjonen viste overskrift og "Se alle arrangementer"-lenke også når det ikke fantes kommende arrangementer. Nå skjules hele seksjonen når det ikke er noe å vise, samme mønster som "Forstå regelverket". Redaktør slipper å fjerne modulen manuelt (som var dagens workaround).

### Fjern hardkodede veiledningstitler (#494)
Titlene "Kom i gang" og "Steg for steg" hadde fallback i koden, så et tomt felt falt tilbake til standardteksten. Fallbacken er fjernet slik at et tomt felt gir ingen tittel. Dagens innhold ser likt ut siden begge feltene er satt i prod. "Enkel liste" (seksjon 3) oppførte seg allerede slik.

Bygger grønt, alle 149 unit-tester passerer.

Closes #494