### PR TITLE
feat(veiledning): content-picker for lenker i veiledningsnavigasjon

### DIFF
--- a/apps/cms-umbraco/Composers/ContentTypeComposer.cs
+++ b/apps/cms-umbraco/Composers/ContentTypeComposer.cs
@@ -2899,10 +2899,11 @@ public class ContentTypeComponent : IAsyncComponent
             IsElement = true,
         };
         ct.AddPropertyGroup("innhold", "Innhold");
-        ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, mandatory: true), "innhold");
-        ct.AddPropertyType(Prop("beskrivelse", "Beskrivelse", _textStringDt), "innhold");
-        ct.AddPropertyType(Prop("url", "URL", _textStringDt), "innhold");
-        ct.AddPropertyType(Prop("ikon", "Ikon", _textStringDt, description: "Ikonnavn fra Aksel (f.eks. HandHeart, Package)"), "innhold");
+        ct.AddPropertyType(Prop("tittel", "Tittel", _textStringDt, mandatory: true, sortOrder: 0), "innhold");
+        ct.AddPropertyType(Prop("beskrivelse", "Beskrivelse", _textStringDt, sortOrder: 1), "innhold");
+        ct.AddPropertyType(Prop("lenke", "Lenke", _contentPickerDt, description: "Velg veiledning, artikkel eller eksempel. Overstyrer URL-feltet. Bruk URL for eksterne lenker.", sortOrder: 2), "innhold");
+        ct.AddPropertyType(Prop("url", "URL (ekstern lenke)", _textStringDt, sortOrder: 3), "innhold");
+        ct.AddPropertyType(Prop("ikon", "Ikon", _textStringDt, description: "Ikonnavn fra Aksel (f.eks. HandHeart, Package)", sortOrder: 4), "innhold");
         _contentTypeService.Save(ct);
         return ct;
     }
@@ -2911,9 +2912,28 @@ public class ContentTypeComponent : IAsyncComponent
     {
         var ct = _contentTypeService.Get("veiledningKort");
         if (ct == null) return;
-        if (ct.PropertyTypeExists("ikon")) return;
-        ct.AddPropertyType(Prop("ikon", "Ikon", _textStringDt, description: "Ikonnavn fra Aksel (f.eks. HandHeart, Package)"), "innhold");
-        _contentTypeService.Save(ct);
+        bool changed = false;
+        if (!ct.PropertyTypeExists("ikon"))
+        {
+            ct.AddPropertyType(Prop("ikon", "Ikon", _textStringDt, description: "Ikonnavn fra Aksel (f.eks. HandHeart, Package)"), "innhold");
+            changed = true;
+        }
+        // Lenke-picker så redaktør kan klikke seg til intern veiledning/artikkel/eksempel
+        // i stedet for å lime inn URL (#513). Additivt: URL-feltet og verdiene beholdes.
+        if (!ct.PropertyTypeExists("lenke"))
+        {
+            ct.AddPropertyType(Prop("lenke", "Lenke", _contentPickerDt, description: "Velg veiledning, artikkel eller eksempel. Overstyrer URL-feltet. Bruk URL for eksterne lenker."), "innhold");
+            changed = true;
+        }
+        var url = ct.PropertyTypes.FirstOrDefault(p => p.Alias == "url");
+        if (url != null && url.Name != "URL (ekstern lenke)") { url.Name = "URL (ekstern lenke)"; changed = true; }
+        // Kanonisk rekkefølge (picker rett over URL) så backoffice ser likt ut på ferske og migrerte noder.
+        foreach (var (alias, order) in new[] { ("tittel", 0), ("beskrivelse", 1), ("lenke", 2), ("url", 3), ("ikon", 4) })
+        {
+            var pt = ct.PropertyTypes.FirstOrDefault(p => p.Alias == alias);
+            if (pt != null && pt.SortOrder != order) { pt.SortOrder = order; changed = true; }
+        }
+        if (changed) _contentTypeService.Save(ct);
     }
 
     private IContentType CreateVerktoyKortElement()

--- a/apps/frontend/src/lib/umbraco.ts
+++ b/apps/frontend/src/lib/umbraco.ts
@@ -452,6 +452,8 @@ export interface Sandkasse {
 export interface VeiledningKort {
   tittel: string;
   beskrivelse?: string;
+  /** Content-picker: id på valgt veiledning/artikkel/eksempel. Løses til URL via pool. Overstyrer url. */
+  lenkeId?: string;
   url?: string;
   ikon?: string;
 }
@@ -1525,6 +1527,7 @@ function mapVeiledningKort(value: unknown): VeiledningKort[] {
     return {
       tittel: (props.tittel as string) || '',
       beskrivelse: (props.beskrivelse as string) || undefined,
+      lenkeId: pickerId(props.lenke),
       url: (props.url as string) || undefined,
       ikon: (props.ikon as string) || undefined,
     };

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -9,7 +9,7 @@ import TextWithImage from '../../components/shared/TextWithImage.astro';
 import ExampleLinkCards from '../../components/shared/ExampleLinkCards.astro';
 import AkselIcon from '../../components/shared/AkselIcon.astro';
 import LinkList from '../../components/shared/LinkList.astro';
-import { getVeiledningOversikt, getVeiledningGuider, getEksempler, getMediaUrl, MEDIA_WIDTH } from '../../lib/umbraco';
+import { getVeiledningOversikt, getVeiledningGuider, getEksempler, getArtikler, getMediaUrl, MEDIA_WIDTH } from '../../lib/umbraco';
 import { splitLastWord } from '../../lib/text';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
@@ -17,12 +17,14 @@ const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('
 let cmsData: Awaited<ReturnType<typeof getVeiledningOversikt>> = null;
 let guides: Awaited<ReturnType<typeof getVeiledningGuider>> = { data: [], meta: { pagination: { page: 1, pageSize: 0, pageCount: 0, total: 0 } } };
 let cases: Awaited<ReturnType<typeof getEksempler>> = { data: [], meta: { pagination: { page: 1, pageSize: 0, pageCount: 0, total: 0 } } };
+let articles: Awaited<ReturnType<typeof getArtikler>> = { data: [], meta: { pagination: { page: 1, pageSize: 0, pageCount: 0, total: 0 } } };
 
 try {
-  [cmsData, guides, cases] = await Promise.all([
+  [cmsData, guides, cases, articles] = await Promise.all([
     getVeiledningOversikt({ preview: isPreview }),
     getVeiledningGuider({ preview: isPreview }),
     getEksempler({ preview: isPreview }),
+    getArtikler(100, { preview: isPreview }),
   ]);
 } catch (e) {
   console.error('Failed to fetch veiledning page data:', e);
@@ -34,10 +36,20 @@ const heroTitle = cmsData?.heroTittel || 'Veiledning og guider';
 const heroText = cmsData?.heroTekst || 'Lurer du på hva det er lurt å tenke på når du bruker KI eller lager KI-løsninger? Her finner du veiledninger laget og kvalitetssikret av jurister og andre fagfolk.';
 const heroImageUrl = cmsData?.heroBilde ? getMediaUrl(cmsData.heroBilde, MEDIA_WIDTH.hero) : undefined;
 
+// Redaktørvalgt lenke (content-picker, #513) løses mot hentede pools så vi bruker
+// frontend-slug (CMS-route kan avvike). Faller tilbake til det manuelle url-feltet.
+const lenkeById = new Map<string, string>([
+  ...guides.data.map((g): [string, string] => [g.id, `/veiledning/${g.slug}`]),
+  ...articles.data.map((a): [string, string] => [a.id, `/artikler/${a.slug}`]),
+  ...cases.data.map((c): [string, string] => [c.id, `/eksempler/${c.slug}`]),
+]);
+const resolveLenke = (kort?: { lenkeId?: string; url?: string }): string | undefined =>
+  (kort?.lenkeId ? lenkeById.get(kort.lenkeId) : undefined) ?? kort?.url ?? undefined;
+
 // Featured article — "Kom i gang"
 const featuredTitle = cmsData?.seksjon1Kort?.[0]?.tittel || 'Hva er KI og hva kan du bruke det til?';
 const featuredDesc = cmsData?.seksjon1Kort?.[0]?.beskrivelse || 'Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.';
-const featuredHref = cmsData?.seksjon1Kort?.[0]?.url || '/veiledning/kom-i-gang';
+const featuredHref = resolveLenke(cmsData?.seksjon1Kort?.[0]) || '/veiledning/kom-i-gang';
 // Ingen hardkodet fallback: redaktøren skal kunne fjerne tittelen helt (#494).
 // TextWithImage skjuler label-feltet når det er tomt.
 const featuredLabel = cmsData?.seksjon1Tittel;
@@ -51,7 +63,7 @@ const richLinks = (cmsData?.seksjon2Kort?.length ?? 0) > 0
   ? cmsData!.seksjon2Kort!.map(k => ({
       title: k.tittel,
       desc: k.beskrivelse || '',
-      href: k.url || '#',
+      href: resolveLenke(k) || '#',
     }))
   : guides.data.map(g => ({
       title: g.tittel,
@@ -63,7 +75,7 @@ const richLinks = (cmsData?.seksjon2Kort?.length ?? 0) > 0
 const simpleLinks = (cmsData?.seksjon3Kort?.length ?? 0) > 0
   ? cmsData!.seksjon3Kort!.map(k => ({
       title: k.tittel,
-      href: k.url || '#',
+      href: resolveLenke(k) || '#',
     }))
   : [
       { title: 'Hva innebærer KI-loven?', href: '/artikler/ki-loven' },


### PR DESCRIPTION
Sara meldte at hun ikke får lenket opp eksisterende veiledninger med et klikk på veiledningsnavigasjonen, kun ved å lime inn URL (#513).

- Nytt `lenke`-felt (content-picker) på `veiledningKort`-elementet. Redaktør velger veiledning, artikkel eller eksempel direkte i stedet for å lime inn URL.
- Frontend løser valgt innhold mot hentede pools og bygger URL fra frontend-slug. CMS-route kan avvike fra slug (f.eks. guide-route `/gjoer-dataene-ki-klare/` mot slug `gjor-dataene-ki-klare`), så pool-oppslag er nødvendig for riktig lenke.
- Siden henter nå også artikkel-poolen (seksjon 3 lenker til artikler).

Additivt: det eksisterende `url`-feltet og alle verdier beholdes, relabelet "URL (ekstern lenke)" og brukt som fallback. Ingen innholdsmigrering.

Closes #513