### PR TITLE
fix(frontend): skjul tag-boksen på eksempelkort når tag er tom (#623)

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -20,7 +20,7 @@ interface Props {
   eksempler?: any[];
   upcomingEvents?: Kalenderhendelse[];
   veiledninger?: VeiledningGuide[];
-  eksempelKort: { href: string; title: string; tag: string }[];
+  eksempelKort: { href: string; title: string; tag?: string }[];
 }
 const { seksjoner, latestArticles, eksempler = [], upcomingEvents = [], veiledninger = [], eksempelKort } = Astro.props;
 const featuredArticle = latestArticles[0];
@@ -49,10 +49,10 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     .map((k) => {
       const ex = eksempler.find((e: any) => e.id === k.id);
       return ex
-        ? { href: `/eksempler/${ex.slug}`, title: ex.tittel, tag: 'Eksempel', lead: k.ingress || ex.ingress || undefined }
+        ? { href: `/eksempler/${ex.slug}`, title: ex.tittel, lead: k.ingress || ex.ingress || undefined }
         : null;
     })
-    .filter((c) => c !== null) as { href: string; title: string; tag: string; lead?: string }[];
+    .filter((c) => c !== null) as { href: string; title: string; lead?: string }[];
 ---
 
 {seksjoner.map((block) => {
@@ -156,11 +156,10 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     // Redaktørvalgte eksempler overstyrer auto-pool. Tomt → behold nåværende oppførsel.
     const valgte = block.kort?.length ? resolveEksempelKort(block.kort) : [];
     const kort = valgte.length > 0 ? valgte : eksempelKort;
-    const eksempelTag = block.kortTag || 'Eksempel';
     return (
       <section data-layout-block="content" class="examples-section">
         <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Lær av andre'}</h2>
-        <ExampleLinkCards cards={kort.filter((c): c is { href: string; title: string; tag: string } => 'href' in c && 'title' in c).map((c, i) => ({ ...c, tag: eksempelTag, variant: (i === 0 ? 'medium' : 'light') as 'dark' | 'medium' | 'light' }))} />
+        <ExampleLinkCards cards={kort.filter((c): c is { href: string; title: string } => 'href' in c && 'title' in c).map((c, i) => ({ ...c, tag: block.kortTag, variant: (i === 0 ? 'medium' : 'light') as 'dark' | 'medium' | 'light' }))} />
         <ArrowLink href={block.lenkeUrl || '/eksempler'} text={block.lenketekst || 'Se alle eksempler'} />
       </section>
     );

--- a/apps/frontend/src/components/shared/ExampleCard.astro
+++ b/apps/frontend/src/components/shared/ExampleCard.astro
@@ -12,7 +12,7 @@ interface Props {
 const {
   href,
   title,
-  tag = 'Eksempel',
+  tag,
   variant = 'dark',
 } = Astro.props;
 

--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -109,7 +109,7 @@ const seksjoner = oversikt?.seksjoner?.length ? oversikt.seksjoner : fallbackSek
               <ExampleLinkCards cards={items.map((e, i) => ({
                 href: `/eksempler/${e.slug}`,
                 title: e.tittel,
-                tag: s.kortTag || 'Eksempel',
+                tag: s.kortTag,
                 variant: s.kortFarger?.[i],
               }))} />
             </div>

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -11,7 +11,7 @@ let latestArticles: any[] = [];
 let eksempler: any[] = [];
 let upcomingEvents: Kalenderhendelse[] = [];
 let veiledninger: VeiledningGuide[] = [];
-let eksempelKort: { href: string; title: string; tag: string }[] = [];
+let eksempelKort: { href: string; title: string; tag?: string }[] = [];
 try {
   // Preview gjelder kun forsidens egen kladd (struktur/overskrifter/pins). Kortene henter
   // alltid PUBLISERT innhold, slik at preview matcher det publikum ser (ingen upubliserte lekker inn).
@@ -29,7 +29,6 @@ try {
   eksempelKort = eksempler.slice(0, 2).map((c: any) => ({
     href: `/eksempler/${c.slug}`,
     title: c.tittel,
-    tag: 'Eksempel',
   }));
   const veiledningerRes = await getVeiledningGuider({ preview: isPreview });
   veiledninger = veiledningerRes.data;

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -84,7 +84,7 @@ const simpleLinks = (cmsData?.seksjon3Kort?.length ?? 0) > 0
     ];
 
 // Case cards — "Lær av andre"
-const eksempelTag = cmsData?.eksempelKortTag || 'Eksempel';
+const eksempelTag = cmsData?.eksempelKortTag;
 const caseCards = cases.data.length > 0
   ? cases.data.slice(0, 2).map(c => ({
       title: c.tittel,


### PR DESCRIPTION
Lukker #623.

`ExampleCard` hadde `tag = 'Eksempel'` som default-verdi. Komponenten har fra før en guard (`{tag && ...}`) som utelater boksen når tag mangler, men default-verdien gjorde at guarden aldri slo inn. Fallbacken er fjernet både i komponenten og på kallstedene.

Berørte flater: forsiden (Lær av andre), /eksempler (eksempelGruppe) og /veiledning (Lær av andre).

`kortTag` og `eksempelKortTag` i CMS er urørt. Setter redaktøren en verdi der, vises boksen som før.

Verifisert mot prod-CMS: 10 kort på tvers av de tre sidene rendrer i dag «Eksempel», etter endringen rendres ingen tag. Med en verdi satt på `kortTag` kommer boksen tilbake.