### PR TITLE
fix(frontend): fjern dødt fallback-innhold som maskerer manglende CMS-data

### DIFF
--- a/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
+++ b/apps/frontend/src/components/landing/ForsideSeksjonerRenderer.astro
@@ -81,13 +81,13 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     return (
       <section class="aktuelt" data-layout-block="edge">
         <div data-layout-block="content">
-          <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Aktuelt'}</h2>
+          {block.overskrift && <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift}</h2>}
           {featured && (
             <NewsCard
               href={`/artikler/${featured.slug}`}
               title={featured.tittel}
               tagColor="brand1"
-              lead={featured.lead || 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.'}
+              lead={featured.lead}
               image={featured.image}
               imageAlt=""
               variant="featured"
@@ -118,7 +118,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     return (
       <section class="arrangementer" data-layout-block="edge">
         <div class="arrangementer-section" data-layout-block="content">
-          <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Kommende arrangementer'}</h2>
+          {block.overskrift && <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift}</h2>}
           {valgt && (
             <EventCard {...hendelseTilEventCard(valgt)} />
           )}
@@ -131,10 +131,12 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
   if (block.contentType === 'forsideVeiledning') {
     // Redaktørvalgt veiledning gir standardverdier; tekstfeltene overstyrer.
     const valgt = block.veiledningId ? veiledninger.find((v) => v.id === block.veiledningId) : undefined;
-    const tittel = block.tittel || valgt?.tittel || 'Gjør dataene KI-klare';
-    const ingress = block.ingress || valgt?.ingress || 'Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.';
+    const tittel = block.tittel || valgt?.tittel;
+    const ingress = block.ingress || valgt?.ingress;
     const href = block.lenkeUrl || (valgt ? `/veiledning/${valgt.slug}` : '/veiledning');
     const image = block.illustrasjon ? getMediaUrl(block.illustrasjon) : (valgt?.seoBilde ? getMediaUrl(valgt.seoBilde) : undefined);
+    // Uten tittel har seksjonen ikke noe innhold å vise, og TextWithImage krever den.
+    if (!tittel) return null;
     return (
       <section class="veiledning-section" data-layout-block="edge">
         <div data-layout-block="content">
@@ -143,9 +145,9 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
             href={href}
             image={image}
             imageAlt="Illustrasjon"
-            label={block.label || 'Veiledning'}
+            label={block.label}
           >
-            <p slot="body">{ingress}</p>
+            {ingress && <p slot="body">{ingress}</p>}
           </TextWithImage>
         </div>
       </section>
@@ -158,7 +160,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     const kort = valgte.length > 0 ? valgte : eksempelKort;
     return (
       <section data-layout-block="content" class="examples-section">
-        <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Lær av andre'}</h2>
+        {block.overskrift && <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift}</h2>}
         <ExampleLinkCards cards={kort.filter((c): c is { href: string; title: string } => 'href' in c && 'title' in c).map((c, i) => ({ ...c, tag: block.kortTag, variant: (i === 0 ? 'medium' : 'light') as 'dark' | 'medium' | 'light' }))} />
         <ArrowLink href={block.lenkeUrl || '/eksempler'} text={block.lenketekst || 'Se alle eksempler'} />
       </section>
@@ -178,7 +180,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
     if (lenker.length === 0) return null;
     return (
       <section class="forsta-section" data-layout-block="content">
-        <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift || 'Forstå regelverket'}</h2>
+        {block.overskrift && <h2 class="ds-heading section-heading" data-size="lg">{block.overskrift}</h2>}
         <ul class="forsta-liste">
           {lenker.map((l) => (
             <li>
@@ -196,7 +198,7 @@ const resolveEksempelKort = (kort: { id?: string; ingress?: string }[] | undefin
   if (block.contentType === 'forsideSandkasse') {
     const sandkasseLinkId = `sandkasse-link-${block.id}`;
     // Pilen limes til siste ord så den ikke brekker alene (#464)
-    const sandkasseTittel = splitLastWord(block.overskrift || 'Den regulatoriske sandkassen');
+    const sandkasseTittel = splitLastWord(block.overskrift ?? '');
     return (
       <section class="sandkasse-section" data-layout-block="content">
         <div class="sandkasse-card" data-clickdelegatefor={sandkasseLinkId}>

--- a/apps/frontend/src/components/layout/Layout.astro
+++ b/apps/frontend/src/components/layout/Layout.astro
@@ -11,7 +11,7 @@ import '../../styles/search-dialog.css';
 import './header.css';
 
   interface Props {
-  title: string;
+  title?: string;
   description?: string;
   ogType?: 'website' | 'article';
   ogImage?: string;
@@ -36,7 +36,8 @@ const currentPath = Astro.url.pathname;
 // origin since it returns localhost when behind Azure's reverse proxy.
 const siteUrl = Astro.site?.href.replace(/\/$/, '') || 'https://ki.norge.no';
 const canonicalUrl = `${siteUrl}${currentPath}`;
-const fullTitle = `${title} | KI Norge`;
+// Mangler CMS-tittelen, faller vi tilbake til bare nettstedsnavnet (aldri "undefined | KI Norge").
+const fullTitle = title ? `${title} | KI Norge` : 'KI Norge';
 // Version query busts stale link-preview thumbnail caches without changing the asset path.
 const DEFAULT_OG_IMAGE = '/og-image.png?v=3c5667a2';
 // CMS-media (/media/...) gjores absolutt mot CMS-hosten; ellers prefikses

--- a/apps/frontend/src/pages/artikler/index.astro
+++ b/apps/frontend/src/pages/artikler/index.astro
@@ -23,7 +23,7 @@ try {
   Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
-const heroTittel = oversikt?.heroTittel || 'Aktuelt';
+const heroTittel = oversikt?.heroTittel;
 const heroSubtittel = oversikt?.heroSubtittel || '';
 const seoTitle = oversikt?.seoTittel || heroTittel;
 const seoDesc = oversikt?.seoBeskrivelse || 'Nyheter, analyser og artikler om kunstig intelligens i norsk offentlig sektor.';
@@ -67,7 +67,7 @@ const remaining = rest.slice(9);
 <Layout title={seoTitle} description={seoDesc} ogImage={oversikt?.seoBilde?.url}>
   <section data-layout-block="content" class="artikler-page">
     <header class="artikler-header">
-      <h1 class="ds-heading" data-size="xl">{heroTittel}</h1>
+      {heroTittel && <h1 class="ds-heading" data-size="xl">{heroTittel}</h1>}
       {heroSubtittel && <p class="artikler-subtitle">{heroSubtittel}</p>}
     </header>
 

--- a/apps/frontend/src/pages/eksempler/index.astro
+++ b/apps/frontend/src/pages/eksempler/index.astro
@@ -4,7 +4,7 @@ import ArticleCardFeatured from '../../components/shared/ArticleCardFeatured.ast
 import ExampleLinkCards from '../../components/shared/ExampleLinkCards.astro';
 import ExampleCard from '../../components/shared/ExampleCard.astro';
 import ArticleCardCompact from '../../components/shared/ArticleCardCompact.astro';
-import { getEksempler, getEksemplerOversikt, getArtikler, getVeiledningGuider, getMediaUrl, MEDIA_WIDTH, type Eksempel, type Artikkel, type VeiledningGuide, type EksemplerSeksjon } from '../../lib/umbraco';
+import { getEksempler, getEksemplerOversikt, getArtikler, getVeiledningGuider, getMediaUrl, MEDIA_WIDTH, type Eksempel, type Artikkel, type VeiledningGuide } from '../../lib/umbraco';
 
 const isPreview = Astro.url.searchParams.has('preview') || !!Astro.cookies.get('preview')?.value;
 
@@ -29,7 +29,7 @@ try {
   Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
-const heroTittel = oversikt?.heroTittel || 'Eksempler';
+const heroTittel = oversikt?.heroTittel;
 const seoTitle = oversikt?.seoTittel || heroTittel;
 const seoDesc = oversikt?.seoBeskrivelse || 'Lær av andre offentlige virksomheters erfaringer med kunstig intelligens.';
 
@@ -38,35 +38,13 @@ const relatertById = new Map<string, Artikkel | VeiledningGuide>();
 artikler.forEach(a => relatertById.set(a.id, a));
 guider.forEach(g => relatertById.set(g.id, g));
 
-// Hard-coded seksjoner som matcher Figma-designet. Refererer til eksempler og artikler
-// fra mock-fixturen via ID. Brukes når CMS ikke leverer seksjoner.
-const eksempelIder = eksempler.map(e => e.id);
-const artikkelIder = artikler.map(a => a.id);
-
-const fallbackSeksjoner: EksemplerSeksjon[] = [
-  // 1) Featured eksempel
-  { contentType: 'eksempelFeatured', id: 'fallback-featured', eksempelId: eksempelIder[0], ingress: 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.' },
-  // 2) 2x2 grid (4 kort) — farger fra standardmønsteret i ExampleLinkCards (#461)
-  { contentType: 'eksempelGruppe', id: 'fallback-gruppe-1', eksempelIds: eksempelIder.slice(0, 4) },
-  // 3) 3-kolonne grid (3 kort)
-  { contentType: 'eksempelGruppe', id: 'fallback-gruppe-2', antallKolonner: 3, eksempelIds: eksempelIder.slice(0, 3) },
-  // 4) Enda en featured
-  { contentType: 'eksempelFeatured', id: 'fallback-featured-2', eksempelId: eksempelIder[1] || eksempelIder[0], ingress: 'Denne artikkelen gir en oversikt over den norske situasjonen, basert på tidligere utredninger og utviklingstrekk i den nasjonale KI-infrastrukturen.' },
-  // 5) 2 kort
-  { contentType: 'eksempelGruppe', id: 'fallback-gruppe-3', eksempelIds: eksempelIder.slice(0, 2) },
-  // 6) Relatert innhold (3 artikler)
-  { contentType: 'eksempelRelatert', id: 'fallback-relatert', relatertIds: artikkelIder.slice(0, 3), relatertTags: ['Digitaliseringsstrategien', 'Offentlig sektor', 'Arbeidsmarkedet'] },
-  // 7) Kontakt-seksjon
-  { contentType: 'eksempelKontakt', id: 'fallback-kontakt', tittel: 'Ønsker du å dele et eksempel?', navn: 'Navn Navnesen', epost: 'navn@digdir.no', stilling: 'Rådgiver i Digitaliseringsdirektoratet' },
-];
-
-const seksjoner = oversikt?.seksjoner?.length ? oversikt.seksjoner : fallbackSeksjoner;
+const seksjoner = oversikt?.seksjoner ?? [];
 ---
 
 <Layout title={seoTitle} description={seoDesc} ogImage={oversikt?.seoBilde?.url}>
   <div class="eksempler-page">
     <header class="eksempler-header" data-layout-block="content">
-      <h1 class="ds-heading eksempler-title" data-size="xl">{heroTittel}</h1>
+      {heroTittel && <h1 class="ds-heading eksempler-title" data-size="xl">{heroTittel}</h1>}
     </header>
 
     {seksjoner.length === 0 && eksempler.length > 0 && (

--- a/apps/frontend/src/pages/kalender/[slug].astro
+++ b/apps/frontend/src/pages/kalender/[slug].astro
@@ -22,27 +22,7 @@ try {
   console.error('Failed to fetch kalenderhendelse:', e);
 }
 
-if (!hendelse) {
-  // Ingen hendelse funnet (CMS-feil eller ukjent slug): vis fallback, men ikke
-  // cache den på edgen — ellers serveres en mock til alle på en ekte URL.
-  Astro.response.headers.set('Cache-Control', 'private, no-store');
-  hendelse = {
-    id: 'mock',
-    documentId: 'mock',
-    tittel: 'Markedsdialog om Felles løft: sammenhengende tjenester for barn og unge',
-    slug: slug || 'mock',
-    ingress: 'Automatisk tale-til-tekst, kvalitetssikring av transkripsjoner og talestyrt kamerateknologi for åstedsarbeid effektiviserer politiarbeidet.',
-    startDato: '2026-03-03T08:30:00',
-    sluttDato: '2026-03-03T15:00:00',
-    tid: '08.30–15.00',
-    sted: 'Oslo',
-    lenke: '#',
-    createdAt: '2026-01-01',
-    updatedAt: '2026-01-01',
-    publishedAt: '2026-01-01',
-    locale: 'nb-NO',
-  };
-}
+if (!hendelse) return Astro.redirect('/kalender');
 
 const seoTitle = hendelse.tittel;
 const seoDesc = hendelse.ingress || '';

--- a/apps/frontend/src/pages/kalender/index.astro
+++ b/apps/frontend/src/pages/kalender/index.astro
@@ -16,8 +16,8 @@ try {
   Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
-const tittel = kalender?.tittel || 'Kalender';
-const ingress = kalender?.ingress || 'Her finner du arrangementer om KI fra private og offentlige aktører.';
+const tittel = kalender?.tittel;
+const ingress = kalender?.ingress;
 const seoTitle = kalender?.seoTittel || tittel;
 const seoDesc = kalender?.seoBeskrivelse || ingress;
 
@@ -54,7 +54,7 @@ const tidligere = hendelser
 ---
 <Layout title={seoTitle} description={seoDesc} ogImage={kalender?.seoBilde?.url}>
   <header class="kalender-header" data-layout-block="content">
-    <h1 class="ds-heading" data-size="xl">{tittel}</h1>
+    {tittel && <h1 class="ds-heading" data-size="xl">{tittel}</h1>}
     {ingress && <p class="kalender-ingress">{ingress}</p>}
   </header>
 

--- a/apps/frontend/src/pages/om-oss.astro
+++ b/apps/frontend/src/pages/om-oss.astro
@@ -20,7 +20,7 @@ try {
   Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
-const tittel = omOss?.tittel || 'Om KI Norge';
+const tittel = omOss?.tittel;
 const seoTitle = omOss?.seoTittel || 'Om oss';
 const seoDesc = omOss?.seoBeskrivelse || omOss?.ingress || 'Om KI Norge – en nasjonal satsing for ansvarlig bruk av kunstig intelligens.';
 const seoImage = omOss?.seoBilde?.url || omOss?.artikkelBilde?.url;
@@ -41,7 +41,7 @@ const contentBlocks = allBlocks.filter(b => b.contentType !== 'artikkelByline');
   <section class="article-hero" data-layout-block="edge">
     <div class="article-hero-inner">
       <div class="article-hero-text">
-        <h1 class="ds-heading article-title" data-size="xl">{tittel}</h1>
+        {tittel && <h1 class="ds-heading article-title" data-size="xl">{tittel}</h1>}
       </div>
     </div>
   </section>

--- a/apps/frontend/src/pages/veiledning/index.astro
+++ b/apps/frontend/src/pages/veiledning/index.astro
@@ -32,8 +32,8 @@ try {
   Astro.response.headers.set('Cache-Control', 'private, no-store');
 }
 
-const heroTitle = cmsData?.heroTittel || 'Veiledning og guider';
-const heroText = cmsData?.heroTekst || 'Lurer du på hva det er lurt å tenke på når du bruker KI eller lager KI-løsninger? Her finner du veiledninger laget og kvalitetssikret av jurister og andre fagfolk.';
+const heroTitle = cmsData?.heroTittel;
+const heroText = cmsData?.heroTekst;
 const heroImageUrl = cmsData?.heroBilde ? getMediaUrl(cmsData.heroBilde, MEDIA_WIDTH.hero) : undefined;
 
 // Redaktørvalgt lenke (content-picker, #513) løses mot hentede pools så vi bruker
@@ -47,8 +47,8 @@ const resolveLenke = (kort?: { lenkeId?: string; url?: string }): string | undef
   (kort?.lenkeId ? lenkeById.get(kort.lenkeId) : undefined) ?? kort?.url ?? undefined;
 
 // Featured article — "Kom i gang"
-const featuredTitle = cmsData?.seksjon1Kort?.[0]?.tittel || 'Hva er KI og hva kan du bruke det til?';
-const featuredDesc = cmsData?.seksjon1Kort?.[0]?.beskrivelse || 'Lær om hva kunstig intelligens er, hva du kan bruke det til og hvordan du kommer i gang.';
+const featuredTitle = cmsData?.seksjon1Kort?.[0]?.tittel;
+const featuredDesc = cmsData?.seksjon1Kort?.[0]?.beskrivelse;
 const featuredHref = resolveLenke(cmsData?.seksjon1Kort?.[0]) || '/veiledning/kom-i-gang';
 // Ingen hardkodet fallback: redaktøren skal kunne fjerne tittelen helt (#494).
 // TextWithImage skjuler label-feltet når det er tomt.
@@ -103,16 +103,18 @@ const seoDesc = cmsData?.seoBeskrivelse || heroText;
 <Layout title={seoTitle} description={seoDesc} ogImage={cmsData?.seoBilde?.url}>
   <!-- Hero -->
   <section class="veil-hero" data-layout-block="content">
-    <h1 class="ds-heading" data-size="xl">{heroTitle}</h1>
-    <p class="ds-paragraph veil-hero-text" data-size="xl">{heroText}</p>
+    {heroTitle && <h1 class="ds-heading" data-size="xl">{heroTitle}</h1>}
+    {heroText && <p class="ds-paragraph veil-hero-text" data-size="xl">{heroText}</p>}
   </section>
 
   <!-- Kom i gang — Featured article with illustration -->
-  <section class="veil-featured" data-layout-block="content">
-    <TextWithImage title={featuredTitle} href={featuredHref} image={featuredImage} imageAlt="" label={featuredLabel}>
-      <p slot="body">{featuredDesc}</p>
-    </TextWithImage>
-  </section>
+  {featuredTitle && (
+    <section class="veil-featured" data-layout-block="content">
+      <TextWithImage title={featuredTitle} href={featuredHref} image={featuredImage} imageAlt="" label={featuredLabel}>
+        {featuredDesc && <p slot="body">{featuredDesc}</p>}
+      </TextWithImage>
+    </section>
+  )}
 
   <!-- Steg for steg — Rich link list -->
   {richLinks.length > 0 && (


### PR DESCRIPTION
Fallback i koden som ser ut som ekte innhold gjør CMS-feil vanskelige å oppdage. Denne PR-en fjerner de fallbackene som er døde i dag, altså der feltet faktisk er fylt i prod. Et tomt felt framover feiler synlig i stedet for å bli papret over.

**Verste tilfelle: `kalender/[slug]`.** Enhver ukjent slug rendret et oppdiktet arrangement med ekte tittel, ingress, dato og sted. `https://ki.norge.no/kalender/finnes-ikke` gir «Markedsdialog om Felles løft ...» i dag. Nå redirect til `/kalender`, slik `artikler/[slug]` og `eksempler/[slug]` allerede gjør.

Fjernet ellers `fallbackSeksjoner` på /eksempler (CMS leverer 3 ekte seksjoner) og hardkodede overskrifter/ingresser på forside, veiledning, kalender, artikler, eksempler og om-oss. Overskrifter rendres nå betinget, samme mønster som `seksjon2Tittel` fra #494.

**Beholdt bevisst**
- 404, 503 og cookie-varselet. De trenger hardkodet tekst nettopp fordi de skal virke når CMS er nede.
- De tre fallbackene som faktisk vises i prod i dag (`forsideAktuelt.lenketekst`, `forsideArrangementer.lenketekst`, `forsideSandkasse.tekst`). De fjernes når feltene er fylt i CMS, ellers ville teksten forsvunnet for besøkende.

`Layout` tar nå valgfri `title` og faller tilbake til nettstedsnavnet alene, i stedet for å rendre `undefined | KI Norge`.

**Verifisering.** Kjørt mot prod-CMS og sammenlignet tekstinnholdet med live ki.norge.no. Forside, /eksempler, /veiledning, /kalender, /om-oss og /artikler rendrer identisk. Ukjent kalender-slug gir 302 til /kalender.