### PR TITLE
fix(frontend): nyhetsbilder til midten med klamret høyde, bredere illustrasjon (#584, #585)

### DIFF
--- a/apps/frontend/src/components/shared/NewsCard.astro
+++ b/apps/frontend/src/components/shared/NewsCard.astro
@@ -190,7 +190,8 @@ const formattedDate = date
     gap: var(--ds-size-4);
     flex: 1;
     justify-content: center;
-    padding-block: var(--ds-size-8);
+    /* Holder kortet innenfor bildets tak på 300px, så bunnkantene flukter (#584). */
+    padding-block: var(--ds-size-4);
 
     @media (max-width: 767px) {
       padding-block: 0;

--- a/apps/frontend/src/components/shared/NewsCard.astro
+++ b/apps/frontend/src/components/shared/NewsCard.astro
@@ -135,6 +135,8 @@ const formattedDate = date
 
   .news-card--image .news-card-image {
     aspect-ratio: 4 / 3;
+    min-height: 220px;
+    max-height: 300px;
     overflow: hidden;
     background-color: var(--image-fallback-bg, #d9d9d9);
   }
@@ -168,8 +170,11 @@ const formattedDate = date
   }
 
   .news-card--featured .news-card-image {
-    flex: 0 0 45%;
-    aspect-ratio: 4 / 3;
+    /* Bildet går helt til midten av kortet, og høyden følger teksten
+       innenfor 220-300px (#584). */
+    flex: 0 0 50%;
+    min-height: 220px;
+    max-height: 300px;
     overflow: hidden;
   }
 

--- a/apps/frontend/src/components/shared/TextWithImage.astro
+++ b/apps/frontend/src/components/shared/TextWithImage.astro
@@ -42,14 +42,15 @@ const titleParts = splitLastWord(title);
     gap: var(--ds-size-12);
 
     @media (min-width: 768px) {
-      grid-template-columns: 2fr 1fr;
+      /* Smalere tekstkolonne gir illustrasjonen mer plass (#585). */
+      grid-template-columns: 1fr 1fr;
       align-items: center;
       gap: var(--ds-size-22);
     }
 
     &[data-image-position='left'] {
       @media (min-width: 768px) {
-        grid-template-columns: 1fr 2fr;
+        grid-template-columns: 1fr 1fr;
 
         & .illustration {
           order: -1;


### PR DESCRIPTION
Lukker #584 og #585.

**#584 nyhetsbilder.** Featured-kortet hadde bildet på `flex: 0 0 45%` med fast `aspect-ratio: 4/3`. Det ga 344px høyde på 1440px skjerm, altså over taket på 300, og bildet stoppet 51px før midten av kortet. Bildet går nå helt til midtpunktet og høyden følger teksten innenfor 220-300px. Samme klamring er lagt på bildekortene i oversiktene, der 4:3 ga opptil 364px.

**#585 illustrasjon og grid.** Tekstkolonnen i `TextWithImage` er smalere, `1fr 1fr` i stedet for `2fr 1fr`, så illustrasjonen får plassen skissen viser. Mobil er uendret, én kolonne.

**#585 punkt 2 krevde ingen endring.** Hero-illustrasjonen er allerede midtstilt med teksten, målt til midtpunkt 674px for begge. `.hero-grid` har `align-items: center` fra før.

**Målt før og etter, fire bredder**

| | 800px | 1024px | 1440px |
|---|---|---|---|
| Featured bildehøyde | 394 → 300 | 331 → 300 | 344 → 300 |
| Kortbilde i oversikt | 270 → 270 | 354 → 300 | 364 → 300 |
| TextWithImage tekst/illustrasjon | 443/221 → 332/332 | 592/296 → 444/444 | 620/310 → 465/465 |

Alle bildehøyder ligger nå innenfor 220-300 på 390, 800, 1024 og 1440px. Kjørt mot prod-CMS og kontrollert på forside, /veiledning og /artikler.