### PR TITLE
chore(cms): legg rørleggingen uSync trenger for å overta skjemaet

### DIFF
--- a/apps/cms-umbraco/.gitignore
+++ b/apps/cms-umbraco/.gitignore
@@ -14,8 +14,14 @@ App_Data/
 wwwroot/media/*
 !wwwroot/media/.gitkeep
 
-## uSync-eksporter (innholdsspeiling, skal ikke i repo)
-uSync/
+## uSync-eksporter. Innhold og media er speilings-artefakter og skal aldri i repo.
+## Skjema (ContentTypes/DataTypes) SKAL committes når uSync overtar skjemaeierskapet,
+## men bare en eksport tatt fra PROD. Se docs/usync-skjema-prereq.md.
+uSync/*
+!uSync/v17
+uSync/v17/*
+!uSync/v17/ContentTypes
+!uSync/v17/DataTypes
 
 ## SQLite database
 *.sqlite.db

--- a/apps/cms-umbraco/KiNorge.Cms.csproj
+++ b/apps/cms-umbraco/KiNorge.Cms.csproj
@@ -41,6 +41,20 @@
   </ItemGroup>
 
   <!--
+    Skjemafilene uSync importerer må ligge i imaget, ellers har prod ingenting å
+    importere den dagen uSync overtar skjemaeierskapet fra ContentTypeComposer.
+    Innhold og media kopieres bevisst IKKE, de transporteres med
+    scripts/sync-prod-til-tt02.sh. Globen treffer ingenting før en prod-eksport
+    er committet, se docs/usync-skjema-prereq.md.
+  -->
+  <ItemGroup>
+    <None Include="uSync/v17/ContentTypes/**/*.config;uSync/v17/DataTypes/**/*.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
+  <!--
     Regenererer det git-ignorerte speilet av /shared/content-routes.json fra
     kilden før build/publish, slik at `dotnet run`/`dotnet build` alltid er i
     synk uten et eget pre-steg. Condition-en skrur targeten av når /shared ikke

--- a/docs/usync-skjema-prereq.md
+++ b/docs/usync-skjema-prereq.md
@@ -1,0 +1,83 @@
+# Forutsetninger før uSync kan overta skjemaet fra ContentTypeComposer
+
+Gjelder den fulle migreringen (jobb 2), ikke tt02-piloten (#560). Piloten
+transporterer filer med `scripts/sync-prod-til-tt02.sh` og trenger ikke noe av
+dette.
+
+Denne PR-en legger kun rørleggingen. Selve skjemaeksporten er bevisst ikke
+committet, se «Nøklene må komme fra prod» under.
+
+## Hva som manglet
+
+Migreringsplanen ba oss bekrefte at `apps/cms-umbraco/uSync/` ikke er
+gitignorert og at Dockerfile tar den med i imaget. Begge deler var usanne:
+
+- `.gitignore` ignorerte hele `uSync/`, og null uSync-filer var committet.
+- `KiNorge.Cms.csproj` hadde ingen regel som kopierte uSync-filer til
+  publish-output, og Dockerfile sender bare `/app/publish` videre til
+  runtime-imaget.
+
+Fjernet man composeren i den tilstanden, ville prod startet uten skjemakilde:
+ingen composer og ingen filer å importere.
+
+## Hva denne PR-en endrer
+
+- `.gitignore` er snevret inn. `ContentTypes/` og `DataTypes/` kan spores,
+  `Content/` og `Media/` er fortsatt ignorert siden de er speilings-artefakter.
+- `KiNorge.Cms.csproj` kopierer skjemafilene til output og publish. Globen
+  treffer ingenting i dag, så regelen er inert til en eksport er committet.
+
+## Nøklene må komme fra prod
+
+ContentTypeComposer setter aldri `.Key` selv, så Umbraco tildeler
+content-typene tilfeldige GUID-er per database. Målt på to ferske lokale
+databaser: **alle 58 dokumenttype-nøkler var forskjellige**. Blant datatypene
+var 36 like (Umbracos innebygde har faste nøkler) og 21 forskjellige (de
+composeren lager).
+
+Innhold refererer blokker via nøkkel. Committer man en skjemaeksport tatt fra
+en dev-maskin, og den senere importeres i prod, får prod-typene dev-nøkler som
+prod sitt innhold ikke peker på. Alle blokkmoduler blir «Unsupported». Det er
+nøyaktig symptomet tt02-speilet har i dag, men da i prod.
+
+**Derfor: eksporten som committes skal tas fra PROD**, via backoffice,
+Settings, uSync, Export. Ikke fra lokal maskin og ikke fra tt02.
+
+## Eksporten må tas fra en ferdig bygget database
+
+`ExportAtStartup` kan kappløpe med composeren. Målt: på en boot der composeren
+bygget skjemaet samtidig, eksporterte uSync 58 datatyper mens en ferdig bygget
+database ga 61.
+
+Eksporter derfor fra en instans som allerede har kjørt composeren ferdig, altså
+en vanlig kjørende prod, ikke en førstegangs-boot.
+
+## Verifisert underveis
+
+Eksporten er tro mot databasen. Sammenlignet uSync-filene mot SQLite direkte:
+
+| | database | uSync-filer | avvik |
+|---|---|---|---|
+| Dokumenttyper | 58 | 58 | ingen |
+| Datatyper | 61 | 61 | ingen |
+| Nøkler | — | — | ingen |
+| Properties per type | 324 | — | ingen |
+
+Differansen mellom 66 og 58 content-typer i databasen er Umbracos egne
+innebygde (`File`, `Folder`, `Image`, `Member`, `umbracoMedia*`), som
+composeren ikke lager og som ikke hører hjemme i eksporten.
+
+## Gjenstår før jobb 2
+
+1. Ta skjemaeksport fra prod og commit `ContentTypes/` + `DataTypes/`.
+2. Kjør A/B-verifiseringen: én database bygget av composeren mot én bygget av
+   uSync-import, og sammenlign typer, properties, datatyper og tillatte barn.
+3. Pensjoner composeren og aktiver uSync-import i SAMME PR. Kjører begge
+   samtidig, slåss de om eierskapet.
+
+## Lokal gotcha
+
+Umbraco skriver om `appsettings.json` ved lokal oppstart. Den stripper
+kommentarer og legger inn en generert `Imaging.HMACSecretKey`. Sjekk
+`git status` etter lokal CMS-kjøring så ikke en generert nøkkel havner i en
+commit.


### PR DESCRIPTION
Forberedelse til jobb 2 (uSync overtar skjemaet fra `ContentTypeComposer`). Rører ikke tt02-piloten i #560, som transporterer filer med `sync-prod-til-tt02.sh` og ikke trenger noe av dette.

**Migreringsplanens steg 0 var ikke oppfylt.** Planen ba oss bekrefte at `apps/cms-umbraco/uSync/` ikke er gitignorert og at Dockerfile tar den med i imaget. Begge deler var usanne:

- `.gitignore` ignorerte hele `uSync/`, og null uSync-filer var committet
- `KiNorge.Cms.csproj` hadde ingen regel som kopierte uSync-filer til publish-output, og Dockerfile sender bare `/app/publish` videre

Fjernet man composeren i den tilstanden, ville prod startet uten skjemakilde. Ingen composer og ingen filer å importere.

**Endringer**
- `.gitignore` snevret inn så `ContentTypes/` og `DataTypes/` kan spores, mens `Content/` og `Media/` fortsatt ignoreres. Verifisert med `git check-ignore`.
- `csproj` kopierer skjemafilene til output og publish. Globen treffer ingenting i dag, så regelen er inert til en eksport er committet. Bygger grønt.
- `docs/usync-skjema-prereq.md` med funn og gjenstående steg.

**Skjemaeksporten er bevisst ikke committet.** `ContentTypeComposer` setter aldri `.Key`, så Umbraco tildeler tilfeldige GUID-er per database. Målt på to ferske lokale databaser: **alle 58 dokumenttype-nøkler var forskjellige** (datatyper: 36 like, som er Umbracos innebygde, og 21 forskjellige). Siden innhold refererer blokker via nøkkel, ville en dev-eksport importert i prod gitt prod-typene nøkler prod sitt innhold ikke peker på, altså «Unsupported» på alle blokkmoduler. Eksporten må tas fra prod.

**Verifisert underveis: eksporten er tro mot databasen.** Sammenlignet uSync-filene mot SQLite direkte, og fant null avvik på dokumenttyper (58/58), datatyper (61/61), nøkler og properties per type (324). Differansen mellom 66 og 58 content-typer i databasen er Umbracos innebygde (`File`, `Folder`, `Image`, `Member`, `umbracoMedia*`), som composeren ikke lager.