### PR TITLE
fix(deps): pin undici over Trivy-flagget HIGH (CVE-2026-13697)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   esbuild: ^0.28.1
   ws: ^8.21.0
   sharp: ^0.35.0
+  undici: ^7.29.0
   svgo: ^4.0.2
 
 importers:
@@ -2829,8 +2830,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -5287,7 +5288,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@25.9.4)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260625.1
       ws: 8.21.1
       youch: 4.1.0-beta.10
@@ -5300,7 +5301,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@25.9.4)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260701.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -5313,7 +5314,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@25.9.4)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260714.1
       ws: 8.21.1
       youch: 4.1.0-beta.10
@@ -5854,7 +5855,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ overrides:
   esbuild: "^0.28.1" # GHSA-gv7w-rqvm-qjhr
   ws: "^8.21.0" # CVE-2026-48779
   sharp: "^0.35.0" # GHSA-f88m-g3jw-g9cj
+  undici: "^7.29.0" # CVE-2026-13697, transitiv via miniflare/wrangler
   svgo: "^4.0.2" # GHSA-2p49-hgcm-8545
   # vite-override fjernet: astro 6.4 sin ^7.3.2 drar nå inn en fikset 7.x selv
   # (CVE-2026-53571 fikset i 7.3.5), så pinningen var overflødig og hindret


### PR DESCRIPTION
Trivy fs-scan feiler på alle åpne PR-er fordi `undici` 7.28.0 i lockfilen har CVE-2026-13697. Cache-interceptoren mishandler feilformede svar. Ikke noe med PR-ene å gjøre, scanneren leser hele lockfilen.

Transitiv via `miniflare` og `wrangler`, så det finnes ingen direkte avhengighet å bumpe. Pinner `^7.29.0` i pnpm-overrides, samme mønster som esbuild, ws, sharp og svgo.

Resolved går fra 7.28.0 til 7.29.0. Frontend-bygg grønt, 149 enhetstester grønne.