### PR TITLE
feat(cms): commit prod sitt uSync-skjema (58 content-typer, 59 datatyper)

### DIFF
--- a/apps/cms-umbraco/uSync/v17/ContentTypes/accordionsection.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/accordionsection.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="405c4ebf-1cb8-4a9c-aae2-2ee426ba760f" Alias="accordionSection" Level="1">
+  <Info>
+    <Name>Accordion Section</Name>
+    <Icon>icon-list</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Legacy trekkspill-element. Bruk Trekkspill-modulen i artikkel-innhold i stedet.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>a3011aa9-6d97-4680-9700-317d1f3bbf65</Key>
+      <Name>Innhold</Name>
+      <Alias>body</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Innhold som vises når trekkspillet åpnes]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4a819bbb-4181-4256-928f-016bc047e48b</Key>
+      <Name>Tittel</Name>
+      <Alias>title</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Synlig tittel på trekkspillet (klikkes for å åpne)]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>c8bd51b4-5155-4c01-a65d-13e983e61abc</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkel.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkel.config
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="387c36e8-69c0-4c33-8724-81742da30ae9" Alias="artikkel" Level="1">
+  <Info>
+    <Name>Artikkel</Name>
+    <Icon>icon-newspaper-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Artikler og nyheter</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>e0896603-343e-49ec-8f6e-84e71688140e</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen (eller under på mobil).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ee58b90e-5774-4a01-b4b4-f41731048860</Key>
+      <Name>Bakgrunn</Name>
+      <Alias>bakgrunn</Alias>
+      <Definition>55043cae-9d13-4015-b915-789d02b4b825</Definition>
+      <Type>Umbraco.ColorPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bakgrunnsfarge for artikkelhodet.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b28da9ad-8e74-444d-a6bc-48be55371992</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>92b0e061-cea4-4212-b8ad-699ee09ed2a9</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1e4753be-73b3-467e-b5c0-51348487d7ca</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>954c4353-b6b0-4b7d-8b9f-ae860d5c811e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedinnhold]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0d290ebd-1937-4cc6-b77a-e61d19ae0266</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e67e4738-fe74-4cdc-9a53-3f89fd80775b</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>afda4753-bd08-4273-b0e1-c20d9d7de856</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7bdb6df9-9d42-4ea7-b145-74e7938cdfe7</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. Genereres automatisk fra tittel hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c4230d5b-fbee-405f-a1d2-cfe6ca3ba2b1</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>4a704258-c957-4ab5-a506-7370eeec3273</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>5e4c6dbb-9196-4155-ba76-782f2f8e1414</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>82a7db65-deda-478d-bab8-588ee8b53874</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelbildeseksjon.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelbildeseksjon.config
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="c063d005-38e9-4469-93f7-0dd71d961a76" Alias="artikkelBildeSeksjon" Level="1">
+  <Info>
+    <Name>Bilde</Name>
+    <Icon>icon-picture</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Bilde med valgfri bildetekst og fotokreditering</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>511ac6bb-1333-4393-a67f-e9a5b641e1ab</Key>
+      <Name>Bilde</Name>
+      <Alias>bilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>62b9f3d5-746a-4bd6-9cfa-77826ab07fd1</Key>
+      <Name>Alternativ tekst</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a1e68a40-1957-4d24-85b0-e7efd926d605</Key>
+      <Name>Bildetekst</Name>
+      <Alias>bildetekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bildetekst og evt. fotograf/kilde, f.eks. 'Foto: Dag Alveng']]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>44941e66-3309-42ba-82aa-e82bd6c140ab</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelbyline.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelbyline.config
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="e44ec3b2-10f6-4494-a36b-5177bbc74c45" Alias="artikkelByline" Level="1">
+  <Info>
+    <Name>Forfatter (byline)</Name>
+    <Icon>icon-user</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Personlig forfatter-byline. Vis navn, stilling, virksomhet og dato. Skjules hvis alle felt er tomme.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>63e0b8a0-00e4-4382-a0f8-ca3a4088ed67</Key>
+      <Name>Dato</Name>
+      <Alias>dato</Alias>
+      <Definition>5046194e-4237-453c-a547-15db3a07c4e1</Definition>
+      <Type>Umbraco.DateTime</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Dato for artikkelen. Hvis tom brukes artikkelens publiseringsdato.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>334e52b8-4076-4cee-9af2-5b690defcd65</Key>
+      <Name>Navn</Name>
+      <Alias>navn</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Forfatterens navn, eller 'Av redaksjonen']]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9cf92f95-4a68-4839-9a0b-a920848d0ab5</Key>
+      <Name>Stilling</Name>
+      <Alias>stilling</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[F.eks. 'Rådgiver']]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>25cbdb4a-7ffe-41ef-82cd-729a1aaf9757</Key>
+      <Name>Virksomhet</Name>
+      <Alias>virksomhet</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[F.eks. 'Digitaliseringsdirektoratet']]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>77900f53-1611-464c-8a5b-69711e531dd3</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelcallout.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelcallout.config
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="5dd55423-1bbd-4c4c-9c0a-8f0b52928e1a" Alias="artikkelCallout" Level="1">
+  <Info>
+    <Name>Artikkel Callout</Name>
+    <Icon>icon-alert</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Varselboks (info, obs, advarsel, suksess)</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>891043d7-8ae3-4c96-bb24-3a3df636dc54</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>14b95a3d-1d2f-48bb-9a3f-c468e52208aa</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6bf216f7-c366-4a28-a33d-ab26b22aa1ca</Key>
+      <Name>Variant</Name>
+      <Alias>variant</Alias>
+      <Definition>b776f85f-f33e-4d14-841f-9f1405392303</Definition>
+      <Type>Umbraco.DropDown.Flexible</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg type varselboks]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>555d1417-c455-4f45-b5f9-ba49e0f27ba6</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelfeatured.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelfeatured.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="17f3575a-ce60-4d9d-9cad-1e9fb73e3e9c" Alias="artikkelFeatured" Level="1">
+  <Info>
+    <Name>Fremhevet artikkel</Name>
+    <Icon>icon-bullhorn</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Stor hero-blokk på Aktuelt-siden. Pek på én artikkel som vises som featured.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>00d47bfe-3621-41b0-beb9-27725904cfd8</Key>
+      <Name>Artikkel</Name>
+      <Alias>artikkel</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikkelen som skal fremheves.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3a3686fe-96a6-461f-babc-7bbd9c89e568</Key>
+      <Name>Ingress (overstyr)</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: artikkelens egen ingress. Skriv her for å overstyre.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>e062e2e0-c808-4f07-aa77-f375d061e8fe</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelfremheving.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelfremheving.config
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="4b3cac2f-623b-46ac-a3d4-8caf0276fdf1" Alias="artikkelFremheving" Level="1">
+  <Info>
+    <Name>Fremheving</Name>
+    <Icon>icon-favorite</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Uthevet boks med valgfritt bilde, bakgrunnsfarge og sitat-tegn. Brukes for fakta, høydepunkter og sitater.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>c8d059f7-e7af-4379-93f2-f8e4002e79f3</Key>
+      <Name>Bilde</Name>
+      <Alias>bilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfritt bilde til venstre for teksten på desktop, over på mobil]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3abfc871-70a5-4a1b-a60e-6649e37c143a</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8360c001-ea80-4b73-8cd0-62de53132a5e</Key>
+      <Name>Kilde</Name>
+      <Alias>kilde</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri kilde/citat-attribusjon, vises under teksten]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b8b5930c-8113-4de9-bc63-b66130a769dd</Key>
+      <Name>Tekst</Name>
+      <Alias>tekst</Alias>
+      <Definition>df46ef09-2c6f-48ef-9c38-62784314af84</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedteksten i fremhevingen. Bare grunnleggende formatering tillatt (fet, kursiv, lister, lenker).]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>02524f4a-eebd-4216-9036-3634690bb504</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift over teksten]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6333b6ba-cd66-4c41-8ce3-6bbc67f056d4</Key>
+      <Name>Vis anførselstegn</Name>
+      <Alias>visAnforselstegn</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Slå på «...» rundt teksten (Sitat-stil). Standard av.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>aab7c45e-6967-4a40-9f8a-80573f253054</Key>
+      <Name>Vis bakgrunnsfarge</Name>
+      <Alias>visBakgrunn</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Slå på lyseblå bakgrunn (Faktaboks-stil). Standard på.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>687b8b1f-757e-4a68-bc15-3553329d6e13</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelgruppe.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelgruppe.config
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="b4b298e1-37c4-4c5d-a443-d3ade3bad888" Alias="artikkelGruppe" Level="1">
+  <Info>
+    <Name>Artikkel-gruppe</Name>
+    <Icon>icon-grid</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Grid av artikler. Velg tittel (valgfri), antall kolonner (1-4) og opptil 6 artikler.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>9daeda64-18b6-4875-bf6a-b4d1ec3c254d</Key>
+      <Name>Antall kolonner</Name>
+      <Alias>antallKolonner</Alias>
+      <Definition>53c859b1-21a5-40cb-ab18-da0ad085a329</Definition>
+      <Type>Umbraco.DropDown.Flexible</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hvor mange kort per rad i grid-visningen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>dd01887f-280a-4e2a-a1bc-de0d541d3781</Key>
+      <Name>Artikkel 1</Name>
+      <Alias>artikkel1</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikkel som vises i kortet.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>29fabd10-193b-4aae-8fd5-7af89cab1747</Key>
+      <Name>Artikkel 2</Name>
+      <Alias>artikkel2</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4478bba9-496b-4c1b-83a7-bff0d00ab71b</Key>
+      <Name>Artikkel 3</Name>
+      <Alias>artikkel3</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a180b02e-c694-4bad-9569-b05c9cc400be</Key>
+      <Name>Artikkel 4</Name>
+      <Alias>artikkel4</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ce796638-eabc-460e-b149-1676ba93f65f</Key>
+      <Name>Artikkel 5</Name>
+      <Alias>artikkel5</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>053bd143-2eea-4440-820c-17eff02a53d3</Key>
+      <Name>Artikkel 6</Name>
+      <Alias>artikkel6</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>8</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f6c5cc1c-c1b5-46b1-a9f2-6fe1b1c7ede2</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift over gruppen.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>c3d03f3c-dd35-4ed5-a502-833f0121ab67</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelinfoboks.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelinfoboks.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="12fd6733-7e46-4b1b-a954-80be9bff4612" Alias="artikkelInfoBoks" Level="1">
+  <Info>
+    <Name>Artikkel Infoboks</Name>
+    <Icon>icon-info</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Blå infoboks (#e5f2f7 bakgrunn)</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>fb4bdbb8-e3db-4a02-8fa9-216bf6149b86</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ae3f4be8-e286-4442-9089-b4aaf787253e</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>0a52ba6e-f2b1-4ebd-9a0f-db1b217e4cf4</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelinnholdfra.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelinnholdfra.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="307e019a-bbcf-4211-a09a-ffce2d52d011" Alias="artikkelInnholdFra" Level="1">
+  <Info>
+    <Name>Innhold fra organisasjon</Name>
+    <Icon>icon-shield</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Markerer at innholdet kommer fra en annen virksomhet (ikke en navngitt forfatter).</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>c38d70d1-2bf4-4da4-a499-6db43c8ffb87</Key>
+      <Name>Sist oppdatert</Name>
+      <Alias>dato</Alias>
+      <Definition>5046194e-4237-453c-a547-15db3a07c4e1</Definition>
+      <Type>Umbraco.DateTime</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Dato for siste oppdatering. Hvis tom brukes artikkelens oppdateringsdato.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>2c3fd8ca-1bea-4019-b662-cc21f6bb4f6d</Key>
+      <Name>Virksomhet</Name>
+      <Alias>virksomhet</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Navn på virksomheten som har levert innholdet]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>7ee4d798-6de5-4f55-a553-433cefa5aa1f</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelkontaktkort.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelkontaktkort.config
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="d8b6c846-e796-4e70-afd3-2ca356a0990b" Alias="artikkelKontaktkort" Level="1">
+  <Info>
+    <Name>Kontaktkort</Name>
+    <Icon>icon-message</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Kontaktkort med navn, stilling, virksomhet, e-post og telefon. Lyseblå bakgrunn.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>55e163da-f595-41bf-aff3-69458e19a190</Key>
+      <Name>E-post</Name>
+      <Alias>epost</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kontaktens e-postadresse]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e2e2652d-a2c7-4af5-b8f5-67ab515f1e64</Key>
+      <Name>Navn</Name>
+      <Alias>navn</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kontaktpersonens navn]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5405ac36-377f-4269-bf99-0cb3410a6635</Key>
+      <Name>Stilling</Name>
+      <Alias>stilling</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f3be3273-aed0-4973-83c1-5c66cb1433ca</Key>
+      <Name>Telefon</Name>
+      <Alias>telefon</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfritt telefonnummer]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>22269cd2-0012-4b8d-be11-75f15cb3f084</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift, f.eks. 'Kontaktperson' eller 'Spørsmål?']]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8fc7fa7b-90db-4c9e-ba7d-852030ee8c49</Key>
+      <Name>Virksomhet</Name>
+      <Alias>virksomhet</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Anbefalt sammen med eller i stedet for e-post for å gjøre personen lett å finne]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>e287d5ff-4e2b-42ef-b798-7e7705659eb2</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelprosessstegitem.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelprosessstegitem.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="60a48165-34ef-47b7-a43c-87f214ad29de" Alias="artikkelProsessStegItem" Level="1">
+  <Info>
+    <Name>Prosesstegg-element</Name>
+    <Icon>icon-list</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et enkelt steg i en prosess. Nummereres automatisk fra rekkefølge.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>bf2817ad-5e04-4ba1-9f65-4b7f6011350d</Key>
+      <Name>Beskrivelse</Name>
+      <Alias>beskrivelse</Alias>
+      <Definition>df46ef09-2c6f-48ef-9c38-62784314af84</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskrivelse av dette steget. Bare grunnleggende formatering tillatt.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ac4f341e-6def-40d2-896e-fbdd5e93cd19</Key>
+      <Name>Etikett</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri etikett ved siden av nummeret. Standard: 'Steg'. Kan overstyres til f.eks. 'Fase' eller 'Idé'.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>e6116cbc-c4f2-4b8a-bd43-9b92514f252c</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelprosessteg.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelprosessteg.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="250deaaf-6798-41f2-a4c4-4e2a2fc23de2" Alias="artikkelProsessteg" Level="1">
+  <Info>
+    <Name>Prosessteg</Name>
+    <Icon>icon-ordered-list</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Nummerert liste over steg i en prosess. Hvert steg får automatisk nummer.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>a0830008-70aa-495a-a9f6-e30d94fb6ec4</Key>
+      <Name>Steg</Name>
+      <Alias>steg</Alias>
+      <Definition>3d6431ea-42a2-4e89-8f8c-e7b1313047f8</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Legg til ett eller flere steg. Nummereres automatisk.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>cb2cece0-dea8-4792-8812-8621a8fed45b</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift over hele prosessen, f.eks. 'Slik foregår prosessen']]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>c55c97f2-9abe-4c8e-bb5e-fd692cefd7a3</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelrelatert.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelrelatert.config
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="ac5871bc-864d-4d27-bf23-1c9d7cb46a01" Alias="artikkelRelatert" Level="1">
+  <Info>
+    <Name>Kort-gruppe (kun merkelapp)</Name>
+    <Icon>icon-link</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>3 kort med kun merkelapp og tittel (ingen bilde). Pek på artikler eller veiledninger.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>7ed377a1-9065-42f1-951b-bb34f8dcbdb3</Key>
+      <Name>Relatert 1</Name>
+      <Alias>relatert1</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikkel eller veiledning.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6b04e344-7647-459a-aa8e-d696b06b070d</Key>
+      <Name>Relatert 2</Name>
+      <Alias>relatert2</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c11385c8-834c-4020-a024-01e260ed7686</Key>
+      <Name>Relatert 3</Name>
+      <Alias>relatert3</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d115f02a-4d4d-4d00-a02a-a441315fc6d3</Key>
+      <Name>Merkelapp 1</Name>
+      <Alias>relatertTag1</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri merkelapp på kort 1.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f1b2a576-747c-4a2a-b055-334008818d69</Key>
+      <Name>Merkelapp 2</Name>
+      <Alias>relatertTag2</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri merkelapp på kort 2.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>84270e1b-d75b-48db-88dd-b0c242932d62</Key>
+      <Name>Merkelapp 3</Name>
+      <Alias>relatertTag3</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri merkelapp på kort 3.]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4c1272ca-b521-440b-914b-082427aee414</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift over kortene.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>8b5c9d15-4985-425a-afb3-54e89e6a0949</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelsitat.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkelsitat.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="1ec90ee4-c393-4c97-ba90-c4ef3104e720" Alias="artikkelSitat" Level="1">
+  <Info>
+    <Name>Artikkel Sitat</Name>
+    <Icon>icon-quote</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Uthevet sitat med valgfri kilde</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>12885301-9615-4b23-8546-58515e1d86e1</Key>
+      <Name>Kilde</Name>
+      <Alias>kilde</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>dbadded6-3221-4b32-b360-8fb7270c76ba</Key>
+      <Name>Sitat</Name>
+      <Alias>sitat</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>430cd5e2-b369-4c11-a74f-1ee2f85a12eb</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkeltekst.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkeltekst.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="c5ddaf44-3abe-41a7-8b47-e1b82c66d95e" Alias="artikkelTekst" Level="1">
+  <Info>
+    <Name>Brødtekst</Name>
+    <Icon>icon-edit</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Rik tekstblokk med overskrifter (H2/H3/H4), lister, lenker, fet, kursiv og blockquote</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>c08d31c5-ad75-4e7c-98a2-aaf40a2ae702</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>4fdee952-eada-4745-84e0-cde8994dc35c</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkeltrekkspill.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkeltrekkspill.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="f6e6bb2f-ea53-4462-8a15-ea4382de55f0" Alias="artikkelTrekkspill" Level="1">
+  <Info>
+    <Name>Trekkspill</Name>
+    <Icon>icon-list</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Klikkbar tittel som åpner skjult innhold under. Bra for bonus-info, ofte stilte spørsmål, eller detaljer leseren kan hoppe over.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>4a154f40-486f-4cb6-8221-14ee28a54111</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>84c16e76-c0b3-49df-abc9-3d0aa26011ae</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>8e985e41-b613-4a33-9936-c1f9cfc29428</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikkeltrekkspillsettings.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikkeltrekkspillsettings.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="65cb2117-645a-46af-b2ac-625492d575be" Alias="artikkelTrekkspillSettings" Level="1">
+  <Info>
+    <Name>Trekkspill — innstillinger</Name>
+    <Icon>icon-settings</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Per-trekkspill innstillinger. Vises som egen tab i blokk-editoren.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>18866ee7-6638-4d87-bd54-1340ecab115e</Key>
+      <Name>Gruppe-tittel</Name>
+      <Alias>gruppeTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hvis satt: dette trekkspillet starter en ny gruppe med denne tittelen. La stå tom for at trekkspillet skal slå seg sammen med trekkspill rett over.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="gruppe">Gruppering</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>7dd37754-e61b-41e8-be4b-64bcbdf51645</Key>
+      <Caption>Gruppering</Caption>
+      <Alias>gruppe</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/artikler.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/artikler.config
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="4d5db812-809f-4372-9024-f91619ad7ed9" Alias="artikler" Level="1">
+  <Info>
+    <Name>Artikler</Name>
+    <Icon>icon-newspaper-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="387c36e8-69c0-4c33-8724-81742da30ae9" SortOrder="0">artikkel</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>78dc4656-fbaa-44cc-98e7-989c7778d305</Key>
+      <Name>Fremhevet artikkel</Name>
+      <Alias>featuredArtikkel</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikkel som vises stort øverst. Tom = bruk nyeste automatisk.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>74d5342d-bfce-409a-8ea4-349413450474</Key>
+      <Name>Subtittel</Name>
+      <Alias>heroSubtittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort støttetekst under tittelen. Kan stå tom.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e81139cd-4b71-409e-bee2-c882cac86b5d</Key>
+      <Name>Tittel</Name>
+      <Alias>heroTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises som overskrift på /artikler. Default er 'Aktuelt' hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e6299235-c405-480e-895c-d30bb448af06</Key>
+      <Name>Seksjoner</Name>
+      <Alias>seksjoner</Alias>
+      <Definition>3655b796-f129-4c08-a962-bd0fc7481c0a</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bygg opp /artikler med fremhevet artikkel, kort-grupper (1–4 kolonner) og merkelapp-kort. Reorder ved drag og drop. La stå tom for automatisk visning.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>eebc7d07-4553-43f3-bc22-c90e98d1a24f</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b64445e5-8ecf-411b-9a2f-d07006f461a6</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1528f850-cbba-4be2-9424-223f6de8bbbc</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>4ce8f4c1-a4e7-46da-8221-2e6902264a12</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>d4480a2d-0ae6-4e20-8b36-06bdc253897d</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/eksempel.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/eksempel.config
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="19b78454-19a6-4705-b5cd-b08a39b70c14" Alias="eksempel" Level="1">
+  <Info>
+    <Name>Eksempel</Name>
+    <Icon>icon-science</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Eksempler fra offentlig sektor</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>6e8ba327-dcb4-4b4b-8199-656beb77b0cd</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen (eller under på mobil).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>17ef5f14-fe4d-4b62-bdeb-21784fd03c18</Key>
+      <Name>Bakgrunn</Name>
+      <Alias>bakgrunn</Alias>
+      <Definition>55043cae-9d13-4015-b915-789d02b4b825</Definition>
+      <Type>Umbraco.ColorPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bakgrunnsfarge for artikkelhodet.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>fc5a0a3c-adf6-4fcb-8914-567cd76d95e7</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c82bfde4-658c-43e9-8dfb-d861c5bc77f7</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>76d59f67-20be-4f17-b380-fb0c4c5a73d1</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>e1c48978-c80c-4540-b5f5-da4d77578bb4</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedinnhold]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>38e8f003-0ef1-41cd-a31e-5bcbbf1fbaae</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>286d5f8d-2a45-44fe-8b21-bc6cc2659fb0</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1690d858-ea93-41b6-899d-270277726bd6</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9e455e91-07a2-4107-a333-28472ac84eae</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. Genereres automatisk fra tittel hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>02a3e378-97bf-4a28-8dfc-972a107a927c</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>0cc2ce4f-e0ff-47e1-8d82-92900c8d121f</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>49a1d1aa-c388-475a-8e0a-32cc733acb62</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>ecfed5db-dc98-4f7b-bd47-147547ea2d77</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelfeatured.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelfeatured.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="db3ab525-e80d-45ba-8b65-b090db99a783" Alias="eksempelFeatured" Level="1">
+  <Info>
+    <Name>Fremhevet eksempel</Name>
+    <Icon>icon-bullhorn</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Stor hero-blokk på Eksempler-siden. Pek på ett eksempel som vises som featured.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>0941fc58-953c-498d-bbb5-b89fa26ac088</Key>
+      <Name>Eksempel</Name>
+      <Alias>eksempel</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg eksempelet som skal fremheves.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>2fcad10a-6e14-4e42-aa2f-b8a7294db815</Key>
+      <Name>Ingress (overstyr)</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: eksemplets egen ingress. Skriv her for å overstyre.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>10055483-d09d-42a0-ab80-8ba215eb4c94</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelgruppe.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelgruppe.config
@@ -1,0 +1,177 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="c0a6d510-6451-4867-b8e9-8df04f041769" Alias="eksempelGruppe" Level="1">
+  <Info>
+    <Name>Eksempel-gruppe</Name>
+    <Icon>icon-grid</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Grid av eksempler. Velg tittel (valgfri), antall kolonner (1-4) og opptil 6 eksempler.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>d44e26d1-bbb1-4a99-846f-77992117ca6e</Key>
+      <Name>Antall kolonner</Name>
+      <Alias>antallKolonner</Alias>
+      <Definition>53c859b1-21a5-40cb-ab18-da0ad085a329</Definition>
+      <Type>Umbraco.DropDown.Flexible</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hvor mange kort per rad i grid-visningen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>16daaf63-b85b-4b2e-bf89-3a932b2be4d6</Key>
+      <Name>Eksempel 1</Name>
+      <Alias>eksempel1</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg eksempel som vises i kortet.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>db4f3d3e-a7bd-4243-9f88-2d13429623ee</Key>
+      <Name>Eksempel 2</Name>
+      <Alias>eksempel2</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>76a56274-2c9c-406a-9438-3c6b7ae73d0a</Key>
+      <Name>Eksempel 3</Name>
+      <Alias>eksempel3</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c14c223b-7a16-44cd-9077-948bd6359462</Key>
+      <Name>Eksempel 4</Name>
+      <Alias>eksempel4</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>cb107d37-f279-4d5d-b6a7-60121d26bc85</Key>
+      <Name>Eksempel 5</Name>
+      <Alias>eksempel5</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>328e79c9-ee93-4836-ac2c-83a81c3a6239</Key>
+      <Name>Eksempel 6</Name>
+      <Alias>eksempel6</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri, la stå tom hvis gruppen skal ha færre kort.]]></Description>
+      <SortOrder>8</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>95123645-943c-4b40-87b5-65df13720c2a</Key>
+      <Name>Merkelapp på kortene</Name>
+      <Alias>kortTag</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Tekst på merkelappen øverst på hvert kort i gruppen. Standard: Eksempel]]></Description>
+      <SortOrder>9</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3696b7b1-3785-46d8-a979-a5a6b2147002</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift over gruppen.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>b44080a0-2c92-4fb6-a22a-a092ac318388</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelkontakt.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelkontakt.config
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="2307b37a-5967-4b2b-ac9e-54e3990e6ac4" Alias="eksempelKontakt" Level="1">
+  <Info>
+    <Name>Kontakt-boks</Name>
+    <Icon>icon-mailbox</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Kontakt-boks med tittel, navn, e-post og stilling.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>3f4adb6c-895c-445d-9be0-c367656d055e</Key>
+      <Name>E-post</Name>
+      <Alias>epost</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kontaktpersonens e-postadresse.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f52e9162-c569-4515-acc5-a16a06dc99e5</Key>
+      <Name>Navn</Name>
+      <Alias>navn</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kontaktpersonens navn.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>101b8cbc-4fa1-40a2-9799-9a97b3d0fa9f</Key>
+      <Name>Stilling</Name>
+      <Alias>stilling</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kontaktpersonens stilling/tittel.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>120d5146-c8f6-41a7-b307-ce09d89a9e14</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Eks: 'Ønsker du å dele et eksempel?']]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>bc10bab5-b3ef-4e23-9e91-5d6d45bca281</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelrelatert.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/eksempelrelatert.config
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="97e56431-0731-4c67-a68a-a52a210f02b6" Alias="eksempelRelatert" Level="1">
+  <Info>
+    <Name>Relatert innhold</Name>
+    <Icon>icon-link</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>3 kort som peker til relaterte artikler eller veiledninger.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>0dfe746b-5fe6-4aa9-a43f-35ed2408c01a</Key>
+      <Name>Relatert 1</Name>
+      <Alias>relatert1</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikkel eller veiledning.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c1a83cd2-37ec-43e3-9003-945d42dfddc4</Key>
+      <Name>Relatert 2</Name>
+      <Alias>relatert2</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>65e466c3-c9d6-4bd8-abca-07394c9b49fb</Key>
+      <Name>Relatert 3</Name>
+      <Alias>relatert3</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>035ccdc2-44b5-4ef0-9d84-15f77d01deb9</Key>
+      <Name>Merkelapp 1</Name>
+      <Alias>relatertTag1</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri merkelapp på kort 1.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>51ee8ad5-b4ef-44d2-bea6-bb0c8ceba580</Key>
+      <Name>Merkelapp 2</Name>
+      <Alias>relatertTag2</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri merkelapp på kort 2.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0625a14d-b7e6-4c51-82a1-89deb1a11076</Key>
+      <Name>Merkelapp 3</Name>
+      <Alias>relatertTag3</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri merkelapp på kort 3.]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6adda1b0-52ab-427c-941d-94eb76f83afc</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri overskrift over de relaterte lenkene.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>996dd916-c8a3-40f6-9f7f-099267bcd75c</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/eksempler.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/eksempler.config
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="3ddd05e8-ebff-422c-bc3e-2c7956c45de1" Alias="eksempler" Level="1">
+  <Info>
+    <Name>Eksempler</Name>
+    <Icon>icon-science</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Oversiktsside for eksempler. Redigerbart hode + eksempel-barn under.</Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="19b78454-19a6-4705-b5cd-b08a39b70c14" SortOrder="0">eksempel</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>c82e25c8-96a2-406a-adf5-654758ebd0ea</Key>
+      <Name>Tittel</Name>
+      <Alias>heroTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises som overskrift på /eksempler]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f394d6d5-ae81-4d48-9491-c4c9191adddd</Key>
+      <Name>Seksjoner</Name>
+      <Alias>seksjoner</Alias>
+      <Definition>ddb7000e-1391-49e3-afb8-31862debd881</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bygg opp /eksempler med fremhevet eksempel, grupper med 1–4 kolonner, relaterte lenker og kontakt-CTA. Reorder ved drag og drop.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>664056b6-65c1-4f26-b94d-5860d66d51f5</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1cf44ae7-1ef1-4b95-8b0a-3375bbaa78e4</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>667a5e95-ecd0-4d4c-a305-09fa66bcf402</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>14b7c83a-f5ff-456a-bb5d-9faf6ee8cf19</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>a57f3cb2-84f9-407b-948c-299c31b086b6</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/enkelveiledning.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/enkelveiledning.config
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="0af083ac-b274-42a7-ba4a-e772271d6f7a" Alias="enkelVeiledning" Level="1">
+  <Info>
+    <Name>Veiledning Enkel</Name>
+    <Icon>icon-document-spreadsheet</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Veiledning som artikkel — uten understeg eller flersides struktur. Bruk denne når veiledningen er én side med løpende innhold.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>8ee54d51-fb4a-479a-8ccb-dbbe6ceff48b</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen (eller under på mobil).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f8f01af7-bffc-4acc-9df2-04eaa6f9705a</Key>
+      <Name>Bakgrunn</Name>
+      <Alias>bakgrunn</Alias>
+      <Definition>55043cae-9d13-4015-b915-789d02b4b825</Definition>
+      <Type>Umbraco.ColorPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bakgrunnsfarge for artikkelhodet.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>34503334-4ba0-4a6f-ad6f-5e9e549642e1</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1b460b8b-baf9-4d3e-9790-ded0e814f6f2</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9f2e820d-c1ff-44b3-bac4-6568b48a608d</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>954c4353-b6b0-4b7d-8b9f-ae860d5c811e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedinnhold — samme moduler som artikler.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e7fa3873-bc7e-4b7a-baca-162c27a83f39</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d2cb872b-7a67-4cde-b856-b0863d4a2999</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c2383e6a-6d69-4532-98da-0a1a18de58bf</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a7993643-abcf-4ae4-a006-19023c70a479</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. Genereres automatisk fra tittel hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>701470fb-a482-494c-99b1-4b1f79265fbb</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>36731a98-c306-4db5-93d3-bdc90634beb1</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>a969ebc8-4342-452b-9695-9549a314f56d</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>ea22fc7b-0569-4e89-9701-7d5f5110dc53</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forside.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forside.config
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="b6910b0b-f86b-4395-a808-5496b54f4a85" Alias="forside" Level="1">
+  <Info>
+    <Name>Forside</Name>
+    <Icon>icon-home</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Forsiden av nettstedet</Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>984afb43-a8a0-4a11-b5ed-1bdfdd7c579e</Key>
+      <Name>Seksjoner</Name>
+      <Alias>seksjoner</Alias>
+      <Definition>c00700c4-edec-460d-8183-638365e8e1cc</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bygg opp forsiden ved å legge til moduler. Reorder ved drag og slipp.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7f5e6957-354e-4931-b5b8-f8bc7e051a83</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>fe4f8cfb-2590-4a72-a506-511e933b2319</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>840f50ba-5093-4a3c-8cb4-dc7212edb02f</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>4f187f06-b1ea-445c-9d82-0c53911c7e37</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>8</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>9e10c13e-326c-4390-ac81-f6a8de94bc83</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>9</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsideaktuelt.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsideaktuelt.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="68871e1d-b635-4918-9c65-04bf3910c619" Alias="forsideAktuelt" Level="1">
+  <Info>
+    <Name>Forside Aktuelt</Name>
+    <Icon>icon-newspaper-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Seksjon med siste artikler (innhold hentes automatisk)</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>51458f6e-265a-4c49-9307-a5b99ac7adc3</Key>
+      <Name>Fremhevet artikkel</Name>
+      <Alias>fremhevetArtikkel</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikkelen som vises stort. Standard: nyeste artikkel.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b9bf26bd-c654-45e1-84e7-4ccb9e415a13</Key>
+      <Name>Kort</Name>
+      <Alias>kort</Alias>
+      <Definition>bc120566-2cf9-4f95-b623-25c191b189f8</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg artikler. La stå tom for å vise nyeste automatisk. Første kort vises stort.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>45694638-c3be-4ca0-a32f-441870731b49</Key>
+      <Name>Lenketekst</Name>
+      <Alias>lenketekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: Se alle artikler]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>335cad50-9b30-43f0-b74c-b9d868b8683d</Key>
+      <Name>Lenke-URL</Name>
+      <Alias>lenkeUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: /artikler]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>992e36b6-d373-4dca-b115-052f2cb17b8b</Key>
+      <Name>Overskrift</Name>
+      <Alias>overskrift</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>fbf32c50-f1a3-4280-9815-08a19c1a959f</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsidearrangementer.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsidearrangementer.config
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="75a81881-118a-477c-a222-b86521717e18" Alias="forsideArrangementer" Level="1">
+  <Info>
+    <Name>Forside Arrangementer</Name>
+    <Icon>icon-calendar</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Seksjon med kommende arrangement (innhold hentes automatisk)</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>61cd55dd-2b73-4aa1-965f-46208beeb169</Key>
+      <Name>Fremhevet arrangement</Name>
+      <Alias>arrangement</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: neste kommende arrangement]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>fc17fe3c-08dc-4c1d-8822-182a8b93f56a</Key>
+      <Name>Lenketekst</Name>
+      <Alias>lenketekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: Se alle arrangementer]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>eb2f02e9-84a7-489d-a712-54d82a0f30ee</Key>
+      <Name>Lenke-URL</Name>
+      <Alias>lenkeUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: /kalender]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c14b1b3c-7366-4f99-972c-7fb0aa6e5a0a</Key>
+      <Name>Overskrift</Name>
+      <Alias>overskrift</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>540f8ee1-1935-4f32-986c-0eb781b6e424</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsideartikkelkort.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsideartikkelkort.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="db79563e-d5cb-4325-b0a2-ffca880c7621" Alias="forsideArtikkelKort" Level="1">
+  <Info>
+    <Name>Forside Artikkelkort</Name>
+    <Icon>icon-newspaper-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et kort som peker på en artikkel på forsiden</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>ff6b59ab-141c-4dd4-902b-501e8c4bf378</Key>
+      <Name>Artikkel</Name>
+      <Alias>artikkel</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>223a3fab-8f09-46c1-b043-1cb64bf5b539</Key>
+      <Name>Ingress (overstyr)</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: artikkelens egen ingress. Skriv her for å overstyre.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>3ba47cb7-220c-4f2b-82f1-ff567f3a8bb4</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsideeksempelkort.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsideeksempelkort.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="999414cd-60d9-4072-bec8-e9f653936d7c" Alias="forsideEksempelKort" Level="1">
+  <Info>
+    <Name>Forside Eksempelkort</Name>
+    <Icon>icon-light-bulb</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et kort som peker på et eksempel på forsiden</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>6e35201f-b096-47f2-a3f6-4e4026c3f51f</Key>
+      <Name>Eksempel</Name>
+      <Alias>eksempel</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5093d5f2-4e4b-40e7-9025-7efef2558201</Key>
+      <Name>Ingress (overstyr)</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: eksemplets egen ingress. Skriv her for å overstyre.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>1b322458-c5a5-4825-903e-2f20f35a9ef6</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsideforstalenke.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsideforstalenke.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="54f34e34-425b-48b5-a7a8-5764272f2ee0" Alias="forsideForstaLenke" Level="1">
+  <Info>
+    <Name>Forstå regelverket-lenke</Name>
+    <Icon>icon-link</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>En lenke som peker på en veiledning eller artikkel</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>f132c23e-daa4-4a39-aa68-416cf2e05fdf</Key>
+      <Name>Lenke</Name>
+      <Alias>lenke</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg veiledning eller artikkel. Tittel og lenke hentes automatisk.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>1d8bf305-548d-43a9-bb53-7f155ecbcb26</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsideforstaregelverket.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsideforstaregelverket.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="89df006d-6f46-4909-a34d-f4c1fb17cfa5" Alias="forsideForstaRegelverket" Level="1">
+  <Info>
+    <Name>Forstå regelverket</Name>
+    <Icon>icon-book-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Enkel lenkeliste til veiledninger/artikler om regelverk</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>9e96effc-726e-4df0-8c2c-32d915a5d614</Key>
+      <Name>Lenker</Name>
+      <Alias>lenker</Alias>
+      <Definition>3822189c-de95-4aea-b6a1-47012fcffb41</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg veiledninger/artikler som vises som enkel lenkeliste.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3e48b7dc-b41b-42f7-8608-93953c99dbbe</Key>
+      <Name>Overskrift</Name>
+      <Alias>overskrift</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: Forstå regelverket]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>21636843-7028-4a24-9cbe-3ab6acd5ecfa</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsidehero.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsidehero.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="956fc6c9-a077-43c1-9f48-98f9d5f9e05f" Alias="forsideHero" Level="1">
+  <Info>
+    <Name>Forside Hero</Name>
+    <Icon>icon-home</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Hero-seksjon øverst på forsiden</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>244cc93c-0305-4eaa-a043-31430071e5f1</Key>
+      <Name>Illustrasjon</Name>
+      <Alias>illustrasjon</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>21f12b6c-d9fb-488b-98d6-2bdd7bdb449a</Key>
+      <Name>Kom i gang-ledetekst</Name>
+      <Alias>komIGangTekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Liten ledetekst foran lenken, f.eks. "Kom i gang".]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7d1f33c0-ffc1-42bf-a72e-71f6c9e5c037</Key>
+      <Name>Lenketekst</Name>
+      <Alias>lenketekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: Hva er KI og hva kan du bruke det til?]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9ff3c78b-c92a-466d-8abe-3110b54b7bf5</Key>
+      <Name>Lenke-URL</Name>
+      <Alias>lenkeUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: /veiledning/hva-er-ki]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c100fd70-c8f1-482a-aff1-9a06f1a59b2c</Key>
+      <Name>Overskrift</Name>
+      <Alias>overskrift</Alias>
+      <Definition>df46ef09-2c6f-48ef-9c38-62784314af84</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedteksten i hero-seksjonen. Bruk fet skrift for å fremheve ord.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>ce4116e3-4647-42b0-8b65-4a25e2bc5f33</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsidelaeravandre.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsidelaeravandre.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="dbfcac22-3861-482e-89bf-aaed40357728" Alias="forsideLaerAvAndre" Level="1">
+  <Info>
+    <Name>Forside Lær av andre</Name>
+    <Icon>icon-light-bulb</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Seksjon med eksempler (innhold hentes automatisk)</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>2bd34f2e-6c6f-4ba2-96da-61c713635957</Key>
+      <Name>Kort</Name>
+      <Alias>kort</Alias>
+      <Definition>b0680599-6c2c-4ea9-94c1-26c9b2033c9f</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg eksempler. La stå tom for å vise nyeste automatisk.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>aae1a5a6-af4f-44e6-b40d-b33439b9c662</Key>
+      <Name>Merkelapp på kortene</Name>
+      <Alias>kortTag</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Tekst på merkelappen øverst på hvert eksempelkort. Standard: Eksempel]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ea8fb263-a6a4-4e38-8d21-4ad17004b573</Key>
+      <Name>Lenketekst</Name>
+      <Alias>lenketekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: Se alle eksempler]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e413b9bc-2efa-4c57-8643-12fe20efd89e</Key>
+      <Name>Lenke-URL</Name>
+      <Alias>lenkeUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: /eksempler]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1bd7d95e-63c4-4b39-884b-e6bb3721ad50</Key>
+      <Name>Overskrift</Name>
+      <Alias>overskrift</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>7b56eafe-9a91-4664-a5f5-b3a18f576f9a</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsidesandkasse.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsidesandkasse.config
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="a02b9c45-941c-46d3-850b-c25818de9c65" Alias="forsideSandkasse" Level="1">
+  <Info>
+    <Name>Forside Sandkasse</Name>
+    <Icon>icon-box</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Sandkasse-CTA på forsiden</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>dc1300c8-8d56-43f4-997d-9b904f631829</Key>
+      <Name>Illustrasjon</Name>
+      <Alias>illustrasjon</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>90f63ca6-1f3b-4e2d-aa17-e836ef6fee9a</Key>
+      <Name>Lenke-URL</Name>
+      <Alias>lenkeUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: /sandkasse]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>fbd85f27-2924-4691-9f90-e9523f07bfeb</Key>
+      <Name>Lenketekst</Name>
+      <Alias>overskrift</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Klikkbar overskrift på sandkasse-kortet.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>290d174c-e9f3-45a6-9451-011f2b69f264</Key>
+      <Name>Tekst</Name>
+      <Alias>tekst</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort beskrivelse under overskriften.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>c2627a63-957a-47cf-8549-6792e1c37ac0</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/forsideveiledning.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/forsideveiledning.config
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="26de029e-00f2-4e58-b233-2962c6290589" Alias="forsideVeiledning" Level="1">
+  <Info>
+    <Name>Forside Veiledning</Name>
+    <Icon>icon-book-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Fremhevet veiledning på forsiden</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>6163e6d5-9f65-4deb-b925-705b77303a33</Key>
+      <Name>Illustrasjon</Name>
+      <Alias>illustrasjon</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: bildet til valgt veiledning.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8caa03be-7c83-4261-96eb-63b92986e4c0</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: ingressen til valgt veiledning.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>11ec77b5-6cba-49d9-ad68-8541a693db7b</Key>
+      <Name>Label</Name>
+      <Alias>label</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Liten etikett over tittelen, f.eks. "Veiledning".]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9259c481-57cc-4fe7-ad2a-9e070dc88ca9</Key>
+      <Name>Lenke-URL</Name>
+      <Alias>lenkeUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: lenken til valgt veiledning (ellers /veiledning).]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d554a28e-4da1-4136-b659-c2e50bb158dd</Key>
+      <Name>Lenketekst</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Standard: tittelen til valgt veiledning.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>012339e7-8df2-47f4-9c91-c3b1da18b67a</Key>
+      <Name>Veiledning</Name>
+      <Alias>veiledning</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg veiledningen kortet skal peke på. Gir standard tittel, ingress, bilde og lenke.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>b2849691-8abf-4afd-b019-ba72a66dba84</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/globaleinnstillinger.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/globaleinnstillinger.config
@@ -1,0 +1,420 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="c3e29b2f-49f6-4949-9b70-f12bf69bfb8d" Alias="globaleInnstillinger" Level="1">
+  <Info>
+    <Name>Globale innstillinger</Name>
+    <Icon>icon-settings</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Globale tekster brukt på tvers av sidene (cookie-melding, footer, feilsider). Ett node på rot.</Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>531025d7-a0c0-4cf6-b919-57b899e24d13</Key>
+      <Name>404 beskrivelse</Name>
+      <Alias>beskrivelse404</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Forklarende tekst på 404-siden.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="feilsider">Feilsider</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0ec221fc-8e27-4587-af56-a30fa284b4c0</Key>
+      <Name>503 beskrivelse</Name>
+      <Alias>beskrivelse503</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Forklarende tekst på vedlikeholdssiden.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="feilsider">Feilsider</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>2666ae8a-3ccb-4126-96a3-3926e6049350</Key>
+      <Name>Ja-knapp-tekst</Name>
+      <Alias>cookieJaLabel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Tekst på Ja-knappen. Klikker brukeren denne, lagrer vi informasjon for statistikk og analyse.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="cookie">Cookie-melding</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d72e292c-1350-4954-9b32-546515f00c76</Key>
+      <Name>Nei-knapp-tekst</Name>
+      <Alias>cookieNeiLabel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Tekst på Nei-knappen. Klikker brukeren denne, lagres kun strengt nødvendig informasjon.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="cookie">Cookie-melding</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c5ad3934-04bc-4fce-b623-8cf4396bd729</Key>
+      <Name>Tekst under knappene</Name>
+      <Alias>cookieSekundaerTekst</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Lengre informasjonstekst under knappene (f.eks. om nødvendige cookies).]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="cookie">Cookie-melding</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4d0c6fe5-1d73-4479-9276-3b09306d5388</Key>
+      <Name>Tekst</Name>
+      <Alias>cookieTekst</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises i cookie-banneret nederst på siden.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="cookie">Cookie-melding</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>58d4e576-971e-4030-932a-4512cc629685</Key>
+      <Name>Tittel</Name>
+      <Alias>cookieTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overskrift i cookie-banneret. Eks: 'Får vi samle informasjon om hvordan du bruker nettsiden?']]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="cookie">Cookie-melding</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9479dab3-9877-4c42-b7d7-a72d1ca0ab3f</Key>
+      <Name>Beskrivelse</Name>
+      <Alias>footerBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort tekst under logoen i footeren.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="footer/beskrivelse">Beskrivelse</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>961f4b36-6b47-404b-8895-c70aafe72293</Key>
+      <Name>Kontakt e-post</Name>
+      <Alias>footerEpost</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[E-postadressen som vises under "Kontakt oss".]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="footer/kontakt">Kontakt</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e918f431-4ed7-4535-8dbb-dd2dbde782d3</Key>
+      <Name>Om KI Norge</Name>
+      <Alias>footerLenke1Tekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f975c559-242e-45f8-b63a-d160b0db1c0a</Key>
+      <Name>Om KI Norge (URL)</Name>
+      <Alias>footerLenke1Url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>09b1bf24-12d2-4b30-9ad9-9223762e4d74</Key>
+      <Name>Personvernerklæring</Name>
+      <Alias>footerLenke2Tekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>024964cd-e7d4-405f-9ba5-a2542c6078b3</Key>
+      <Name>Personvernerklæring (URL)</Name>
+      <Alias>footerLenke2Url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>2f1377c9-824c-4e8c-a627-0a61c3fca072</Key>
+      <Name>Informasjonskapsler</Name>
+      <Alias>footerLenke3Tekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a43198f7-cfe8-4b2f-bcee-08af5f989062</Key>
+      <Name>Informasjonskapsler (URL)</Name>
+      <Alias>footerLenke3Url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d7c3e9d1-6789-4b98-ba8f-5440e4685379</Key>
+      <Name>Tilgjengelighet</Name>
+      <Alias>footerLenke4Tekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6e1c4165-c6dd-4b29-8fd2-969696dbcfbd</Key>
+      <Name>Tilgjengelighet (URL)</Name>
+      <Alias>footerLenke4Url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>72ff977e-4bf3-46e0-906a-58d8ef67d72e</Key>
+      <Name>Endre samtykke for informasjonskapsler</Name>
+      <Alias>footerLenke5Tekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>8</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9a1f08b0-aef8-4059-b205-26c7e3fa296f</Key>
+      <Name>Endre samtykke (URL)</Name>
+      <Alias>footerLenke5Url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[La stå tom for å vise som knapp som åpner samtykke-banneret.]]></Description>
+      <SortOrder>9</SortOrder>
+      <Tab Alias="footer/lenker">Lenker</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d0fa8dc4-b8b8-43c3-9fb8-1e277c0eb41b</Key>
+      <Name>404 tittel</Name>
+      <Alias>tittel404</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises som overskrift når en side ikke finnes.]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="feilsider">Feilsider</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c2a7145b-85f5-47b3-9cfb-5c117d914edb</Key>
+      <Name>503 tittel</Name>
+      <Alias>tittel503</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises som overskrift på vedlikeholdssiden.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="feilsider">Feilsider</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5dbde71a-195f-4398-82f6-a988344ccdfd</Key>
+      <Name>Vedlikehold-e-post</Name>
+      <Alias>vedlikeholdEpost</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kontakt-e-post for hjelp under vedlikehold.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="feilsider">Feilsider</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>39b39e0e-3b3c-458b-927a-5195f0156e5e</Key>
+      <Caption>Beskrivelse</Caption>
+      <Alias>footer/beskrivelse</Alias>
+      <Type>Group</Type>
+      <SortOrder>4</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>4f437b17-24d4-4455-910e-1cf79f1f7774</Key>
+      <Caption>Feilsider</Caption>
+      <Alias>feilsider</Alias>
+      <Type>Group</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>65527d5f-fae1-4f95-9401-d6be217788e5</Key>
+      <Caption>Cookie-melding</Caption>
+      <Alias>cookie</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>767ea00e-e531-4906-b13b-681ba68c0ec8</Key>
+      <Caption>Footer</Caption>
+      <Alias>footer</Alias>
+      <Type>Tab</Type>
+      <SortOrder>3</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>d2f0acd8-5c63-4cf3-bad5-3b8d76071d08</Key>
+      <Caption>Kontakt</Caption>
+      <Alias>footer/kontakt</Alias>
+      <Type>Group</Type>
+      <SortOrder>5</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>e6e552c3-f28c-46be-b9fc-0eb302fde6c5</Key>
+      <Caption>Lenker</Caption>
+      <Alias>footer/lenker</Alias>
+      <Type>Group</Type>
+      <SortOrder>6</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/kalender.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/kalender.config
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="ef318626-22b6-43e9-8bf8-9e94e50bcee7" Alias="kalender" Level="1">
+  <Info>
+    <Name>Kalender</Name>
+    <Icon>icon-calendar</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Navigasjonsside for arrangementer</Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="1c03c982-4dcf-46e6-b5b2-b0c75c827689" SortOrder="0">kalenderhendelse</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>63f60f3f-08f0-44a6-8d3e-8054bb4f36af</Key>
+      <Name>Fremhevet arrangement</Name>
+      <Alias>featuredHendelse</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg hvilken hendelse som vises i den store boksen på toppen.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>44130153-830a-4a2f-a43d-aa791c3815f2</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>94ef935a-aaf5-45bd-80e0-9e97e2acbc55</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f35d6348-8fb7-4ed1-961d-5a8536bd8d73</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>31ee9624-33e5-4524-a6e9-139cc263853e</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e85c4137-7f33-49f9-a7e7-e681abfeb7af</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>36d3aad3-f278-4566-afa9-8410fe8ecfdb</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>63a8246a-cc73-4637-849a-8e473957c936</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/kalenderhendelse.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/kalenderhendelse.config
@@ -1,0 +1,216 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="1c03c982-4dcf-46e6-b5b2-b0c75c827689" Alias="kalenderhendelse" Level="1">
+  <Info>
+    <Name>Kalenderhendelse</Name>
+    <Icon>icon-calendar</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Arrangement, workshop eller frokostseminar</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>9aa2c849-b42a-4eb7-91aa-d91d5824745b</Key>
+      <Name>Detaljert beskrivelse</Name>
+      <Alias>detaljertBeskrivelse</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises på enkeltsiden og i featured-boksen.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5f01aa13-3aaa-48c4-8cef-60afe9b73d31</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort beskrivelse for kortvisning.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5e60d8c7-94a2-429f-ad4d-8f569fe352d7</Key>
+      <Name>Lenke</Name>
+      <Alias>lenke</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL til påmelding eller mer info.]]></Description>
+      <SortOrder>9</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a39e8398-f354-4838-baae-6baf1b8065f0</Key>
+      <Name>Pris</Name>
+      <Alias>pris</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[F.eks. "Gratis" eller "1 500 kr". La stå tom for å skjule pris på siden.]]></Description>
+      <SortOrder>10</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>2b5f959c-9d61-4b29-be34-bd897e97a93f</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e85a1ba6-c568-4796-ba04-df083c973bc3</Key>
+      <Name>Sluttdato</Name>
+      <Alias>sluttDato</Alias>
+      <Definition>5046194e-4237-453c-a547-15db3a07c4e1</Definition>
+      <Type>Umbraco.DateTime</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Fyll ut ved flere dager.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0b12fa6a-6fb8-4c3c-9698-4d5ab06a2038</Key>
+      <Name>Startdato</Name>
+      <Alias>startDato</Alias>
+      <Definition>5046194e-4237-453c-a547-15db3a07c4e1</Definition>
+      <Type>Umbraco.DateTime</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5c0c1c0f-f1eb-40e3-865a-19b8ea54cb3e</Key>
+      <Name>Sted</Name>
+      <Alias>sted</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Fysisk adresse eller "Digitalt".]]></Description>
+      <SortOrder>8</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>aba86923-6acc-4ea9-8250-465de47b7961</Key>
+      <Name>Tid</Name>
+      <Alias>tid</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Klokkeslett, f.eks. "09:00-11:00" eller "Hele dagen".]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>010038ef-e5e2-4d6d-a79c-e0e7747f816b</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>30f067d8-b446-4ee7-b361-2449d045c52e</Key>
+      <Name>Merkelapp</Name>
+      <Alias>type</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kommaseparert, f.eks. "Frokostseminar, Offentlig". Vises som merkelapp(er) på kortet.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>97518be4-9bcb-47e7-9f59-b0da5f188c17</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>e30dd83e-014a-4bd5-bc3f-b4c2ac6752c3</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/omoss.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/omoss.config
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="61b8d81c-126c-44c6-9544-5faf815e23de" Alias="omOss" Level="1">
+  <Info>
+    <Name>Om Oss</Name>
+    <Icon>icon-umb-members</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Om Oss-siden</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>30697146-615f-49ae-a9b1-ca8593380f9b</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen (eller under på mobil).]]></Description>
+      <SortOrder>7</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>956f74d6-f4a7-45ea-a66b-a0b723723c32</Key>
+      <Name>Bakgrunn</Name>
+      <Alias>bakgrunn</Alias>
+      <Definition>55043cae-9d13-4015-b915-789d02b4b825</Definition>
+      <Type>Umbraco.ColorPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bakgrunnsfarge for artikkelhodet.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>27d2e80c-b392-4a40-aab6-38ed1f4c8580</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>8</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7881e46e-4852-40cf-9f49-baf56b207d8c</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>6</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>af45f6de-ec66-49ac-865b-c0146482ac4b</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>954c4353-b6b0-4b7d-8b9f-ae860d5c811e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedinnhold]]></Description>
+      <SortOrder>9</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5f1a1690-f15d-452b-b3b1-19073449e489</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4d4ac9b0-d083-492e-b7e9-50102eafa908</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b3eae7f3-3326-4ec3-bf48-137c737ca908</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>cc75b560-667e-46b0-b0ee-025f109d7b01</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. Genereres automatisk fra tittel hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>25b9cc79-2a0f-4399-8145-8292ad9071c2</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>0f5d3c85-8469-4107-95c5-0a6d8ab3018c</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>a26f85fa-6b01-4a84-b429-d84f9484c09a</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>cfdd65c9-8280-45a1-8309-b31401e1112b</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/omossblokk.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/omossblokk.config
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="00990345-eb98-4e2a-8eef-0a1e45a5e7ed" Alias="omOssBlokk" Level="1">
+  <Info>
+    <Name>Om Oss Seksjon</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>En seksjon på Om Oss-siden. Tittel, tekst og valgfritt bilde.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>321ba400-cdbb-470c-8f88-53d9166f8a4b</Key>
+      <Name>Bilde</Name>
+      <Alias>bilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>fa0e6928-1415-427d-b28b-e9c809fb42a9</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ca3bfcc5-8192-4b02-a626-3a0ae8fcbe75</Key>
+      <Name>Tekst</Name>
+      <Alias>tekst</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>15220b65-b158-4412-ba3a-d8a15fb7007b</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>57d57adb-0c76-4dcf-8555-a69b9bdb18fd</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/omossseksjon.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/omossseksjon.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="619e0b1f-b9e7-4ae4-87d3-ae4ae5098eec" Alias="omOssSeksjon" Level="1">
+  <Info>
+    <Name>Om Oss Seksjon (utgår)</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Utgår — bruk seksjon-blokker på Om Oss i stedet</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>bd7447c7-9884-4c6f-bd2c-11447f32111a</Key>
+      <Name>Bilde</Name>
+      <Alias>bilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c6de02ae-e19b-46c2-b85e-649f81ba0cc6</Key>
+      <Name>Rekkefølge</Name>
+      <Alias>rekkefolge</Alias>
+      <Definition>2e6d3631-066e-44b8-aec4-96f09099b2b5</Definition>
+      <Type>Umbraco.Integer</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d21c15dd-a8a1-4d4b-99af-4c44c6230164</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>07444a1a-e863-4935-bcc6-15850c2c02ed</Key>
+      <Name>Tekst</Name>
+      <Alias>tekst</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>cc47f56f-477c-410e-adab-b5e1fe87e492</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>548efa1b-f612-4a1b-b4cb-198af841f773</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/sandkasse.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/sandkasse.config
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="0fea4272-5495-468e-aaa2-ac66aa50fbbd" Alias="sandkasse" Level="1">
+  <Info>
+    <Name>Sandkasse</Name>
+    <Icon>icon-science</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Sandkasse-siden. Skal kun finnes ett eksemplar, plassert under Sider.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>a872f8c7-2cdc-4b2a-afef-a957d641c287</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen (eller under på mobil).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4b36f72d-8706-4f84-afce-124e64496123</Key>
+      <Name>Bakgrunn</Name>
+      <Alias>bakgrunn</Alias>
+      <Definition>55043cae-9d13-4015-b915-789d02b4b825</Definition>
+      <Type>Umbraco.ColorPicker</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bakgrunnsfarge for artikkelhodet.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>110f3992-c75e-4062-be51-e638c99aecb4</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4ff3487b-3e41-4a9c-9c1a-809b69af2f5b</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3b27fdc8-7009-4178-9d71-525c2302fd81</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>954c4353-b6b0-4b7d-8b9f-ae860d5c811e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bygg opp siden med artikkelmoduler (tekst, prosess-steg, trekkspill, osv.).]]></Description>
+      <SortOrder>10</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c05f8cc4-732c-40f1-b239-f1584b43758e</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5a4358ca-2bca-458c-8848-7d21dd86fdd8</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ae4ee3aa-3bd9-4beb-8f5c-b62639879b28</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b91dc01e-6cf3-4617-ab36-34ec8407cbfd</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. Genereres automatisk fra tittel hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8ad96b46-e52c-44bd-95e8-6b5a6ab8577f</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>0c935753-9767-4723-8231-0e69c155d411</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>642c9b79-7507-440b-9e8a-73348f9026a9</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>cd23a444-4af7-496f-ab60-642feb498108</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/side.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/side.config
@@ -1,0 +1,191 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="f7031fad-39e7-4731-a86d-c711afcf1d2b" Alias="side" Level="1">
+  <Info>
+    <Name>Side</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Generelle sider</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>64bdd240-aa3c-4a24-b8e5-545b00922fe5</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3b938e78-6c04-4c46-87f9-9cc8b4ec473a</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4f551d86-e4ee-4d4e-a67d-1dcc4fed0a99</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d482856b-ac6e-4cd9-9178-f62bb4e233aa</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>954c4353-b6b0-4b7d-8b9f-ae860d5c811e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>34e7fcbb-b926-44ed-ad44-bd3a71933785</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>bda2b9bf-2aa6-46e0-9b7c-bb2509152969</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>fc650102-1d87-430f-9809-e15ec874d006</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3d866136-90bc-4cd4-8ba0-ea9cb4c947fa</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. La stå tom for å generere automatisk fra tittelen.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>cc0c240c-0ef2-4cea-aa34-beb9be18c80c</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>08071429-15d8-4278-8158-3a0271796ec8</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>2e434d1d-872a-4acc-a3df-e0fa36c47d40</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>6db79af7-d2c1-4b88-8475-fbb07bc95b73</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/sider.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/sider.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="7b4d8b4e-758c-4c9e-a5f0-7b8f76bfb797" Alias="sider" Level="1">
+  <Info>
+    <Name>Andre sider</Name>
+    <Icon>icon-folder</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="f7031fad-39e7-4731-a86d-c711afcf1d2b" SortOrder="0">side</ContentType>
+    <ContentType Key="61b8d81c-126c-44c6-9544-5faf815e23de" SortOrder="1">omOss</ContentType>
+    <ContentType Key="0fea4272-5495-468e-aaa2-ac66aa50fbbd" SortOrder="2">sandkasse</ContentType>
+  </Structure>
+  <GenericProperties />
+  <Tabs />
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/stegartikkel.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/stegartikkel.config
@@ -1,0 +1,191 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="b7d2d42a-a423-4db4-8e60-cfbc773ca742" Alias="stegartikkel" Level="1">
+  <Info>
+    <Name>Stegartikkel</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Supplerende artikkel under et veiledningssteg</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>41f2b773-73a5-4fcc-9179-8622cb864c08</Key>
+      <Name>Hovedbilde</Name>
+      <Alias>artikkelBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedbilde som vises ved siden av tittelen (eller under på mobil).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>11b7201f-e2ce-4b11-a8c4-d2c25326e3f8</Key>
+      <Name>Alternativ tekst for bilde</Name>
+      <Alias>bildeAlt</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Beskriver bildet for skjermlesere. La stå tom hvis bildet kun er dekorativt.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f8909835-c0a5-422b-8a8b-d259dfeaa4d2</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5bafb84e-9c17-428b-bcfe-9015db78911d</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>954c4353-b6b0-4b7d-8b9f-ae860d5c811e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Hovedinnhold]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c21b7730-d060-4669-ada3-fac2a2fe92c5</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>343781dc-0438-4ec6-98e3-31496eb09b6d</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>86e06b75-d2b2-47c3-ad5d-afcebf7997b1</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d06b58e9-e4fe-4415-a802-0991834ddb06</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. Genereres automatisk fra tittel hvis tom.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>962116ef-9d48-424e-a7f6-d30970d56878</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>04c74224-50e2-4e45-8628-f12c65fdfdd6</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>93892354-7bd6-4ef0-8d97-691dadde19d8</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>e52c6e02-8156-406b-9148-07a5ad6c5fac</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/tipitem.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/tipitem.config
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="1bfc5768-b22a-48f4-8507-934258ed46e8" Alias="tipItem" Level="1">
+  <Info>
+    <Name>Tips</Name>
+    <Icon>icon-lightbulb</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et tips-kort. Brukes i tre-tips-seksjonen på forsiden.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>85b85289-d0fb-4bd8-b0aa-1e25ae2eabac</Key>
+      <Name>Bilde</Name>
+      <Alias>tipsBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfritt illustrasjonsbilde]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>49da720a-e31a-4971-9980-5df75b5b6310</Key>
+      <Name>Tekst</Name>
+      <Alias>tipsTekst</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[1-3 setninger som forklarer tipset]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4ab4acef-320e-484f-a592-0a02d7ed677e</Key>
+      <Name>Tittel</Name>
+      <Alias>tipsTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort, presis tittel — vises som overskrift på tipset]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>9630c25a-ba63-4719-bdbc-34c76e952866</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningeksempel.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningeksempel.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="798cd93a-8199-403a-a728-edc3a41b10a1" Alias="veiledningEksempel" Level="1">
+  <Info>
+    <Name>Eksempel (veiledning)</Name>
+    <Icon>icon-lightbulb</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Eksempel-boks med tittel og innhold. Brukes for å vise konkrete eksempler i et veiledningssteg.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>a97904a0-d8dd-475b-a3c3-21ee19cedc12</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>944bf003-cd6a-4160-962d-c609eb705aae</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>261f0fde-3133-42ea-bff3-6e01522a629b</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledninger.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledninger.config
@@ -1,0 +1,295 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="61d6c137-47a7-4e80-acba-41813b61fb7a" Alias="veiledninger" Level="1">
+  <Info>
+    <Name>Veiledning</Name>
+    <Icon>icon-book-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="87949778-2f58-4624-a7f9-f3b3afb83d5e" SortOrder="0">veiledningGuide</ContentType>
+    <ContentType Key="0af083ac-b274-42a7-ba4a-e772271d6f7a" SortOrder="1">enkelVeiledning</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>6a478ba4-2600-41ef-afde-cd6b089c676b</Key>
+      <Name>Merkelapp på eksempelkort</Name>
+      <Alias>eksempelKortTag</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Tekst på merkelappen på eksempelkortene i "Lær av andre". Standard: Eksempel]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="laerAvAndre">Lær av andre</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9b726e14-d862-4cf6-a737-4625df842f2e</Key>
+      <Name>Hero-bilde</Name>
+      <Alias>heroBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="hero">Hero</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>30291a19-564c-4213-808c-7e5e6ce7a031</Key>
+      <Name>Hero-label</Name>
+      <Alias>heroLabel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="hero">Hero</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>21095ba1-ba34-4e93-becc-3f48ac4f9f71</Key>
+      <Name>Hero-tekst</Name>
+      <Alias>heroTekst</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="hero">Hero</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9b347a9d-668d-49be-9c7f-5931aaa660b0</Key>
+      <Name>Hero-tittel</Name>
+      <Alias>heroTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="hero">Hero</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>13c4da12-2746-4f02-b468-380103e0ff5e</Key>
+      <Name>Kort</Name>
+      <Alias>seksjon1Kort</Alias>
+      <Definition>a739d03f-0eef-43dd-9f64-62b924d2e576</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seksjon1">Fremhevet veiledning og artikler</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0d4ce631-0d58-482e-88dd-9190cc62310e</Key>
+      <Name>Tittel</Name>
+      <Alias>seksjon1Tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seksjon1">Fremhevet veiledning og artikler</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1a05b1d2-4953-4c0e-bf47-0d93a17b1a08</Key>
+      <Name>Kort</Name>
+      <Alias>seksjon2Kort</Alias>
+      <Definition>a739d03f-0eef-43dd-9f64-62b924d2e576</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seksjon2">Rik liste</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>316b9b03-5ec4-45a8-adf4-5ad9cadc4c04</Key>
+      <Name>Tittel</Name>
+      <Alias>seksjon2Tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seksjon2">Rik liste</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6bf3d9cc-4312-4882-967d-11922d747320</Key>
+      <Name>Kort</Name>
+      <Alias>seksjon3Kort</Alias>
+      <Definition>a739d03f-0eef-43dd-9f64-62b924d2e576</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seksjon3">Enkel liste</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>db74d90d-fadc-412d-8509-0808e39af4e2</Key>
+      <Name>Tittel</Name>
+      <Alias>seksjon3Tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seksjon3">Enkel liste</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c0fc85f1-2fe1-41c2-b171-d5db677e89e6</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr beskrivelse i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0ef78f4f-aaf9-4b4d-b68d-162bc1f06006</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Bilde som vises ved deling på sosiale medier]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9e67a239-1a2d-48ea-96be-a5e504412baa</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Overstyr tittel i søkeresultater og sosiale medier]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>2aa0f815-5400-4c51-9ace-f895f735e22c</Key>
+      <Caption>Lær av andre</Caption>
+      <Alias>laerAvAndre</Alias>
+      <Type>Group</Type>
+      <SortOrder>6</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>765f04b8-66c6-43e8-b362-fb75748bacfd</Key>
+      <Caption>Fremhevet veiledning og artikler</Caption>
+      <Alias>seksjon1</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>bad4ea15-83c3-4908-a15d-b544d24b910a</Key>
+      <Caption>Enkel liste</Caption>
+      <Alias>seksjon3</Alias>
+      <Type>Group</Type>
+      <SortOrder>5</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>bcba015f-f2ec-4ffe-a941-6eae19348da9</Key>
+      <Caption>Hero</Caption>
+      <Alias>hero</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>c77283d8-ef95-4fb2-a7c2-1814ad15a32a</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Group</Type>
+      <SortOrder>4</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>e465da61-c193-4ea1-9615-f9457307700a</Key>
+      <Caption>Rik liste</Caption>
+      <Alias>seksjon2</Alias>
+      <Type>Group</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningguide.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningguide.config
@@ -1,0 +1,177 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="87949778-2f58-4624-a7f9-f3b3afb83d5e" Alias="veiledningGuide" Level="1">
+  <Info>
+    <Name>Veiledning Guide</Name>
+    <Icon>icon-book-alt</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Oversiktsside for en veiledningsguide</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="41cbf869-3e17-4094-b5d8-f813b519d5cf" SortOrder="0">veiledningSteg</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>119cffb4-62bd-4128-bdd2-13e83e581ed9</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>11a2c612-def6-47b7-a7e7-10366c44f2e6</Key>
+      <Name>Innhold</Name>
+      <Alias>innholdBlokker</Alias>
+      <Definition>5388285c-ecab-47f1-98e6-44551ba0440e</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Moduler som vises på guide-oversikten (tekst, trekkspill, obs).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>010bbd55-dbdc-45cb-ab2f-856141a42dbb</Key>
+      <Name>SEO-beskrivelse</Name>
+      <Alias>seoBeskrivelse</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>752e6083-f372-435f-898f-43f0315da36f</Key>
+      <Name>SEO-bilde</Name>
+      <Alias>seoBilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>47e6727a-5c6e-4416-bd96-63680ca79468</Key>
+      <Name>SEO-tittel</Name>
+      <Alias>seoTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="seo">SEO</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5e0ea9e8-d6ca-474d-bd0d-8219a11bcf4b</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. La stå tom for å generere automatisk fra tittelen.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>56337997-423b-45bb-85b3-bdff1947b901</Key>
+      <Name>Stegtitler</Name>
+      <Alias>stegGruppeTittler</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Tittel per steg-gruppe, én per linje.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8f5d6782-debc-4b2c-be71-a2f38da4a7b9</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>babace99-893a-4a4f-8852-9955c05173f4</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>d3ce5966-d146-4ecb-9eb4-e55db83263bf</Key>
+      <Caption>SEO</Caption>
+      <Alias>seo</Alias>
+      <Type>Group</Type>
+      <SortOrder>100</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>e582fc6b-9047-4444-b611-aa2907aefe34</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledninginfo.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledninginfo.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="dc92d80c-1bb4-4525-b03a-111a96016a53" Alias="veiledningInfo" Level="1">
+  <Info>
+    <Name>Infomodul</Name>
+    <Icon>icon-info</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Informasjonsboks med tittel og innhold. Kan ha innebygd trekkspill og 'Les mer'-lenke.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>18d75b56-a2e8-48c1-b9f9-46e0a90c41d6</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1dcc942a-91a0-4879-af83-f3c6ecc8d8c2</Key>
+      <Name>Les mer-tittel</Name>
+      <Alias>lesMerTittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vises som lenketekst nederst, f.eks. 'Les mer hos Datatilsynet'.]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>01ceb066-c7ec-4b3d-8f50-345fc177dfcc</Key>
+      <Name>Les mer-URL</Name>
+      <Alias>lesMerUrl</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL som 'Les mer'-lenken peker til.]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5849af56-375b-4dde-8617-34a7b7807df6</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a58ea568-98b0-49c8-84ed-c3c11884996b</Key>
+      <Name>Trekkspill</Name>
+      <Alias>trekkspill</Alias>
+      <Definition>a9719cb7-dfb5-464a-8b06-b1a84c5c89fc</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Valgfri innebygd accordion under innholdet.]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>2b582f65-3f30-4103-908d-5d41048a7ff3</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningkort.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningkort.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="1bda8e30-7b48-4593-9f2e-8b965e491a0b" Alias="veiledningKort" Level="1">
+  <Info>
+    <Name>Veiledning Kort</Name>
+    <Icon>icon-grid-2</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et kort i veiledningsoversikten</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>53dfb839-8ff6-438b-91f4-c091402fe9f6</Key>
+      <Name>Beskrivelse</Name>
+      <Alias>beskrivelse</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>808bf6e2-76a7-4f5a-a6cb-a51b3f24c03d</Key>
+      <Name>Ikon</Name>
+      <Alias>ikon</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Ikonnavn fra Aksel (f.eks. HandHeart, Package)]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>cd88d985-bb3f-4b5d-9d4a-72cc644a8a4b</Key>
+      <Name>Lenke</Name>
+      <Alias>lenke</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.ContentPicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg veiledning, artikkel eller eksempel. Overstyrer URL-feltet. Bruk URL for eksterne lenker.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>37ce4824-493e-4da7-885b-52178ed08a7a</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6f143102-9f8b-4d8d-92e0-2f74eb9ca710</Key>
+      <Name>URL (ekstern lenke)</Name>
+      <Alias>url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>d8525cec-9a38-48d2-b41f-2fb9dba4bdec</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningobs.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningobs.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="8ba6a4aa-37f9-4ba5-9305-38b926c35099" Alias="veiledningObs" Level="1">
+  <Info>
+    <Name>Obs</Name>
+    <Icon>icon-pushpin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Varselboks med tittel og tekst. Brukes for å fremheve viktig informasjon i et veiledningssteg.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>2f17d0b9-9107-43da-856a-cc7beb37b515</Key>
+      <Name>Tekst</Name>
+      <Alias>tekst</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>80793427-e15b-4d6f-ae65-657f88104a2d</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>a938c802-43c6-42d0-998f-1970c4c8f5ce</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningsteg.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningsteg.config
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="41cbf869-3e17-4094-b5d8-f813b519d5cf" Alias="veiledningSteg" Level="1">
+  <Info>
+    <Name>Veiledning Steg</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et steg i en veiledningsguide</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="b7d2d42a-a423-4db4-8e60-cfbc773ca742" SortOrder="0">stegartikkel</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>bc4f5a87-3f88-47bb-ba1b-bbee3ec0326d</Key>
+      <Name>Guide-slug</Name>
+      <Alias>guideSlug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Slug til overordnet guide]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>45969a09-69bc-4baa-b875-18194213900f</Key>
+      <Name>Ingress</Name>
+      <Alias>ingress</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Kort introduksjonstekst som vises under tittelen.]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7ce45b8e-1163-43f9-b7b7-3589aa1dd8e2</Key>
+      <Name>Innhold</Name>
+      <Alias>innholdBlokker</Alias>
+      <Definition>12ba60c5-b0bc-4ea6-8a13-1d6d0d8c2daf</Definition>
+      <Type>Umbraco.BlockList</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Moduler som utgjør innholdet i steget (tekst, info, eksempel, obs, trekkspill).]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>d06f35c5-681b-42a0-a008-106a392fe837</Key>
+      <Name>Slug</Name>
+      <Alias>slug</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[URL-vennlig identifikator. La stå tom for å generere automatisk fra tittelen.]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>54bb5cc5-d7fd-4c68-97cc-f3c1e35c82bf</Key>
+      <Name>Steg</Name>
+      <Alias>steg</Alias>
+      <Definition>2e6d3631-066e-44b8-aec4-96f09099b2b5</Definition>
+      <Type>Umbraco.Integer</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Stegnummer (1, 2, 3...)]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>47df0075-d500-4fc4-bcdf-4f1dab1419d4</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4d487d7d-c404-46c5-b597-ca831ef53b64</Key>
+      <Name>Understeg</Name>
+      <Alias>understeg</Alias>
+      <Definition>2e6d3631-066e-44b8-aec4-96f09099b2b5</Definition>
+      <Type>Umbraco.Integer</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Understeg-nummer (1, 2, 3...)]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innstillinger">Innstillinger</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>44389909-0dfc-4023-9732-0c23b60d91ef</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>4c65bd2d-a8c6-4b77-9549-0ab2c81c5e6c</Key>
+      <Caption>Innstillinger</Caption>
+      <Alias>innstillinger</Alias>
+      <Type>Group</Type>
+      <SortOrder>50</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningtekst.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningtekst.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="5c9b4b05-4fb3-42c0-b412-068cfd8b2e98" Alias="veiledningTekst" Level="1">
+  <Info>
+    <Name>Brødtekst (veiledning)</Name>
+    <Icon>icon-edit</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Rik tekstblokk med overskrifter (H2/H3/H4), lister, lenker, fet, kursiv og blockquote.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>47e8694b-f583-4ca4-b58a-3bcff6e036f1</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>fab42bd1-021c-4c59-a194-fb39d5a462ac</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningtrekkspill.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/veiledningtrekkspill.config
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="9aebec16-a0fb-4a4e-aa7d-4edec4e3ba7c" Alias="veiledningTrekkspill" Level="1">
+  <Info>
+    <Name>Trekkspill (veiledning)</Name>
+    <Icon>icon-list</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Klikkbar tittel som åpner skjult innhold under. Bra for bonus-info eller detaljer leseren kan hoppe over.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>ca0a0ec2-9a44-4141-9501-234bfce8aaaf</Key>
+      <Name>Innhold</Name>
+      <Alias>innhold</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f3a05974-329d-409e-86ae-8848f6a6c6c7</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>c855cf6f-616a-4718-9d08-8f0fd1469680</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/ContentTypes/verktoykort.config
+++ b/apps/cms-umbraco/uSync/v17/ContentTypes/verktoykort.config
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="5f508908-970f-474a-a648-b679b899533f" Alias="verktoyKort" Level="1">
+  <Info>
+    <Name>Verktøy Kort</Name>
+    <Icon>icon-wrench</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Et verktøy-kort i veiledningsoversikten</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>e22c3edc-f26f-490d-8b38-795c0bb49416</Key>
+      <Name>Beskrivelse</Name>
+      <Alias>beskrivelse</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e6c5e11e-6740-4fe3-aaf5-03094aec227a</Key>
+      <Name>Bilde</Name>
+      <Alias>bilde</Alias>
+      <Definition>4309a3ea-0d78-4329-a06c-c80b036af19a</Definition>
+      <Type>Umbraco.MediaPicker3</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f7bb3d86-2849-4836-bb32-cdf488825212</Key>
+      <Name>Ikon</Name>
+      <Alias>ikon</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Ikonnavn fra Aksel (f.eks. HandHeart, Package)]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3ab8a8d5-c1b8-420a-8822-f7cca9907f63</Key>
+      <Name>Tittel</Name>
+      <Alias>tittel</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>dbbac064-94a6-4166-9274-6dec164658e2</Key>
+      <Name>URL</Name>
+      <Alias>url</Alias>
+      <Definition>1b4ccf89-8ebd-42c7-b0b9-292ceeea0542</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>420c373d-0d65-44ff-b234-88ddb4096235</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ApprovedColor.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ApprovedColor.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0225af17-b302-49cb-9176-b9f35cab9c17" Alias="Approved Color" Level="1">
+  <Info>
+    <Name>Approved Color</Name>
+    <EditorAlias>Umbraco.ColorPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ColorPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ArtikkelhodeBakgrunnsfarge.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ArtikkelhodeBakgrunnsfarge.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="55043cae-9d13-4015-b915-789d02b4b825" Alias="Artikkelhode Bakgrunnsfarge" Level="1">
+  <Info>
+    <Name>Artikkelhode Bakgrunnsfarge</Name>
+    <EditorAlias>Umbraco.ColorPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ColorPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "items": [
+    {
+      "value": "e9c0c8",
+      "label": "Accent"
+    },
+    {
+      "value": "dfc2d4",
+      "label": "Brand 1"
+    },
+    {
+      "value": "e2d8d2",
+      "label": "Brand 2"
+    }
+  ],
+  "useLabel": true
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListAccordionSections.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListAccordionSections.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="a9719cb7-dfb5-464a-8b06-b1a84c5c89fc" Alias="Block List - Accordion Sections" Level="1">
+  <Info>
+    <Name>Block List - Accordion Sections</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "405c4ebf-1cb8-4a9c-aae2-2ee426ba760f"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListArtikkelInnhold.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListArtikkelInnhold.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="954c4353-b6b0-4b7d-8b9f-ae860d5c811e" Alias="Block List - Artikkel Innhold" Level="1">
+  <Info>
+    <Name>Block List - Artikkel Innhold</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e",
+      "label": "{umbValue: innhold | stripHtml | wordLimit:12}"
+    },
+    {
+      "contentElementTypeKey": "c063d005-38e9-4469-93f7-0dd71d961a76",
+      "label": "{umbValue: bildetekst | fallback:Bilde}"
+    },
+    {
+      "contentElementTypeKey": "f6e6bb2f-ea53-4462-8a15-ea4382de55f0",
+      "settingsElementTypeKey": "65cb2117-645a-46af-b2ac-625492d575be"
+    },
+    {
+      "contentElementTypeKey": "4b3cac2f-623b-46ac-a3d4-8caf0276fdf1",
+      "label": "{umbValue: tekst | stripHtml | wordLimit:12}"
+    },
+    {
+      "contentElementTypeKey": "250deaaf-6798-41f2-a4c4-4e2a2fc23de2"
+    },
+    {
+      "contentElementTypeKey": "e44ec3b2-10f6-4494-a36b-5177bbc74c45"
+    },
+    {
+      "contentElementTypeKey": "307e019a-bbcf-4211-a09a-ffce2d52d011"
+    },
+    {
+      "contentElementTypeKey": "d8b6c846-e796-4e70-afd3-2ca356a0990b",
+      "label": "{umbValue: navn | fallback:Kontaktkort}"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListArtiklerSeksjoner.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListArtiklerSeksjoner.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="3655b796-f129-4c08-a962-bd0fc7481c0a" Alias="Block List - Artikler Seksjoner" Level="1">
+  <Info>
+    <Name>Block List - Artikler Seksjoner</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "17f3575a-ce60-4d9d-9cad-1e9fb73e3e9c"
+    },
+    {
+      "contentElementTypeKey": "b4b298e1-37c4-4c5d-a443-d3ade3bad888"
+    },
+    {
+      "contentElementTypeKey": "ac5871bc-864d-4d27-bf23-1c9d7cb46a01"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListCaseInnhold.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListCaseInnhold.config
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="73f88ca2-3f6e-4015-ab6d-4ffbd21f1834" Alias="Block List - Case Innhold" Level="1">
+  <Info>
+    <Name>Block List - Case Innhold</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e"
+    },
+    {
+      "contentElementTypeKey": "c063d005-38e9-4469-93f7-0dd71d961a76"
+    },
+    {
+      "contentElementTypeKey": "f6e6bb2f-ea53-4462-8a15-ea4382de55f0",
+      "settingsElementTypeKey": "65cb2117-645a-46af-b2ac-625492d575be"
+    },
+    {
+      "contentElementTypeKey": "4b3cac2f-623b-46ac-a3d4-8caf0276fdf1"
+    },
+    {
+      "contentElementTypeKey": "250deaaf-6798-41f2-a4c4-4e2a2fc23de2"
+    },
+    {
+      "contentElementTypeKey": "e44ec3b2-10f6-4494-a36b-5177bbc74c45"
+    },
+    {
+      "contentElementTypeKey": "307e019a-bbcf-4211-a09a-ffce2d52d011"
+    },
+    {
+      "contentElementTypeKey": "d8b6c846-e796-4e70-afd3-2ca356a0990b"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListEksempelInnhold.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListEksempelInnhold.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="e1c48978-c80c-4540-b5f5-da4d77578bb4" Alias="Block List - Eksempel Innhold" Level="1">
+  <Info>
+    <Name>Block List - Eksempel Innhold</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e",
+      "label": "{umbValue: innhold | stripHtml | wordLimit:12}"
+    },
+    {
+      "contentElementTypeKey": "c063d005-38e9-4469-93f7-0dd71d961a76",
+      "label": "{umbValue: bildetekst | fallback:Bilde}"
+    },
+    {
+      "contentElementTypeKey": "f6e6bb2f-ea53-4462-8a15-ea4382de55f0",
+      "settingsElementTypeKey": "65cb2117-645a-46af-b2ac-625492d575be"
+    },
+    {
+      "contentElementTypeKey": "4b3cac2f-623b-46ac-a3d4-8caf0276fdf1",
+      "label": "{umbValue: tekst | stripHtml | wordLimit:12}"
+    },
+    {
+      "contentElementTypeKey": "250deaaf-6798-41f2-a4c4-4e2a2fc23de2"
+    },
+    {
+      "contentElementTypeKey": "e44ec3b2-10f6-4494-a36b-5177bbc74c45"
+    },
+    {
+      "contentElementTypeKey": "307e019a-bbcf-4211-a09a-ffce2d52d011"
+    },
+    {
+      "contentElementTypeKey": "d8b6c846-e796-4e70-afd3-2ca356a0990b",
+      "label": "{umbValue: navn | fallback:Kontaktkort}"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListEksemplerSeksjoner.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListEksemplerSeksjoner.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ddb7000e-1391-49e3-afb8-31862debd881" Alias="Block List - Eksempler Seksjoner" Level="1">
+  <Info>
+    <Name>Block List - Eksempler Seksjoner</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "db3ab525-e80d-45ba-8b65-b090db99a783"
+    },
+    {
+      "contentElementTypeKey": "c0a6d510-6451-4867-b8e9-8df04f041769"
+    },
+    {
+      "contentElementTypeKey": "97e56431-0731-4c67-a68a-a52a210f02b6"
+    },
+    {
+      "contentElementTypeKey": "2307b37a-5967-4b2b-ac9e-54e3990e6ac4"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideArtikkelkort.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideArtikkelkort.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="bc120566-2cf9-4f95-b623-25c191b189f8" Alias="Block List - Forside Artikkelkort" Level="1">
+  <Info>
+    <Name>Block List - Forside Artikkelkort</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "db79563e-d5cb-4325-b0a2-ffca880c7621"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideEksempelkort.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideEksempelkort.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="b0680599-6c2c-4ea9-94c1-26c9b2033c9f" Alias="Block List - Forside Eksempelkort" Level="1">
+  <Info>
+    <Name>Block List - Forside Eksempelkort</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "999414cd-60d9-4072-bec8-e9f653936d7c"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideForstaaLenker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideForstaaLenker.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="3822189c-de95-4aea-b6a1-47012fcffb41" Alias="Block List - Forside Forstå Lenker" Level="1">
+  <Info>
+    <Name>Block List - Forside Forstå Lenker</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "54f34e34-425b-48b5-a7a8-5764272f2ee0"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideSeksjoner.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListForsideSeksjoner.config
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="c00700c4-edec-460d-8183-638365e8e1cc" Alias="Block List - Forside Seksjoner" Level="1">
+  <Info>
+    <Name>Block List - Forside Seksjoner</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "956fc6c9-a077-43c1-9f48-98f9d5f9e05f"
+    },
+    {
+      "contentElementTypeKey": "68871e1d-b635-4918-9c65-04bf3910c619"
+    },
+    {
+      "contentElementTypeKey": "75a81881-118a-477c-a222-b86521717e18"
+    },
+    {
+      "contentElementTypeKey": "26de029e-00f2-4e58-b233-2962c6290589"
+    },
+    {
+      "contentElementTypeKey": "dbfcac22-3861-482e-89bf-aaed40357728"
+    },
+    {
+      "contentElementTypeKey": "89df006d-6f46-4909-a34d-f4c1fb17cfa5"
+    },
+    {
+      "contentElementTypeKey": "a02b9c45-941c-46d3-850b-c25818de9c65"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListOmOssSeksjoner.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListOmOssSeksjoner.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="176c32ca-ed96-48a3-8999-ebccb802bf79" Alias="Block List - Om Oss Seksjoner" Level="1">
+  <Info>
+    <Name>Block List - Om Oss Seksjoner</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "00990345-eb98-4e2a-8eef-0a1e45a5e7ed"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListProsesstegItems.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListProsesstegItems.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="3d6431ea-42a2-4e89-8f8c-e7b1313047f8" Alias="Block List - Prosessteg Items" Level="1">
+  <Info>
+    <Name>Block List - Prosessteg Items</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "60a48165-34ef-47b7-a43c-87f214ad29de"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListTips.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListTips.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="d4a54620-3aac-4d24-ab36-27d70c8af7c9" Alias="Block List - Tips" Level="1">
+  <Info>
+    <Name>Block List - Tips</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "1bfc5768-b22a-48f4-8507-934258ed46e8"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVeiledningGuide.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVeiledningGuide.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="5388285c-ecab-47f1-98e6-44551ba0440e" Alias="Block List - Veiledning Guide" Level="1">
+  <Info>
+    <Name>Block List - Veiledning Guide</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "5c9b4b05-4fb3-42c0-b412-068cfd8b2e98",
+      "label": "{umbValue: innhold | stripHtml | wordLimit:12}"
+    },
+    {
+      "contentElementTypeKey": "9aebec16-a0fb-4a4e-aa7d-4edec4e3ba7c",
+      "label": "{umbValue: tittel | fallback:Trekkspill}"
+    },
+    {
+      "contentElementTypeKey": "8ba6a4aa-37f9-4ba5-9305-38b926c35099",
+      "label": "{umbValue: tittel | fallback:Obs}"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVeiledningKort.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVeiledningKort.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="a739d03f-0eef-43dd-9f64-62b924d2e576" Alias="Block List - Veiledning Kort" Level="1">
+  <Info>
+    <Name>Block List - Veiledning Kort</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "1bda8e30-7b48-4593-9f2e-8b965e491a0b"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVeiledningSteg.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVeiledningSteg.config
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="12ba60c5-b0bc-4ea6-8a13-1d6d0d8c2daf" Alias="Block List - Veiledning Steg" Level="1">
+  <Info>
+    <Name>Block List - Veiledning Steg</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "5c9b4b05-4fb3-42c0-b412-068cfd8b2e98",
+      "label": "{umbValue: innhold | stripHtml | wordLimit:12}"
+    },
+    {
+      "contentElementTypeKey": "dc92d80c-1bb4-4525-b03a-111a96016a53",
+      "label": "{umbValue: tittel | fallback:Info}"
+    },
+    {
+      "contentElementTypeKey": "798cd93a-8199-403a-a728-edc3a41b10a1",
+      "label": "{umbValue: tittel | fallback:Eksempel}"
+    },
+    {
+      "contentElementTypeKey": "8ba6a4aa-37f9-4ba5-9305-38b926c35099",
+      "label": "{umbValue: tittel | fallback:Obs}"
+    },
+    {
+      "contentElementTypeKey": "9aebec16-a0fb-4a4e-aa7d-4edec4e3ba7c",
+      "label": "{umbValue: tittel | fallback:Trekkspill}"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVerktoeyKort.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/BlockListVerktoeyKort.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="9181a182-51c0-4671-97e6-4dbfa7f6b370" Alias="Block List - Verktøy Kort" Level="1">
+  <Info>
+    <Name>Block List - Verktøy Kort</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "5f508908-970f-474a-a648-b679b899533f"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/CalloutVariant.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/CalloutVariant.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="b776f85f-f33e-4d14-841f-9f1405392303" Alias="Callout Variant" Level="1">
+  <Info>
+    <Name>Callout Variant</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "items": [
+    "info",
+    "obs",
+    "advarsel",
+    "suksess"
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/CheckboxList.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/CheckboxList.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="fbaf13a8-4036-41f2-93a3-974f678c312a" Alias="Checkbox list" Level="1">
+  <Info>
+    <Name>Checkbox list</Name>
+    <EditorAlias>Umbraco.CheckBoxList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.CheckBoxList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ContentPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ContentPicker.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="fd1e0da5-5606-4862-b679-5d0cf3a52a59" Alias="Content Picker" Level="1">
+  <Info>
+    <Name>Content Picker</Name>
+    <EditorAlias>Umbraco.ContentPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DocumentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/DatePicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/DatePicker.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="5046194e-4237-453c-a547-15db3a07c4e1" Alias="Date Picker" Level="1">
+  <Info>
+    <Name>Date Picker</Name>
+    <EditorAlias>Umbraco.DateTime</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DatePicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "format": "YYYY-MM-DD"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/DatePickerWithTime.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/DatePickerWithTime.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="e4d66c0f-b935-4200-81f0-025f7256b89a" Alias="Date Picker with time" Level="1">
+  <Info>
+    <Name>Date Picker with time</Name>
+    <EditorAlias>Umbraco.DateTime</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DatePicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "format": "YYYY-MM-DD HH:mm:ss"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/DateTimePickerWithTimeZone.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/DateTimePickerWithTimeZone.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="88e8a052-30ee-4d44-a507-59f2cdfc769c" Alias="Date Time Picker (with time zone)" Level="1">
+  <Info>
+    <Name>Date Time Picker (with time zone)</Name>
+    <EditorAlias>Umbraco.DateTimeWithTimeZone</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DateTimeWithTimeZonePicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "timeFormat": "HH:mm",
+  "timeZones": {
+    "mode": "all"
+  }
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Dropdown.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Dropdown.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0b6a45e7-44ba-430d-9da5-4e46060b9e03" Alias="Dropdown" Level="1">
+  <Info>
+    <Name>Dropdown</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": false
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/DropdownMultiple.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/DropdownMultiple.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="f38f0ac7-1d27-439c-9f3f-089cd8825a53" Alias="Dropdown multiple" Level="1">
+  <Info>
+    <Name>Dropdown multiple</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": true
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/EksempelGruppeKolonner.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/EksempelGruppeKolonner.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="53c859b1-21a5-40cb-ab18-da0ad085a329" Alias="Eksempel-gruppe Kolonner" Level="1">
+  <Info>
+    <Name>Eksempel-gruppe Kolonner</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "items": [
+    "1",
+    "2",
+    "3",
+    "4"
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ImageCropper.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ImageCropper.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1df9f033-e6d4-451f-b8d2-e0cbc50a836f" Alias="Image Cropper" Level="1">
+  <Info>
+    <Name>Image Cropper</Name>
+    <EditorAlias>Umbraco.ImageCropper</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ImageCropper</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ImageMediaPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ImageMediaPicker.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ad9f0cf2-bda2-45d5-9ea1-a63cfc873fd3" Alias="Image Media Picker" Level="1">
+  <Info>
+    <Name>Image Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "cc07b313-0843-4aa8-bbda-871c8da728c8",
+  "multiple": false,
+  "validationLimit": {
+    "min": 0,
+    "max": 1
+  }
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelBigint.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelBigint.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="930861bf-e262-4ead-a704-f99453565708" Alias="Label (bigint)" Level="1">
+  <Info>
+    <Name>Label (bigint)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "BIGINT"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelBytes.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelBytes.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f" Alias="Label (bytes)" Level="1">
+  <Info>
+    <Name>Label (bytes)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "labelTemplate": "{=value | bytes}",
+  "umbracoDataValueType": "BIGINT"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelDatetime.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelDatetime.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0e9794eb-f9b5-4f20-a788-93acd233a7e4" Alias="Label (datetime)" Level="1">
+  <Info>
+    <Name>Label (datetime)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "DATETIME"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelDecimal.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelDecimal.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8f1ef1e1-9de4-40d3-a072-6673f631ca64" Alias="Label (decimal)" Level="1">
+  <Info>
+    <Name>Label (decimal)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "DECIMAL"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelInteger.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelInteger.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8e7f995c-bd81-4627-9932-c40e568ec788" Alias="Label (integer)" Level="1">
+  <Info>
+    <Name>Label (integer)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "INT"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelPixels.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelPixels.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="5eb57825-e15e-4fc7-8e37-fca65cdafbde" Alias="Label (pixels)" Level="1">
+  <Info>
+    <Name>Label (pixels)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "labelTemplate": "{=value}px",
+  "umbracoDataValueType": "INT"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelString.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelString.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="f0bc4bfb-b499-40d6-ba86-058885a5178c" Alias="Label (string)" Level="1">
+  <Info>
+    <Name>Label (string)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "STRING"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LabelTime.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LabelTime.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="a97cec69-9b71-4c30-8b12-ec398860d7e8" Alias="Label (time)" Level="1">
+  <Info>
+    <Name>Label (time)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "TIME"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/LenkeURL.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/LenkeURL.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1b4ccf89-8ebd-42c7-b0b9-292ceeea0542" Alias="Lenke / URL" Level="1">
+  <Info>
+    <Name>Lenke / URL</Name>
+    <EditorAlias>Umbraco.TextBox</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.TextBox</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ListViewContent.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ListViewContent.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="c0808dd3-8133-4e4b-8ce8-e2bea84a96a4" Alias="List View - Content" Level="1">
+  <Info>
+    <Name>List View - Content</Name>
+    <EditorAlias>Umbraco.ListView</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Collection</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "includeProperties": [
+    {
+      "alias": "updateDate",
+      "header": "Last edited",
+      "isSystem": true
+    },
+    {
+      "alias": "creator",
+      "header": "Updated by",
+      "isSystem": true
+    }
+  ],
+  "layouts": [
+    {
+      "name": "Grid",
+      "collectionView": "Umb.CollectionView.Document.Grid",
+      "icon": "icon-thumbnails-small",
+      "isSystem": true,
+      "selected": true
+    },
+    {
+      "name": "List",
+      "collectionView": "Umb.CollectionView.Document.Table",
+      "icon": "icon-list",
+      "isSystem": true,
+      "selected": true
+    }
+  ],
+  "orderBy": "updateDate",
+  "orderDirection": "desc",
+  "pageSize": 100
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/ListViewMedia.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/ListViewMedia.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="3a0156c4-3b8c-4803-bdc1-6871faa83fff" Alias="List View - Media" Level="1">
+  <Info>
+    <Name>List View - Media</Name>
+    <EditorAlias>Umbraco.ListView</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Collection</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "includeProperties": [
+    {
+      "alias": "updateDate",
+      "header": "Last edited",
+      "isSystem": true
+    },
+    {
+      "alias": "creator",
+      "header": "Updated by",
+      "isSystem": true
+    }
+  ],
+  "layouts": [
+    {
+      "name": "Grid",
+      "collectionView": "Umb.CollectionView.Media.Grid",
+      "icon": "icon-thumbnails-small",
+      "isSystem": true,
+      "selected": true
+    },
+    {
+      "name": "List",
+      "collectionView": "Umb.CollectionView.Media.Table",
+      "icon": "icon-list",
+      "isSystem": true,
+      "selected": true
+    }
+  ],
+  "orderBy": "updateDate",
+  "orderDirection": "desc",
+  "pageSize": 100
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/MediaPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/MediaPicker.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="4309a3ea-0d78-4329-a06c-c80b036af19a" Alias="Media Picker" Level="1">
+  <Info>
+    <Name>Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": false,
+  "validationLimit": {
+    "min": 0,
+    "max": 1
+  }
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/MemberPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/MemberPicker.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1ea2e01f-ebd8-4ce1-8d71-6b1149e63548" Alias="Member Picker" Level="1">
+  <Info>
+    <Name>Member Picker</Name>
+    <EditorAlias>Umbraco.MemberPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MemberPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/MultiURLPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/MultiURLPicker.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="b4e3535a-1753-47e2-8568-602cf8cfee6f" Alias="Multi URL Picker" Level="1">
+  <Info>
+    <Name>Multi URL Picker</Name>
+    <EditorAlias>Umbraco.MultiUrlPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MultiUrlPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/MultipleImageMediaPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/MultipleImageMediaPicker.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0e63d883-b62b-4799-88c3-157f82e83ecc" Alias="Multiple Image Media Picker" Level="1">
+  <Info>
+    <Name>Multiple Image Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "cc07b313-0843-4aa8-bbda-871c8da728c8",
+  "multiple": true
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/MultipleMediaPicker.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/MultipleMediaPicker.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1b661f40-2242-4b44-b9cb-3990ee2b13c0" Alias="Multiple Media Picker" Level="1">
+  <Info>
+    <Name>Multiple Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": true
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Numeric.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Numeric.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="2e6d3631-066e-44b8-aec4-96f09099b2b5" Alias="Numeric" Level="1">
+  <Info>
+    <Name>Numeric</Name>
+    <EditorAlias>Umbraco.Integer</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Integer</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Radiobox.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Radiobox.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="bb5f57c9-ce2b-4bb9-b697-4caca783a805" Alias="Radiobox" Level="1">
+  <Info>
+    <Name>Radiobox</Name>
+    <EditorAlias>Umbraco.RadioButtonList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.RadioButtonList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/RichtextEditor.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/RichtextEditor.config
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ca90c950-0aff-4e72-b976-a30b1ac57dad" Alias="Richtext editor" Level="1">
+  <Info>
+    <Name>Richtext editor</Name>
+    <EditorAlias>Umbraco.RichText</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Tiptap</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "allowedMediaTypes": "cc07b313-0843-4aa8-bbda-871c8da728c8,c4b1efcf-a9d5-41c4-9621-e9d273b52a9c",
+  "extensions": [
+    "Umb.Tiptap.RichTextEssentials",
+    "Umb.Tiptap.Anchor",
+    "Umb.Tiptap.Block",
+    "Umb.Tiptap.Blockquote",
+    "Umb.Tiptap.Bold",
+    "Umb.Tiptap.BulletList",
+    "Umb.Tiptap.CodeBlock",
+    "Umb.Tiptap.Heading",
+    "Umb.Tiptap.HtmlAttributeClass",
+    "Umb.Tiptap.HtmlAttributeDataset",
+    "Umb.Tiptap.HtmlAttributeId",
+    "Umb.Tiptap.HtmlAttributeStyle",
+    "Umb.Tiptap.HtmlTagDiv",
+    "Umb.Tiptap.HtmlTagSpan",
+    "Umb.Tiptap.Italic",
+    "Umb.Tiptap.Link",
+    "Umb.Tiptap.OrderedList",
+    "Umb.Tiptap.Strike",
+    "Umb.Tiptap.Subscript",
+    "Umb.Tiptap.Superscript",
+    "Umb.Tiptap.Table",
+    "Umb.Tiptap.TextAlign",
+    "Umb.Tiptap.TextDirection",
+    "Umb.Tiptap.TextIndent",
+    "Umb.Tiptap.TrailingNode",
+    "Umb.Tiptap.Underline"
+  ],
+  "maxImageSize": 500,
+  "overlaySize": "medium",
+  "toolbar": [
+    [
+      [
+        "Umb.Tiptap.Toolbar.Paragraph",
+        "Umb.Tiptap.Toolbar.Heading2",
+        "Umb.Tiptap.Toolbar.Heading3",
+        "Umb.Tiptap.Toolbar.Heading4",
+        "Umb.Tiptap.Toolbar.ClearFormatting"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.SourceEditor"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Bold",
+        "Umb.Tiptap.Toolbar.Italic",
+        "Umb.Tiptap.Toolbar.Underline"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.TextAlignLeft",
+        "Umb.Tiptap.Toolbar.TextAlignCenter",
+        "Umb.Tiptap.Toolbar.TextAlignRight"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.BulletList",
+        "Umb.Tiptap.Toolbar.OrderedList"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Blockquote"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Link",
+        "Umb.Tiptap.Toolbar.Unlink"
+      ]
+    ]
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/RichtextEditorBegrenset.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/RichtextEditorBegrenset.config
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="df46ef09-2c6f-48ef-9c38-62784314af84" Alias="Richtext editor (begrenset)" Level="1">
+  <Info>
+    <Name>Richtext editor (begrenset)</Name>
+    <EditorAlias>Umbraco.RichText</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Tiptap</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "extensions": [
+    "Umb.Tiptap.RichTextEssentials",
+    "Umb.Tiptap.Bold",
+    "Umb.Tiptap.BulletList",
+    "Umb.Tiptap.HtmlAttributeClass",
+    "Umb.Tiptap.HtmlAttributeId",
+    "Umb.Tiptap.Italic",
+    "Umb.Tiptap.Link",
+    "Umb.Tiptap.OrderedList",
+    "Umb.Tiptap.TrailingNode"
+  ],
+  "toolbar": [
+    [
+      [
+        "Umb.Tiptap.Toolbar.Bold",
+        "Umb.Tiptap.Toolbar.Italic",
+        "Umb.Tiptap.Toolbar.ClearFormatting"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.BulletList",
+        "Umb.Tiptap.Toolbar.OrderedList"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Link",
+        "Umb.Tiptap.Toolbar.Unlink"
+      ]
+    ]
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Tags.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Tags.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="b6b73142-b9c1-4bf8-a16d-e1c23320b549" Alias="Tags" Level="1">
+  <Info>
+    <Name>Tags</Name>
+    <EditorAlias>Umbraco.Tags</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Tags</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "group": "default",
+  "storageType": "Json"
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Textarea.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Textarea.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3" Alias="Textarea" Level="1">
+  <Info>
+    <Name>Textarea</Name>
+    <EditorAlias>Umbraco.TextArea</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.TextArea</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Textstring.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Textstring.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0cc0eba1-9960-42c9-bf9b-60e150b429ae" Alias="Textstring" Level="1">
+  <Info>
+    <Name>Textstring</Name>
+    <EditorAlias>Umbraco.TextBox</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.TextBox</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/Truefalse.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/Truefalse.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="92897bc6-a5f3-4ffe-ae27-f2e7e33dda49" Alias="True/false" Level="1">
+  <Info>
+    <Name>True/false</Name>
+    <EditorAlias>Umbraco.TrueFalse</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Toggle</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/UploadArticle.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/UploadArticle.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="bc1e266c-dac4-4164-bf08-8a1ec6a7143d" Alias="Upload Article" Level="1">
+  <Info>
+    <Name>Upload Article</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "pdf",
+    "docx",
+    "doc"
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/UploadAudio.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/UploadAudio.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8f430dd6-4e96-447e-9dc0-cb552c8cd1f3" Alias="Upload Audio" Level="1">
+  <Info>
+    <Name>Upload Audio</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "mp3",
+    "weba",
+    "oga",
+    "opus"
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/UploadFile.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/UploadFile.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="84c6b441-31df-4ffe-b67e-67d5bc3ae65a" Alias="Upload File" Level="1">
+  <Info>
+    <Name>Upload File</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/UploadVectorGraphics.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/UploadVectorGraphics.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="215cb418-2153-4429-9aef-8c0f0041191b" Alias="Upload Vector Graphics" Level="1">
+  <Info>
+    <Name>Upload Vector Graphics</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "svg"
+  ]
+}]]></Config>
+</DataType>

--- a/apps/cms-umbraco/uSync/v17/DataTypes/UploadVideo.config
+++ b/apps/cms-umbraco/uSync/v17/DataTypes/UploadVideo.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="70575fe7-9812-4396-bbe1-c81a76db71b5" Alias="Upload Video" Level="1">
+  <Info>
+    <Name>Upload Video</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "mp4",
+    "webm",
+    "ogv"
+  ]
+}]]></Config>
+</DataType>


### PR DESCRIPTION
Skjemakilden jobb 2 hviler på. Eksportert fra prod backoffice på image 47, hentet read-only fra podden med `kubectl exec ... tar`, lagt under `uSync/v17`. Ingen skriving mot prod.

**Hvorfor den måtte tas fra prod.** `ContentTypeComposer` setter aldri `.Key` selv, så Umbraco gir content-typene tilfeldige GUID-er per database. Målt konkret:

| | `artikkelBildeSeksjon` |
|---|---|
| prod | `c063d005-38e9-4469-93f7-0dd71d961a76` |
| fersk lokal bygging | `20ffaa92-ed2a-483b-84bf-5ccc4d76860f` |

Innhold refererer blokker via nøkkel. En dev-eksport importert i prod ville gitt prod-typene nøkler prod sitt innhold ikke peker på, altså «Unsupported» på alle blokkmoduler. Det er akkurat symptomet tt02-speilet har i dag.

**Innhold**: 58 ContentTypes, 59 DataTypes, 616KB. Ikke `Content/` eller `Media/`, de er fortsatt gitignorert av #643.

**Verifisert**
- `dotnet publish` legger alle 117 filene i `publish/uSync/v17/`, altså i runtime-imaget. Csproj-regelen fra #643 gjør jobben.
- Ingen treff på passord, nøkler, tokens eller connection strings i filene.

Dette alene endrer ingen oppførsel. Filene ligger inerte til noen aktiverer import, og prod sitt Default-sett er fortsatt eksport-only.