### PR TITLE
fix(deploy): bekreft at imaget faktisk kjører før deployet meldes OK

### DIFF
--- a/scripts/deploy-cms.sh
+++ b/scripts/deploy-cms.sh
@@ -15,10 +15,11 @@ set -uo pipefail
 
 ENV="${1:-}"; TAG="${2:-}"
 case "$ENV" in
-  tt02) CMS="https://kinorgeportal.tt02.dis-core.altinn.cloud"; FE="https://ki-norge-frontend-tt02.digitaliseringsdirektoratet.workers.dev" ;;
-  prod) CMS="https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev"; FE="https://ki.norge.no" ;;
+  tt02) KCTX="dis-core-tt02-aks"; CMS="https://kinorgeportal.tt02.dis-core.altinn.cloud"; FE="https://ki-norge-frontend-tt02.digitaliseringsdirektoratet.workers.dev" ;;
+  prod) KCTX="dis-core-prod-aks"; CMS="https://cms-kinorgeportal-prod.digitaliseringsdirektoratet.workers.dev"; FE="https://ki.norge.no" ;;
   *) echo "Bruk: bash scripts/deploy-cms.sh <tt02|prod> [image-tag]"; exit 1 ;;
 esac
+KNS="product-kinorgeportal"
 fail() { echo "FEIL: $*" >&2; exit 1; }
 note() { echo "▸ $*"; }
 
@@ -66,7 +67,31 @@ gh workflow run publish-syncroot-main.yaml --field environment="$ENV" --field im
   || fail "syncroot start feilet."
 watch_run publish-syncroot-main.yaml "syncroot" || fail "Syncroot-publisering feilet."
 
-note "3/3 Venter paa flux-rollout + verifiserer helse…"
+# Flux henter syncroot-artefakten paa intervall (5 min), saa den nye taggen er
+# IKKE ute i det oyeblikket publish-jobben er gronn. Uten dette sjekket rapporterte
+# scriptet suksess mens klyngen fortsatt kjorte forrige image.
+note "3/3 Venter paa at image $TAG faktisk kjorer…"
+if command -v kubectl >/dev/null && kubectl --context "$KCTX" -n "$KNS" get pods --request-timeout=20s >/dev/null 2>&1; then
+  ROLLED=0
+  for i in $(seq 1 60); do
+    running=$(kubectl --context "$KCTX" -n "$KNS" get pods \
+      -o jsonpath='{.items[0].spec.containers[?(@.name=="umbraco")].image}' \
+      --request-timeout=20s 2>/dev/null | sed 's/.*://')
+    ready=$(kubectl --context "$KCTX" -n "$KNS" get pods \
+      -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="umbraco")].ready}' \
+      --request-timeout=20s 2>/dev/null)
+    echo "  [$i] kjorende image=${running:-?} ready=${ready:-?}"
+    if [ "$running" = "$TAG" ] && [ "$ready" = "true" ]; then ROLLED=1; break; fi
+    sleep 15
+  done
+  [ "$ROLLED" = "1" ] || fail "Image $TAG kjorer fortsatt ikke i $ENV etter ~15 min. Sjekk flux: kubectl --context $KCTX -n $KNS get ocirepository,kustomization"
+  note "Image $TAG bekreftet kjorende."
+else
+  echo "  ADVARSEL: naar ikke klyngen (kubectl/VPN), kan IKKE bekrefte at image $TAG faktisk kjorer."
+  echo "  Helsesjekken under sier bare at NOE svarer, ikke at det er den nye versjonen."
+fi
+
+note "Verifiserer helse…"
 for i in $(seq 1 40); do
   fe=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$FE/" 2>/dev/null)
   total=$(curl -s --max-time 15 "$CMS/umbraco/delivery/api/v2/content?filter=contentType:artikkel&take=1" \


### PR DESCRIPTION
Scriptet meldte «OK: prod frisk etter rollout (image 47)» mens klyngen fortsatt kjørte image 45. Det skjedde i dag på **både prod og tt02**, så det er systematisk.

**Årsak.** Helsesjekken spurte bare om frontenden svarte 200 og om Delivery API ga et tall. Begge deler er like sant for det gamle imaget. Flux henter syncroot-artefakten på 5-minutters intervall, så den nye taggen er ikke ute i det øyeblikket publish-jobben blir grønn.

**Fiks.** Scriptet poller nå kjørende image i podden til det matcher taggen og containeren er ready, før helsesjekken kjøres. Feiler med flux-diagnosetips hvis det ikke skjer innen ~15 min.

Uten Altinn-VPN når ikke kubectl klyngen. Da hoppes sjekket over, men scriptet sier tydelig fra at det **ikke** kan bekrefte versjonen, i stedet for å melde suksess som før.

Målt i dag: prod brukte ~3 min fra grønn publish-jobb til image 47 faktisk kjørte, tt02 ~3,5 min. Begge ville blitt feilrapportert som ferdige.