### PR TITLE
feat(cms): la uSync reconcilere skjemaet ved oppstart (trigger på tt02)

### DIFF
--- a/apps/cms-umbraco/appsettings.json
+++ b/apps/cms-umbraco/appsettings.json
@@ -111,18 +111,19 @@
       "DefaultSet": "Default"
     },
     "Sets": {
-      // Standard for ALLE miljø (inkl. prod): KUN eksport, også for skjema.
-      // Import er av (Actions: ["Export"]), så Import-knappen i prod er en død
-      // no-op og selv API-import blokkeres, også om en import-trigger skulle
-      // lekke. Skjema-eksport er read-only (skriver filer, rører ikke databasen)
-      // og brukes til å fange prod sine content-type-nøkler for speiling til tt02.
+      // Standard for ALLE miljø (inkl. prod). INNHOLD og MEDIA er fortsatt
+      // eksport-only, så en feilklikket import aldri kan overskrive prod-innhold.
+      // SKJEMA (content types + data types) tillater import, fordi uSync skal eie
+      // skjemaet og reconcilere det mot de committede filene ved oppstart
+      // (ImportAtStartup: "Settings"). Filene er prod sin egen eksport, så
+      // importen er en no-op så lenge filene og databasen er i sync.
       "Default": {
         "HandlerDefaults": { "Enabled": false },
         "Handlers": {
           "ContentHandler": { "Enabled": true, "Actions": [ "Export" ] },
           "MediaHandler": { "Enabled": true, "Actions": [ "Export" ] },
-          "ContentTypeHandler": { "Enabled": true, "Actions": [ "Export" ] },
-          "DataTypeHandler": { "Enabled": true, "Actions": [ "Export" ] }
+          "ContentTypeHandler": { "Enabled": true, "Actions": [ "All" ] },
+          "DataTypeHandler": { "Enabled": true, "Actions": [ "All" ] }
         }
       },
       // Import + eksport, også skjema. Brukes KUN av tt02 via env-var

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -61,6 +61,14 @@ patches:
         value:
           name: USYNC_OWNS_SCHEMA
           value: "true"
+      # Naar uSync eier skjemaet maa noe reconcilere det mot filene ved oppstart,
+      # slik composeren gjorde. Kun Settings-gruppa: innhold og media er
+      # eksport-only i settet, saa de hoppes over uansett.
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: uSync__Settings__ImportAtStartup
+          value: Settings
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
Siste manglende brikke før jobb 2. Skal uSync eie skjemaet må noe asserte det ved oppstart, slik `ContentTypeComposer` gjør i dag. Denne PR-en legger triggeren og gjør den brukbar, men slår den **kun på for tt02**.

**Default-settet tillater nå import av skjema.** Content types og data types får `Actions: ["All"]`. Innhold og media forblir eksport-only, så en feilklikket import kan aldri overskrive prod-innhold. Det var den opprinnelige hensikten med import-vernet i #535, og den er intakt.

**Dette løser juni-problemet.** Da så `ImportAtStartup` ut til å ignorere `DefaultSet=Speiling` og kjørte inert mot det eksport-only Default-settet. Når begge sett tillater skjema-import spiller det ingen rolle hvilket startup-importen lander på, så tvetydigheten forsvinner i stedet for å måtte feilsøkes.

**Prod er urørt.** Triggeren settes per miljø i syncroot, ikke globalt i appsettings. `syncroot/prod` har verken `USYNC_OWNS_SCHEMA` eller `ImportAtStartup`, så prod sin composer eier skjemaet nøyaktig som før. Det unngår at composer og uSync asserter skjema samtidig, som migreringsplanen advarer mot.

Eneste prod-synlige endring: Import-knappen på Settings-kortet blir funksjonell for skjema. Filene i imaget er prod sin egen eksport (#645), så et klikk er en no-op.

**Målt lokalt med akkurat denne configen**

| | |
|---|---|
| Startup-import kjørte | 2 handlers, 116 elementer, 151ms |
| Endringer | **0** |
| Skjema før/etter to importer | identisk, 456 linjer |
| CMS etterpå | backoffice 200 |

Loggen bekrefter at importen faktisk kjørte (`uSync: Running Import at startup group=Settings`), ikke bare hoppet over. Det var verdt å sjekke: uSync skriver ikke historikk-fil for importer, så «ingen historikk» ser ut som «kjørte ikke».