### PR TITLE
feat(cms): la uSync eie skjemaet i prod (jobb 2)

### DIFF
--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -51,6 +51,22 @@ patches:
         value:
           name: Cloudflare__SiteBaseUrl
           value: https://ki.norge.no
+      # uSync overtar skjemaet fra ContentTypeComposer. Composeren staar igjen i
+      # koden, men hopper over skjema-asserting naar denne er satt, saa rollback
+      # er aa fjerne disse to blokkene og deploye paa nytt.
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USYNC_OWNS_SCHEMA
+          value: "true"
+      # Reconcilerer skjemaet mot de committede filene ved hver oppstart, slik
+      # composeren gjorde. Kun Settings-gruppa: innhold og media er eksport-only
+      # i Default-settet, saa de hoppes over uansett.
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: uSync__Settings__ImportAtStartup
+          value: Settings
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
Setter `USYNC_OWNS_SCHEMA=true` og `uSync__Settings__ImportAtStartup=Settings` i prod-kustomization. Nøyaktig de samme to variablene tt02 har kjørt på siden i går. `ContentTypeComposer` slutter å asserte skjema, og uSync reconcilerer det mot de committede filene ved hver oppstart.

**Composeren fjernes ikke.** De 3702 linjene står igjen i koden og hopper bare over skjema-assertingen. Rollback er å slette disse to blokkene og deploye på nytt. Ingen kodeendring, ingen databasemigrering, ingen versjonsstempling.

**Bevisgrunnlag**

| Kontroll | Resultat |
|---|---|
| Eksporten komplett mot databasen | 58/58 dokumenttyper, 61/61 datatyper, nøkler og property-antall uten avvik |
| uSync bygger samme skjema som composeren | null avvik på typer, properties og tillatte barn |
| Oppdaterings-stien lokalt | 456 linjer skjema identisk før og etter to påfølgende oppstarts-importer |
| **Prod sin egen Report** | **0 av 117 endringer**, målt to ganger, sist etter reboot på image 49 i natt |
| tt02 | et døgn med uSync-eid skjema, friskt |

**Viktig funn underveis:** uSync 17.3.6 **re-nøkler** typer ved import, i motsetning til det som var dokumentert fra juni. Bevist på tt02, der importen ga 468 `Key`-endringer fordi tt02 sine nøkler faktisk avvek fra prod sine. Det er trygt i prod fordi filene er eksportert fra prod og nøklene allerede matcher, og det er nettopp det 0/117 måler. Konsekvensen er en ny driftsregel: driver filene fra prod-databasen, må de re-eksporteres før neste import, ellers re-nøkles prod og alt blokkinnhold blir «Unsupported».

Verifisert at `kubectl kustomize syncroot/prod` bygger og at begge variablene lander i det rendrede manifestet, identisk med tt02.