### PR TITLE
feat(cms): stopp uSync-import som ville re-nøklet skjemaet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,8 @@ Frontend henter innhold via Umbraco Delivery API v2. Prod-databasen er Azure SQL
 
 **Innholdsskriving fra kode = anti-pattern**: Skjema (content types) settes i kode via `ContentTypeComposer`, men content NODES skal ALDRI skrives fra oppstartskode. Det har gitt 3 prod-incidenter (Sandkasse, nesten Caser, og veiledningsduplikat fra dev-seederen). `ContentSeeder` er derfor fjernet helt; demo/test-innhold lages via editor. Se `docs/seeder-content-write-audit.md`.
 
+**uSync eier skjemaet i prod. IKKE regenerer `apps/cms-umbraco/uSync/`**: filene der er prod sitt skjema og importeres ved hver oppstart. uSync re-nøkler ved import, og content-typene har tilfeldige GUID-er per database. En eksport tatt fra lokal maskin eller tt02, committet inn, gir prod-typene nye nøkler og gjør ALT blokkinnhold «Unsupported». Skal du eksportere eller committe noe der: **stopp og spør Lars først**, og si fra om konsekvensen. Eksporten skal alltid tas fra prod. `SchemaRekeyGuard` avbryter en import som ville re-nøklet, men den er en sikring, ikke en tillatelse. Se `apps/cms-umbraco/uSync/README.md`.
+
 ## Deploy
 
 - **CMS:** dis-core via GitHub Actions («Docker build and publish» + «Publish Syncroot artifacts», miljø tt02/prod).

--- a/apps/cms-umbraco/.gitignore
+++ b/apps/cms-umbraco/.gitignore
@@ -18,6 +18,7 @@ wwwroot/media/*
 ## Skjema (ContentTypes/DataTypes) SKAL committes når uSync overtar skjemaeierskapet,
 ## men bare en eksport tatt fra PROD. Se docs/usync-skjema-prereq.md.
 uSync/*
+!uSync/README.md
 !uSync/v17
 uSync/v17/*
 !uSync/v17/ContentTypes

--- a/apps/cms-umbraco/Composers/SchemaRekeyGuard.cs
+++ b/apps/cms-umbraco/Composers/SchemaRekeyGuard.cs
@@ -1,0 +1,174 @@
+using System.Xml.Linq;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services;
+using uSync.BackOffice;
+using uSync.BackOffice.Notifications;
+using uSync.Core.Notifications;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Stopper en uSync-import som ville gitt eksisterende content-typer eller datatyper
+/// NYE nøkler.
+///
+/// Hvorfor: innhold refererer blokker via typens nøkkel. Importerer vi en skjemaeksport
+/// som er tatt fra en ANNEN database enn denne, re-nøkles typene og alt blokkinnhold blir
+/// «Unsupported». uSync 17.3.6 re-nøkler uten å spørre (målt på tt02: 468 nøkkelendringer).
+///
+/// Guarden er siste skanse. Den bryr seg ikke om hvordan filene havnet i repoet, så den
+/// dekker også hånd-redigerte filer og filer skrevet av en agent.
+///
+/// Bevisst re-nøkling (f.eks. å aligne tt02 mot prod) krever env-var USYNC_ALLOW_REKEY=true.
+/// </summary>
+public class SchemaRekeyGuardComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<uSyncImportStartingNotification, SchemaRekeyGuard>();
+        builder.AddNotificationHandler<uSyncImportCompletedNotification, SchemaImportReporter>();
+    }
+}
+
+/// <summary>
+/// Gjør en skjema-import som faktisk ENDRET noe synlig.
+///
+/// Prod logger på Warning-nivå (appsettings.Production.json), så uSync sin egen
+/// oppsummering på Info-nivå finnes ikke i loggen der. En import som endrer skjema i prod
+/// er nettopp det man vil oppdage, så den logges på Error og skrives til stdout.
+///
+/// Null endringer er den normale tilstanden og logges ikke.
+/// </summary>
+public class SchemaImportReporter : INotificationHandler<uSyncImportCompletedNotification>
+{
+    private readonly ILogger<SchemaImportReporter> _logger;
+
+    public SchemaImportReporter(ILogger<SchemaImportReporter> logger) => _logger = logger;
+
+    public void Handle(uSyncImportCompletedNotification notification)
+    {
+        var changed = notification.Actions
+            .Where(a => a.Change != uSync.Core.ChangeType.NoChange)
+            .ToList();
+
+        if (changed.Count == 0) return;
+
+        var summary = string.Join(", ", changed.Take(8).Select(a => $"{a.ItemType}:{a.Name}"));
+        var more = changed.Count > 8 ? $" (+{changed.Count - 8})" : "";
+
+        _logger.LogError(
+            "uSync-import ENDRET skjema: {Count} elementer. {Summary}{More}. " +
+            "Forventet tilstand er 0 endringer. Er dette uventet, sjekk om skjemafilene " +
+            "i uSync/v17 kommer fra en annen database enn denne.",
+            changed.Count, summary, more);
+
+        Console.Error.WriteLine(
+            $"ADVARSEL uSync-import endret skjema: {changed.Count} elementer. {summary}{more}");
+    }
+}
+
+public class SchemaRekeyGuard : INotificationHandler<uSyncImportStartingNotification>
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IHostEnvironment _env;
+
+    public SchemaRekeyGuard(
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
+        IHostEnvironment env)
+    {
+        _contentTypeService = contentTypeService;
+        _dataTypeService = dataTypeService;
+        _env = env;
+    }
+
+    public void Handle(uSyncImportStartingNotification notification)
+    {
+        var conflicts = FindRekeyConflicts();
+        if (conflicts.Count == 0) return;
+
+        var allowed = string.Equals(
+            Environment.GetEnvironmentVariable("USYNC_ALLOW_REKEY"), "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        var summary = string.Join("\n  ", conflicts.Take(10));
+        var more = conflicts.Count > 10 ? $"\n  … og {conflicts.Count - 10} til" : "";
+
+        if (allowed)
+        {
+            Console.WriteLine(
+                $"ADVARSEL SchemaRekeyGuard: importen re-nøkler {conflicts.Count} typer, " +
+                $"men USYNC_ALLOW_REKEY=true så den slippes gjennom.\n  {summary}{more}");
+            return;
+        }
+
+        // notification.Cancel respekteres IKKE av uSync 17.3.6 (verifisert: importen kjørte
+        // videre og re-nøklet 80 elementer). Vi kaster i stedet, som avbryter operasjonen.
+        notification.Cancel = true;
+        var message =
+            $"SchemaRekeyGuard STOPPET uSync-importen. Den ville gitt {conflicts.Count} " +
+            $"eksisterende typer nye nøkler, og alt blokkinnhold ville blitt «Unsupported».\n" +
+            $"  {summary}{more}\n" +
+            $"  Årsak er nesten alltid at skjemafilene i uSync/v17 er eksportert fra en ANNEN " +
+            $"database enn denne. De skal tas fra prod.\n" +
+            $"  Er re-nøklingen tilsiktet, sett USYNC_ALLOW_REKEY=true.";
+        Console.Error.WriteLine($"FEIL {message}");
+        throw new InvalidOperationException(message);
+    }
+
+    private List<string> FindRekeyConflicts()
+    {
+        var conflicts = new List<string>();
+        var root = Path.Combine(_env.ContentRootPath, "uSync", "v17");
+        if (!Directory.Exists(root)) return conflicts;
+
+        foreach (var (folder, element, resolver) in new (string, string, Func<string, Guid?>)[]
+        {
+            ("ContentTypes", "ContentType", alias => _contentTypeService.Get(alias)?.Key),
+            ("DataTypes", "DataType", name => FindDataTypeKey(name)),
+        })
+        {
+            var dir = Path.Combine(root, folder);
+            if (!Directory.Exists(dir)) continue;
+
+            foreach (var file in Directory.EnumerateFiles(dir, "*.config", SearchOption.AllDirectories))
+            {
+                var (fileKey, alias) = ReadKeyAndAlias(file, element);
+                if (fileKey is null || string.IsNullOrWhiteSpace(alias)) continue;
+
+                var dbKey = resolver(alias);
+                // Finnes ikke i databasen = ny type, ingen re-nøkling.
+                if (dbKey is null || dbKey == fileKey) continue;
+
+                conflicts.Add($"{folder}/{alias}: databasen har {dbKey}, fila har {fileKey}");
+            }
+        }
+
+        return conflicts;
+    }
+
+    private Guid? FindDataTypeKey(string name) =>
+        _dataTypeService.GetAllAsync().GetAwaiter().GetResult()
+            .FirstOrDefault(d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase))?.Key;
+
+    private static (Guid?, string?) ReadKeyAndAlias(string file, string elementName)
+    {
+        try
+        {
+            var root = XDocument.Load(file).Root;
+            if (root is null || root.Name.LocalName != elementName) return (null, null);
+            var key = (string?)root.Attribute("Key");
+            var alias = (string?)root.Attribute("Alias");
+            return (Guid.TryParse(key, out var g) ? g : null, alias);
+        }
+        catch
+        {
+            // Ulesbar fil er ikke denne guardens problem; uSync rapporterer den selv.
+            return (null, null);
+        }
+    }
+}

--- a/apps/cms-umbraco/uSync/README.md
+++ b/apps/cms-umbraco/uSync/README.md
@@ -1,0 +1,62 @@
+# STOPP — les dette før du rører filene her
+
+Dette er **prod sitt skjema**. Filene under `v17/ContentTypes` og `v17/DataTypes`
+er ikke dokumentasjon eller en cache. De er kilden Umbraco bygger skjemaet fra i
+produksjon, og de importeres ved hver oppstart.
+
+## Til deg som er en agent
+
+Hvis du vurderer å regenerere, eksportere, formatere eller committe filer i denne
+mappa: **ikke gjør det. Stopp og spør brukeren først.** Forklar samtidig hva som
+står her, slik at brukeren kan ta valget med åpne øyne.
+
+Dette gjelder også når det ser ut som ren opprydding, for eksempel «filene er ute
+av sync med databasen, jeg eksporterer på nytt». Det er nettopp den handlingen som
+er farlig.
+
+## Hvorfor det er farlig
+
+Hver content-type har en GUID. Innhold refererer blokkene sine via den GUID-en,
+ikke via aliaset.
+
+`ContentTypeComposer` satte aldri nøkler selv, så Umbraco ga dem tilfeldige
+GUID-er **per database**. Prod, tt02 og hver enkelt utviklermaskin har derfor
+helt ulike nøkler for de samme typene.
+
+uSync 17.3.6 **re-nøkler ved import**. Den skriver fil-nøkkelen inn i databasen,
+også på typer som allerede finnes. Målt på tt02: én import ga 468 nøkkelendringer.
+
+Committer du derfor en eksport tatt fra en annen database enn prod, skjer dette
+ved neste oppstart i prod:
+
+1. uSync gir prod-typene nøklene fra fila
+2. Alt eksisterende innhold peker på de gamle nøklene
+3. Hver eneste blokkmodul i prod blir «Unsupported»
+4. Redaktørene ser tomme artikler, og innholdet kan ikke reddes ved å reversere
+   koden, fordi composeren ikke setter nøkler i det hele tatt
+
+## Den ene regelen
+
+**En skjemaeksport som committes skal alltid være tatt fra prod.** Aldri fra en
+lokal database, aldri fra tt02, aldri fra en fersk container.
+
+Riktig framgangsmåte: prod backoffice → Settings → uSync → Export, hent filene fra
+podden, commit dem.
+
+## Hva som beskytter deg
+
+`SchemaRekeyGuard` (`Composers/SchemaRekeyGuard.cs`) sammenligner fil-nøkler mot
+databasens nøkler før hver import og **avbryter importen** hvis noen eksisterende
+type ville fått ny nøkkel. Skjemaet står da urørt og siden kjører videre.
+
+Guarden er en sikring, ikke en tillatelse. Den fanger feilen etter at den er
+committet. Ikke bruk den som unnskyldning for å teste ting i prod.
+
+Er re-nøkling faktisk tilsiktet, for eksempel for å aligne tt02 mot prod, settes
+`USYNC_ALLOW_REKEY=true` som env-var i det miljøet. Den skal aldri settes i prod.
+
+## Endringer som er trygge
+
+Å legge til en ny type eller en ny property endrer ikke eksisterende nøkler.
+Eksporter fra prod etterpå og commit. Guarden reagerer ikke, fordi ingenting
+re-nøkles.


### PR DESCRIPTION
Sikringen mot det ene som kan velte prod nå som uSync eier skjemaet.

**Problemet.** uSync 17.3.6 re-nøkler content-typer ved import, altså skriver fil-nøkkelen inn i databasen også på typer som allerede finnes. Composeren satte aldri nøkler selv, så prod, tt02 og hver utviklermaskin har ulike GUID-er for samme type. Innhold refererer blokker via nøkkelen. Committer noen en skjemaeksport tatt fra feil database, får prod-typene nye nøkler ved neste oppstart og **alt blokkinnhold blir «Unsupported»**. Det kan ikke reverseres ved å rulle tilbake koden, fordi composeren ikke setter nøkler i det hele tatt.

Den naturlige feilhandlingen er «filene er ute av sync, jeg eksporterer på nytt». Særlig fristende for en agent, som ser det som opprydding.

**Tre lag**

1. **`SchemaRekeyGuard`** avbryter importen hvis en eksisterende type ville fått ny nøkkel. Den leser filene og sammenligner mot databasen, så den bryr seg ikke om hvordan filene havnet i repoet. Dekker også hånd-redigerte filer og filer skrevet av en agent. Tilsiktet re-nøkling (f.eks. aligne tt02 mot prod) krever `USYNC_ALLOW_REKEY=true`.
2. **`SchemaImportReporter`** logger på Error når en import faktisk endret noe. Prod logger på Warning, så uSync sin egen oppsummering på Info-nivå finnes ikke der. Det var nettopp derfor prod så helt stille ut i går. Null endringer logges ikke.
3. **`uSync/README.md` + `CLAUDE.md`** forklarer faren, med et eksplisitt «er du en agent: stopp og spør brukeren først». CLAUDE.md lastes hver økt.

**Verifisert lokalt mot en bevisst feil-eksport** (lokal database, prod sine filer)

| | |
|---|---|
| Uten guard | importen re-nøklet 80 elementer, `artikkelBildeSeksjon` gikk fra lokal nøkkel til prod sin |
| Med guard | importen stoppet, skjema identisk (456 linjer), nøkkel beholdt, backoffice 200 |
| Nøkler matcher (normaltilfellet) | guarden er stille, importen går gjennom |

**Funn verdt å merke seg:** `notification.Cancel = true` virker **ikke** i uSync 17.3.6. Den kompilerer, men importen kjørte videre og re-nøklet likevel. Guarden kaster derfor i stedet, som faktisk avbryter operasjonen. Oppdaget bare fordi jeg testet mot en ekte feil-eksport i stedet for å stole på at API-et gjorde som det het.