### PR TITLE
feat(ci): vokt de committede uSync-skjemafilene

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,8 @@
 /apps/cms-umbraco/                 @larsekhansen
 /scripts/                          @larsekhansen
 /.github/                          @larsekhansen
+
+# Prod sitt skjema. En eksport tatt fra feil database re-nøkler prod og gjør alt
+# blokkinnhold «Unsupported». Skal aldri merges uten review.
+# Se apps/cms-umbraco/uSync/README.md
+/apps/cms-umbraco/uSync/           @larsekhansen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,24 @@ jobs:
             /tmp/frontend.log
           retention-days: 7
 
+  usync-schema-guard:
+    name: uSync schema guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      # Trenger full historikk for aa sammenligne mot base-branchen.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Sjekk uSync-skjemafilene
+        env:
+          # Labelen schema-rekey-approved er den eksplisitte overstyringen.
+          USYNC_REKEY_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'schema-rekey-approved') }}
+        run: |
+          git fetch -q origin "${{ github.base_ref }}"
+          bash scripts/check-usync-schema.sh "origin/${{ github.base_ref }}"
+
   trivy-fs:
     name: Trivy filesystem scan
     runs-on: ubuntu-latest

--- a/apps/cms-umbraco/.gitignore
+++ b/apps/cms-umbraco/.gitignore
@@ -18,8 +18,10 @@ wwwroot/media/*
 ## Skjema (ContentTypes/DataTypes) SKAL committes når uSync overtar skjemaeierskapet,
 ## men bare en eksport tatt fra PROD. Se docs/usync-skjema-prereq.md.
 uSync/*
+!uSync/README.md
 !uSync/v17
 uSync/v17/*
+!uSync/v17/.origin
 !uSync/v17/ContentTypes
 !uSync/v17/DataTypes
 

--- a/apps/cms-umbraco/Composers/SchemaOriginStamp.cs
+++ b/apps/cms-umbraco/Composers/SchemaOriginStamp.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using uSync.BackOffice;
+
+namespace KiNorge.Cms.Composers;
+
+/// <summary>
+/// Stempler hver uSync-eksport med hvilken database den kom fra.
+///
+/// Skjemafilene som committes SKAL være tatt fra prod. Uten et merke i selve
+/// eksporten er det umulig å se i etterkant hvor filene kom fra, og en eksport fra
+/// en lokal database ser helt lik ut i en diff.
+///
+/// Merket skrives av kode, ikke av per-maskin-config, så det følger repoet til alle
+/// som kjører CMS-et. CI leser det og avviser en PR der opprinnelsen ikke er prod
+/// (scripts/check-usync-schema.sh).
+///
+/// Miljøet utledes av UmbracoApplicationUrl, som allerede skiller miljøene fra
+/// hverandre. Ingen ny env-var å huske å sette.
+/// </summary>
+public class SchemaOriginStampComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<uSyncExportCompletedNotification, SchemaOriginStamp>();
+    }
+}
+
+public class SchemaOriginStamp : INotificationHandler<uSyncExportCompletedNotification>
+{
+    private readonly IHostEnvironment _env;
+    private readonly IConfiguration _config;
+    private readonly ILogger<SchemaOriginStamp> _logger;
+
+    public SchemaOriginStamp(IHostEnvironment env, IConfiguration config, ILogger<SchemaOriginStamp> logger)
+    {
+        _env = env;
+        _config = config;
+        _logger = logger;
+    }
+
+    public void Handle(uSyncExportCompletedNotification notification)
+    {
+        var dir = Path.Combine(_env.ContentRootPath, "uSync", "v17");
+        // Bare skjema-eksporter er interessante. Finnes ikke mappa, ble det ikke eksportert skjema.
+        if (!Directory.Exists(Path.Combine(dir, "ContentTypes"))) return;
+
+        var appUrl = _config["Umbraco:CMS:WebRouting:UmbracoApplicationUrl"] ?? "";
+        var stamp = new
+        {
+            environment = DeriveEnvironment(appUrl),
+            applicationUrl = appUrl,
+            database = DeriveDatabaseHost(),
+            exportedAtUtc = DateTime.UtcNow.ToString("o"),
+        };
+
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(dir, ".origin"),
+                JsonSerializer.Serialize(stamp, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (Exception ex)
+        {
+            // Et manglende merke skal aldri velte en eksport.
+            _logger.LogWarning(ex, "Fikk ikke skrevet uSync .origin-merket.");
+        }
+    }
+
+    private static string DeriveEnvironment(string appUrl) => appUrl switch
+    {
+        var u when u.Contains("cms.ki.test.norge.no", StringComparison.OrdinalIgnoreCase) => "tt02",
+        var u when u.Contains("tt02", StringComparison.OrdinalIgnoreCase) => "tt02",
+        var u when u.Contains("cms.ki.norge.no", StringComparison.OrdinalIgnoreCase) => "prod",
+        var u when u.Contains("prod", StringComparison.OrdinalIgnoreCase) => "prod",
+        _ => "local",
+    };
+
+    /// <summary>Kun servernavnet. Connection stringen har ingen passord (workload identity),
+    /// men vi tar med minst mulig uansett.</summary>
+    private string DeriveDatabaseHost()
+    {
+        var cs = _config.GetConnectionString("umbracoDbDSN") ?? "";
+        var server = cs.Split(';')
+            .FirstOrDefault(p => p.TrimStart().StartsWith("Server=", StringComparison.OrdinalIgnoreCase));
+        return server?.Split('=', 2).ElementAtOrDefault(1)?.Trim() ?? "(ukjent)";
+    }
+}

--- a/scripts/check-usync-schema.sh
+++ b/scripts/check-usync-schema.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Vokter de committede uSync-skjemafilene.
+#
+# Fanger den ene endringen som kan velte prod: en skjemaeksport tatt fra en ANNEN
+# database enn prod. uSync re-noekler ved import, og content-typene har tilfeldige
+# GUID-er per database, saa en fremmed eksport gir prod-typene nye noekler og gjoer
+# alt blokkinnhold «Unsupported». Se apps/cms-umbraco/uSync/README.md.
+#
+# Sjekker:
+#   1. Ingen EKSISTERENDE type har faatt ny Key (en fremmed eksport endrer alle paa en gang)
+#   2. Antall typer har ikke falt (fanger avkuttet eller delvis eksport)
+#   3. Hvis .origin finnes, maa den si prod
+#
+# Bruk: bash scripts/check-usync-schema.sh [base-ref]
+#   base-ref  hva som sammenlignes mot, default origin/main
+#
+# Bevisst re-noekling slippes gjennom med env USYNC_REKEY_APPROVED=true
+# (i CI settes den av PR-labelen schema-rekey-approved).
+
+set -uo pipefail
+
+BASE="${1:-origin/main}"
+DIR="apps/cms-umbraco/uSync/v17"
+FAIL=0
+
+note() { echo "▸ $*"; }
+fail() { echo "  FEIL: $*" >&2; FAIL=1; }
+
+git rev-parse --verify -q "$BASE" >/dev/null 2>&1 || { echo "Fant ikke base-ref '$BASE'."; exit 1; }
+
+# Ingen skjemaendringer = ingenting aa sjekke.
+if git diff --quiet "$BASE"...HEAD -- "$DIR" 2>/dev/null; then
+  note "Ingen endringer i $DIR. Hopper over."
+  exit 0
+fi
+
+note "Skjemafiler er endret. Kjorer vakt-sjekkene…"
+
+# ---- 1. Noekkelendringer paa eksisterende typer ----------------------------
+key_of() { grep -oE 'Key="[^"]+"' <<<"$1" | head -1 | sed 's/Key="//;s/"//'; }
+
+REKEYED=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  # Bare filer som finnes i BEGGE. Nye filer kan ikke re-noekle noe.
+  old=$(git show "$BASE:$f" 2>/dev/null) || continue
+  new=$(git show "HEAD:$f" 2>/dev/null) || continue
+  # tr, ikke ${x,,}: macOS har bash 3.2 der den utvidelsen ikke finnes, og
+  # scriptet ville da stille passert i stedet for aa feile.
+  ko=$(key_of "$old" | tr 'A-Z' 'a-z'); kn=$(key_of "$new" | tr 'A-Z' 'a-z')
+  [ -n "$ko" ] && [ -n "$kn" ] || continue
+  if [ "$ko" != "$kn" ]; then
+    REKEYED=$((REKEYED+1))
+    [ "$REKEYED" -le 8 ] && echo "    $(basename "$f"): $ko -> $kn"
+  fi
+done < <(git diff --name-only "$BASE"...HEAD -- "$DIR" | grep '\.config$')
+
+if [ "$REKEYED" -gt 0 ]; then
+  [ "$REKEYED" -gt 8 ] && echo "    … og $((REKEYED-8)) til"
+  if [ "${USYNC_REKEY_APPROVED:-}" = "true" ]; then
+    note "$REKEYED typer re-noekles, men det er eksplisitt godkjent."
+  else
+    fail "$REKEYED eksisterende typer ville faatt NY noekkel."
+    {
+      echo ""
+      echo "  Dette skjer naar skjemafilene er eksportert fra en annen database enn prod."
+      echo "  Importeres de i prod, re-noekles typene og ALT blokkinnhold blir «Unsupported»."
+      echo "  Eksporten skal alltid tas fra prod. Se apps/cms-umbraco/uSync/README.md."
+      echo ""
+      echo "  Er re-noeklingen tilsiktet, sett PR-labelen: schema-rekey-approved"
+    } >&2
+  fi
+else
+  note "Ingen eksisterende type har endret noekkel."
+fi
+
+# ---- 2. Antall typer har ikke falt ----------------------------------------
+count_in() { git ls-tree -r --name-only "$1" -- "$DIR/$2" 2>/dev/null | grep -c '\.config$'; }
+for sub in ContentTypes DataTypes; do
+  before=$(count_in "$BASE" "$sub"); after=$(count_in HEAD "$sub")
+  if [ "${after:-0}" -lt "${before:-0}" ]; then
+    fail "$sub gikk fra $before til $after filer. Delvis eller avkuttet eksport?"
+  else
+    note "$sub: $before -> $after filer."
+  fi
+done
+
+# ---- 3. Opprinnelsesmerket ------------------------------------------------
+ORIGIN_FILE="$DIR/.origin"
+if git cat-file -e "HEAD:$ORIGIN_FILE" 2>/dev/null; then
+  env_name=$(git show "HEAD:$ORIGIN_FILE" | grep -oE '"environment"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
+  if [ "$env_name" = "prod" ]; then
+    note "Opprinnelse: prod."
+  else
+    fail "Opprinnelsesmerket sier '$env_name', ikke 'prod'. Eksporten er tatt feil sted."
+  fi
+else
+  note "Ingen .origin-fil enda (skrives ved neste prod-eksport). Hopper over."
+fi
+
+echo ""
+if [ "$FAIL" -ne 0 ]; then
+  echo "================ SKJEMAVAKT: AVVIST ================" >&2
+  exit 1
+fi
+echo "================ SKJEMAVAKT: OK ===================="
+exit 0

--- a/scripts/deploy-cms.sh
+++ b/scripts/deploy-cms.sh
@@ -98,6 +98,20 @@ for i in $(seq 1 40); do
     -H "Accept: application/json" 2>/dev/null | grep -oE '"total":[0-9]+' | grep -oE '[0-9]+' | head -1)
   echo "  [$i] frontend=$fe  delivery-api-total=${total:-?}"
   if [ "$fe" = "200" ] && [ -n "$total" ]; then
+    # uSync skal reconcilere skjemaet til NULL endringer. Endret den noe, er filene
+    # ute av sync med databasen, og i verste fall er typene re-noeklet. Se
+    # apps/cms-umbraco/uSync/README.md.
+    if command -v kubectl >/dev/null && kubectl --context "$KCTX" -n "$KNS" get pods --request-timeout=20s >/dev/null 2>&1; then
+      changed=$(kubectl --context "$KCTX" -n "$KNS" logs deploy/umbraco -c umbraco --tail=400 --request-timeout=25s 2>/dev/null \
+        | grep -c "uSync-import endret skjema" || true)
+      if [ "${changed:-0}" -gt 0 ]; then
+        echo "" >&2
+        kubectl --context "$KCTX" -n "$KNS" logs deploy/umbraco -c umbraco --tail=400 --request-timeout=25s 2>/dev/null \
+          | grep "uSync-import endret skjema" | tail -2 >&2
+        fail "uSync-importen ENDRET skjemaet i $ENV. Forventet 0 endringer. Sjekk om filene i uSync/v17 kommer fra riktig database."
+      fi
+      note "uSync-import: ingen skjemaendringer."
+    fi
     note "OK: $ENV frisk etter rollout (image $TAG). Bekreft selve endringen mot Delivery API, og kjor evt: bash scripts/smoke-test.sh"
     exit 0
   fi


### PR DESCRIPTION
Lag nummer to rundt det ene som kan velte prod. `SchemaRekeyGuard` (#654) stopper importen i selve CMS-et; dette fanger feilen allerede i PR-en, før den i det hele tatt når et miljø.

**`scripts/check-usync-schema.sh`** kjører når skjemafilene er endret og sjekker tre ting:

| Sjekk | Fanger |
|---|---|
| Ingen EKSISTERENDE type har fått ny `Key` | en eksport fra feil database, som endrer alle 58 på én gang. En legitim endring endrer ingen. |
| Antall typer har ikke falt | avkuttet eller delvis eksport |
| `.origin` sier `prod` | eksport tatt lokalt eller på tt02 |

Overstyres bevisst med PR-labelen `schema-rekey-approved`.

**`SchemaOriginStamp`** skriver `.origin` ved hver eksport, med miljø, applikasjons-URL, databasevert og tidspunkt. Miljøet utledes av `UmbracoApplicationUrl`, som allerede skiller prod (`cms.ki.norge.no`) fra tt02 (`cms.ki.test.norge.no`), så det er ingen ny env-var å huske å sette. Merket skrives av kode, ikke av per-maskin-config, så det følger repoet til alle som kjører CMS-et.

**`deploy-cms.sh`** feiler nå hvis uSync-importen endret skjemaet i miljøet den deployet til. Forventet tilstand er null endringer.

**CODEOWNERS** krever review på `uSync/`.

**Testet lokalt, alle tilfellene**

- ingen skjemaendringer → hopper over, exit 0
- tre endrede nøkler → avvist med forklaring, exit 1
- `USYNC_REKEY_APPROVED=true` → slipper gjennom
- to slettede filer → avvist
- `.origin=local` → avvist, «Eksporten er tatt feil sted»
- `.origin` skrives faktisk ved en ekte eksport-kjøring

**Bug verdt å nevne:** jeg brukte først `${x,,}` til å sammenligne nøkler. Den utvidelsen finnes ikke i bash 3.2, som er det macOS har, så scriptet feilet stille og **passerte en fremmed eksport**. Fanget bare fordi jeg testet mot en faktisk manipulert eksport i stedet for å anta at det virket. Bruker `tr` nå.