### PR TITLE
fix(deps): pinn js-yaml og nanoid over Trivy-flaggede HIGH-CVEer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   sharp: ^0.35.0
   undici: ^7.29.0
   svgo: ^4.0.2
+  js-yaml: ^4.3.1
+  nanoid: ^3.3.17
 
 importers:
 
@@ -2261,10 +2263,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
@@ -2462,13 +2460,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4725,7 +4718,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 1.1.0
       magicast: 0.5.3
@@ -5371,10 +5364,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
@@ -5567,9 +5556,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.15: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   neotraverse@1.0.1: {}
 
@@ -5708,19 +5695,19 @@ snapshots:
 
   postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ overrides:
   sharp: "^0.35.0" # GHSA-f88m-g3jw-g9cj
   undici: "^7.29.0" # CVE-2026-13697, transitiv via miniflare/wrangler
   svgo: "^4.0.2" # GHSA-2p49-hgcm-8545
+  js-yaml: "^4.3.1" # CVE-2026-59870, transitiv via astro
+  nanoid: "^3.3.17" # CVE-2026-67213, transitiv via postcss
   # vite-override fjernet: astro 6.4 sin ^7.3.2 drar nå inn en fikset 7.x selv
   # (CVE-2026-53571 fikset i 7.3.5), så pinningen var overflødig og hindret
   # Renovate i å la vite flyte. Lar den være transitiv til astro 7 (drar inn vite 8).


### PR DESCRIPTION
Trivy fs-skannen har feilet på alle åpne PR-er. To transitive avhengigheter med HIGH, begge med fiks innenfor samme major.

- `js-yaml` 4.3.0 -> 4.3.1 (CVE-2026-59870, kvadratisk CPU i `!!omap`), via astro
- `nanoid` 3.3.16 -> 3.3.18 (CVE-2026-67213, uendelig løkke), via postcss

Ingen 5.x-konsumenter i treet, så pinningene holder seg i samme major. Låsefila krymper 22 linjer fordi duplikatene 3.3.15/3.3.16 og 4.3.0/4.3.1 kollapser.

Verifisert lokalt: frontend-bygg OK, 149 enhetstester OK, ingen sårbare versjoner igjen i `pnpm-lock.yaml`.