### PR TITLE
feat(tt02): åpne ki.test.norge.no

### DIFF
--- a/apps/frontend/wrangler.jsonc
+++ b/apps/frontend/wrangler.jsonc
@@ -23,8 +23,7 @@
 				// ES_API_KEY settes som secret: wrangler secret put ES_API_KEY --env tt02
 				"ES_ENDPOINT": "https://kinorgeportal-elasticsearch-tt02-a61b24.es.germanywestcentral.azure.elastic.cloud",
 				"KI_INDEX": "ki-content",
-				// Holding page on ki.test.norge.no until launch. Flip to "live" to go public.
-				"LAUNCH_MODE": "coming-soon",
+				"LAUNCH_MODE": "live",
 			},
 		},
 		"prod": {


### PR DESCRIPTION
Flipper `LAUNCH_MODE` til `live` for tt02, så holding-siden i middleware ikke lenger slår inn på ki.test.norge.no. Prod er allerede `live`.

robots.txt er uendret: ki.test.norge.no står ikke i `PROD_HOSTS`, så testmiljøet svarer fortsatt `Disallow: /` for alle crawlere.