### PR TITLE
fix(usync): slutt å skrive databasevert i opprinnelsesmerket

### DIFF
--- a/apps/cms-umbraco/Composers/SchemaOriginStamp.cs
+++ b/apps/cms-umbraco/Composers/SchemaOriginStamp.cs
@@ -10,7 +10,7 @@ using uSync.BackOffice;
 namespace KiNorge.Cms.Composers;
 
 /// <summary>
-/// Stempler hver uSync-eksport med hvilken database den kom fra.
+/// Stempler hver uSync-eksport med hvilket miljø den kom fra.
 ///
 /// Skjemafilene som committes SKAL være tatt fra prod. Uten et merke i selve
 /// eksporten er det umulig å se i etterkant hvor filene kom fra, og en eksport fra
@@ -55,7 +55,6 @@ public class SchemaOriginStamp : INotificationHandler<uSyncExportCompletedNotifi
         {
             environment = DeriveEnvironment(appUrl),
             applicationUrl = appUrl,
-            database = DeriveDatabaseHost(),
             exportedAtUtc = DateTime.UtcNow.ToString("o"),
         };
 
@@ -80,14 +79,4 @@ public class SchemaOriginStamp : INotificationHandler<uSyncExportCompletedNotifi
         var u when u.Contains("prod", StringComparison.OrdinalIgnoreCase) => "prod",
         _ => "local",
     };
-
-    /// <summary>Kun servernavnet. Connection stringen har ingen passord (workload identity),
-    /// men vi tar med minst mulig uansett.</summary>
-    private string DeriveDatabaseHost()
-    {
-        var cs = _config.GetConnectionString("umbracoDbDSN") ?? "";
-        var server = cs.Split(';')
-            .FirstOrDefault(p => p.TrimStart().StartsWith("Server=", StringComparison.OrdinalIgnoreCase));
-        return server?.Split('=', 2).ElementAtOrDefault(1)?.Trim() ?? "(ukjent)";
-    }
 }

--- a/apps/cms-umbraco/uSync/v17/.origin
+++ b/apps/cms-umbraco/uSync/v17/.origin
@@ -1,0 +1,5 @@
+{
+  "environment": "prod",
+  "applicationUrl": "https://cms.ki.norge.no",
+  "exportedAtUtc": "2026-08-13T08:41:20.7351436Z"
+}


### PR DESCRIPTION
`.origin` committes til et public repo, så servernavnet til prod-databasen hører ikke hjemme i det. `scripts/check-usync-schema.sh` leser bare `environment`, så feltet ga oss ingenting.

Legger samtidig inn første `.origin`, hentet fra prod-eksporten 2026-08-13. Til nå har opprinnelsessjekken hoppet over fordi fila manglet. Med den på plass sier vakten:

```
▸ Opprinnelse: prod.
================ SKJEMAVAKT: OK ====================
```

Skjemafilene er urørt. Jeg diffet prods ferske eksport mot `uSync/v17/` og både ContentTypes (58) og DataTypes (59) er bit-identiske.