### PR TITLE
feat(cms): testfixturer for tt02 i git

### DIFF
--- a/apps/cms-umbraco/uSync-testinnhold/README.md
+++ b/apps/cms-umbraco/uSync-testinnhold/README.md
@@ -27,6 +27,13 @@ Fixturene får parent `cadd506a-4470-4f3d-9a66-3a4369bdc238` (Artikler) og dukke
 artikkellista på tt02. Nøklene starter alle med `7e57f1c0`, så de er lette å kjenne igjen og
 kan ikke kollidere med ekte innhold.
 
+De ligger på frontenden under `/artikler/<slug>`, for eksempel
+`https://ki.test.norge.no/artikler/testfixtur-alle-moduler/`. Delivery API-et rapporterer
+rota (`/testfixtur-alle-moduler/`), men den ruta finnes ikke i Astro.
+
+Verifisert 2026-08-13: alle 8 blokktypene rendrer, ingen faller ut, og Delivery API-et er
+friskt på `take=100` etter at fixturene lå inne.
+
 Prod kan ikke importere innhold uansett (`Default`-settet er eksport-only), og scriptet nekter
 å kjøre mot en prod-kontekst.
 

--- a/apps/cms-umbraco/uSync-testinnhold/README.md
+++ b/apps/cms-umbraco/uSync-testinnhold/README.md
@@ -1,0 +1,60 @@
+# Testfixturer for tt02
+
+Artikler som presser skjemaet, lagret som uSync Content-filer og lastet inn i tt02 på kommando.
+
+## Hvorfor de ligger i git
+
+tt02 hadde slike fixturer før, laget direkte i backoffice. De mistet blokkinnholdet sitt da
+skjemaet ble re-nøklet 5. august, ingen merket det, og 13. august ble de feid vekk sammen med
+resten av tt02s eget innhold fordi de så ut som rot.
+
+Løse innholdsnoder i et delt miljø har ingen som passer på seg. Her ligger de under versjons-
+kontroll, de dukker opp i diffen når noen endrer en content-type, og en opprydding kan ikke ta
+dem ved et uhell.
+
+## Bruk
+
+```bash
+scripts/last-testfixturer-tt02.sh          # alle utenom brutte referanser
+scripts/last-testfixturer-tt02.sh --alle   # også brutte referanser
+scripts/last-testfixturer-tt02.sh --sjekk  # vis hva som ville blitt kopiert
+```
+
+Scriptet kopierer `.config`-filene inn i tt02-poddens uSync-mappe. Import gjøres i backoffice
+(Settings, uSync, Import) med settet `Speiling`. Aldri Clean.
+
+Fixturene får parent `cadd506a-4470-4f3d-9a66-3a4369bdc238` (Artikler) og dukker opp i
+artikkellista på tt02. Nøklene starter alle med `7e57f1c0`, så de er lette å kjenne igjen og
+kan ikke kollidere med ekte innhold.
+
+Prod kan ikke importere innhold uansett (`Default`-settet er eksport-only), og scriptet nekter
+å kjøre mot en prod-kontekst.
+
+## Fixturene
+
+| Fil | Hva den tester |
+|---|---|
+| `testfixtur-alle-moduler.config` | Hver av de 8 blokktypene `artikkel.innhold` tillater, i én artikkel. Regresjonsvakt mot at en modul faller til Unsupported. |
+| `testfixtur-minimal.config` | Bare påkrevde felt. Fanger rendering som antar at valgfrie felt finnes. |
+| `testfixtur-fiendtlig-innhold.config` | Ekstremt lang tittel, emoji og kombinerende tegn, RTL, nullbredde-tegn, rå HTML limt inn fra Word/Teams, script- og iframe-tagger, tabell uten thead, tre nivåer nøstet liste, tomme avsnitt, ugyldig e-post, tomme valgfrie felt i blokker. |
+| `testfixtur-brutte-referanser.config` | Mediepeker og lenke til nøkler som ikke finnes. |
+
+### Om brutte referanser
+
+Den siste lastes bare med `--alle`, og det er med vilje. Vi vet fra 13. august at én ødelagt
+property inne i en Block List kan velte hele Delivery API-responsen med HTTP 500, ikke bare
+den ene noden. Da ga en dropdown med rå streng i stedet for JSON 500 på alle spørringer med
+`take>=50`.
+
+Å finne ut om en brutt mediepeker gjør det samme er nettopp poenget med fixturen, men vær
+forberedt: skjer det, blir tt02s Delivery API delvis nede til du sletter noden i backoffice.
+Frontenden tåler det bedre enn API-et, siden den henter i mindre porsjoner.
+
+## Legge til en fixtur
+
+Filene ble generert én gang og redigeres nå for hånd. Formatet er uSync sitt Content-format:
+XML med property-verdier i CDATA, der Block List-verdier er JSON med `contentData`,
+`settingsData`, `expose` og `layout`. Kopier en eksisterende fixtur og bytt nøkler.
+
+Alle nøkler i en ny fixtur må være unike. Hold deg til mønsteret `7e57f1c0-NNNN-4000-8000-…`
+så de fortsatt er gjenkjennelige.

--- a/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-alle-moduler.config
+++ b/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-alle-moduler.config
@@ -17,7 +17,7 @@
       <Value><![CDATA[Testfixtur: alle moduler]]></Value>
     </tittel>
     <ingress>
-      <Value><![CDATA[Én artikkel med hver eneste blokktype som artikkel.innhold tillater. Faller en modul til Unsupported, ser du det her først.]]></Value>
+      <Value><![CDATA[Én artikkel med hver eneste blokktype som artikkel.innhold tillater. Faller en modul ut av rendering, ser du det her først.]]></Value>
     </ingress>
     <bakgrunn>
       <Value><![CDATA[{

--- a/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-alle-moduler.config
+++ b/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-alle-moduler.config
@@ -1,0 +1,551 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="7e57f1c0-0001-4000-8000-000000000000" Alias="Testfixtur: alle moduler" Level="2">
+  <Info>
+    <Parent Key="cadd506a-4470-4f3d-9a66-3a4369bdc238">Artikler </Parent>
+    <Path>/Artikler/TestfixturAlleModuler</Path>
+    <Trashed>false</Trashed>
+    <ContentType>artikkel</ContentType>
+    <CreateDate>2026-08-13T09:00:00</CreateDate>
+    <NodeName Default="Testfixtur: alle moduler" />
+    <SortOrder>900</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template />
+  </Info>
+  <Properties>
+    <tittel>
+      <Value><![CDATA[Testfixtur: alle moduler]]></Value>
+    </tittel>
+    <ingress>
+      <Value><![CDATA[Én artikkel med hver eneste blokktype som artikkel.innhold tillater. Faller en modul til Unsupported, ser du det her først.]]></Value>
+    </ingress>
+    <bakgrunn>
+      <Value><![CDATA[{
+  "label": "Brand 1",
+  "value": "#dfc2d4"
+}]]></Value>
+    </bakgrunn>
+    <artikkelBilde>
+      <Value><![CDATA[[
+  {
+    "key": "7e57f1c0-0001-4000-8000-000000000901",
+    "mediaKey": "07de75b9-05d5-487b-ba29-452ad864b3cd",
+    "mediaTypeAlias": "Image",
+    "crops": [],
+    "focalPoint": null
+  }
+]]]></Value>
+    </artikkelBilde>
+    <bildeAlt>
+      <Value><![CDATA[Toppbilde for fixturen]]></Value>
+    </bildeAlt>
+    <slug>
+      <Value><![CDATA[testfixtur-alle-moduler]]></Value>
+    </slug>
+    <innhold>
+      <Value><![CDATA[{
+  "contentData": [
+    {
+      "contentTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e",
+      "key": "7e57f1c0-0001-4000-8000-000000000001",
+      "values": [
+        {
+          "alias": "innhold",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<h2>Brødtekst</h2><p>Vanlig avsnitt med <strong>fet</strong>, <em>kursiv</em> og en <a href=\"/artikler/\">intern lenke</a>.</p><h3>Underoverskrift</h3><ul><li>Punkt én</li><li>Punkt to</li></ul>"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "c063d005-38e9-4469-93f7-0dd71d961a76",
+      "key": "7e57f1c0-0001-4000-8000-000000000002",
+      "values": [
+        {
+          "alias": "bilde",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": [
+            {
+              "key": "7e57f1c0-0001-4000-8000-000000000902",
+              "mediaKey": "07de75b9-05d5-487b-ba29-452ad864b3cd",
+              "mediaTypeAlias": "Image",
+              "crops": [],
+              "focalPoint": null
+            }
+          ]
+        },
+        {
+          "alias": "bildeAlt",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Alt-tekst for testbildet"
+        },
+        {
+          "alias": "bildetekst",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Bildetekst under bildet"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "f6e6bb2f-ea53-4462-8a15-ea4382de55f0",
+      "key": "7e57f1c0-0001-4000-8000-000000000003",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Trekkspill som er lukket"
+        },
+        {
+          "alias": "innhold",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Innhold som ligger skjult til brukeren klikker.</p>"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "4b3cac2f-623b-46ac-a3d4-8caf0276fdf1",
+      "key": "7e57f1c0-0001-4000-8000-000000000004",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Fremheving med bilde og bakgrunn"
+        },
+        {
+          "alias": "tekst",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Uthevet tekst med anførselstegn og bakgrunnsfarge.</p>"
+          }
+        },
+        {
+          "alias": "bilde",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": [
+            {
+              "key": "7e57f1c0-0001-4000-8000-000000000904",
+              "mediaKey": "07de75b9-05d5-487b-ba29-452ad864b3cd",
+              "mediaTypeAlias": "Image",
+              "crops": [],
+              "focalPoint": null
+            }
+          ]
+        },
+        {
+          "alias": "bildeAlt",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Alt-tekst i fremheving"
+        },
+        {
+          "alias": "kilde",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Testkilde"
+        },
+        {
+          "alias": "visAnforselstegn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "1"
+        },
+        {
+          "alias": "visBakgrunn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "250deaaf-6798-41f2-a4c4-4e2a2fc23de2",
+      "key": "7e57f1c0-0001-4000-8000-000000000005",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Prosess med tre steg"
+        },
+        {
+          "alias": "steg",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "contentData": [
+              {
+                "contentTypeKey": "60a48165-34ef-47b7-a43c-87f214ad29de",
+                "key": "7e57f1c0-0001-4000-8000-000000000051",
+                "values": [
+                  {
+                    "alias": "tittel",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Første steg"
+                  },
+                  {
+                    "alias": "beskrivelse",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "layout": {}
+                      },
+                      "markup": "<p>Beskrivelse av første steg.</p>"
+                    }
+                  }
+                ]
+              },
+              {
+                "contentTypeKey": "60a48165-34ef-47b7-a43c-87f214ad29de",
+                "key": "7e57f1c0-0001-4000-8000-000000000052",
+                "values": [
+                  {
+                    "alias": "tittel",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Andre steg"
+                  },
+                  {
+                    "alias": "beskrivelse",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "layout": {}
+                      },
+                      "markup": "<p>Beskrivelse av andre steg.</p>"
+                    }
+                  }
+                ]
+              },
+              {
+                "contentTypeKey": "60a48165-34ef-47b7-a43c-87f214ad29de",
+                "key": "7e57f1c0-0001-4000-8000-000000000053",
+                "values": [
+                  {
+                    "alias": "tittel",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": "Tredje steg"
+                  },
+                  {
+                    "alias": "beskrivelse",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "layout": {}
+                      },
+                      "markup": "<p>Beskrivelse av tredje steg.</p>"
+                    }
+                  }
+                ]
+              }
+            ],
+            "settingsData": [],
+            "expose": [
+              {
+                "contentKey": "7e57f1c0-0001-4000-8000-000000000051",
+                "culture": null,
+                "segment": null
+              },
+              {
+                "contentKey": "7e57f1c0-0001-4000-8000-000000000052",
+                "culture": null,
+                "segment": null
+              },
+              {
+                "contentKey": "7e57f1c0-0001-4000-8000-000000000053",
+                "culture": null,
+                "segment": null
+              }
+            ],
+            "layout": {
+              "Umbraco.BlockList": [
+                {
+                  "contentKey": "7e57f1c0-0001-4000-8000-000000000051",
+                  "contentUdi": null,
+                  "settingsKey": null,
+                  "settingsUdi": null
+                },
+                {
+                  "contentKey": "7e57f1c0-0001-4000-8000-000000000052",
+                  "contentUdi": null,
+                  "settingsKey": null,
+                  "settingsUdi": null
+                },
+                {
+                  "contentKey": "7e57f1c0-0001-4000-8000-000000000053",
+                  "contentUdi": null,
+                  "settingsKey": null,
+                  "settingsUdi": null
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "e44ec3b2-10f6-4494-a36b-5177bbc74c45",
+      "key": "7e57f1c0-0001-4000-8000-000000000006",
+      "values": [
+        {
+          "alias": "navn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Testbruker Testesen"
+        },
+        {
+          "alias": "stilling",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Testansvarlig"
+        },
+        {
+          "alias": "virksomhet",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Digitaliseringsdirektoratet"
+        },
+        {
+          "alias": "dato",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "2026-08-13T09:00:00"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "307e019a-bbcf-4211-a09a-ffce2d52d011",
+      "key": "7e57f1c0-0001-4000-8000-000000000007",
+      "values": [
+        {
+          "alias": "virksomhet",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Digitaliseringsdirektoratet"
+        },
+        {
+          "alias": "dato",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "2026-08-13T09:00:00"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "d8b6c846-e796-4e70-afd3-2ca356a0990b",
+      "key": "7e57f1c0-0001-4000-8000-000000000008",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Kontakt"
+        },
+        {
+          "alias": "navn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Testbruker Testesen"
+        },
+        {
+          "alias": "stilling",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Testansvarlig"
+        },
+        {
+          "alias": "virksomhet",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Digitaliseringsdirektoratet"
+        },
+        {
+          "alias": "epost",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "post@kin.norge.no"
+        },
+        {
+          "alias": "telefon",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "22 00 00 00"
+        }
+      ]
+    }
+  ],
+  "settingsData": [],
+  "expose": [
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000001",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000002",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000003",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000004",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000005",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000006",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000007",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0001-4000-8000-000000000008",
+      "culture": null,
+      "segment": null
+    }
+  ],
+  "layout": {
+    "Umbraco.BlockList": [
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000001",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000002",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000003",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000004",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000005",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000006",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000007",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0001-4000-8000-000000000008",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      }
+    ]
+  }
+}]]></Value>
+    </innhold>
+  </Properties>
+</Content>

--- a/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-brutte-referanser.config
+++ b/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-brutte-referanser.config
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="7e57f1c0-0004-4000-8000-000000000000" Alias="Testfixtur: brutte referanser" Level="2">
+  <Info>
+    <Parent Key="cadd506a-4470-4f3d-9a66-3a4369bdc238">Artikler </Parent>
+    <Path>/Artikler/TestfixturBrutteReferanser</Path>
+    <Trashed>false</Trashed>
+    <ContentType>artikkel</ContentType>
+    <CreateDate>2026-08-13T09:00:00</CreateDate>
+    <NodeName Default="Testfixtur: brutte referanser" />
+    <SortOrder>903</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template />
+  </Info>
+  <Properties>
+    <tittel>
+      <Value><![CDATA[Testfixtur: brutte referanser]]></Value>
+    </tittel>
+    <ingress>
+      <Value><![CDATA[Peker på media og noder som ikke finnes. Last denne bevisst, den kan ta ned Delivery API-et. Se README.]]></Value>
+    </ingress>
+    <bakgrunn>
+      <Value><![CDATA[{
+  "label": "Brand 1",
+  "value": "#dfc2d4"
+}]]></Value>
+    </bakgrunn>
+    <slug>
+      <Value><![CDATA[testfixtur-brutte-referanser]]></Value>
+    </slug>
+    <artikkelBilde>
+      <Value><![CDATA[[
+  {
+    "key": "7e57f1c0-0004-4000-8000-000000000901",
+    "mediaKey": "00000000-dead-4000-8000-000000000000",
+    "mediaTypeAlias": "Image",
+    "crops": [],
+    "focalPoint": null
+  }
+]]]></Value>
+    </artikkelBilde>
+    <innhold>
+      <Value><![CDATA[{
+  "contentData": [
+    {
+      "contentTypeKey": "c063d005-38e9-4469-93f7-0dd71d961a76",
+      "key": "7e57f1c0-0004-4000-8000-000000000002",
+      "values": [
+        {
+          "alias": "bilde",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": [
+            {
+              "key": "7e57f1c0-0004-4000-8000-000000000902",
+              "mediaKey": "00000000-dead-4000-8000-000000000000",
+              "mediaTypeAlias": "Image",
+              "crops": [],
+              "focalPoint": null
+            }
+          ]
+        },
+        {
+          "alias": "bildeAlt",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Bilde som ikke finnes"
+        },
+        {
+          "alias": "bildetekst",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Mediepekeren viser til en nøkkel som ikke er i mediebiblioteket"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e",
+      "key": "7e57f1c0-0004-4000-8000-000000000003",
+      "values": [
+        {
+          "alias": "innhold",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Lenke til en node som ikke finnes: <a href=\"/{localLink:00000000-dead-4000-8000-000000000000}\">slettet side</a></p>"
+          }
+        }
+      ]
+    }
+  ],
+  "settingsData": [],
+  "expose": [
+    {
+      "contentKey": "7e57f1c0-0004-4000-8000-000000000002",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0004-4000-8000-000000000003",
+      "culture": null,
+      "segment": null
+    }
+  ],
+  "layout": {
+    "Umbraco.BlockList": [
+      {
+        "contentKey": "7e57f1c0-0004-4000-8000-000000000002",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0004-4000-8000-000000000003",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      }
+    ]
+  }
+}]]></Value>
+    </innhold>
+  </Properties>
+</Content>

--- a/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-fiendtlig-innhold.config
+++ b/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-fiendtlig-innhold.config
@@ -1,0 +1,353 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="7e57f1c0-0003-4000-8000-000000000000" Alias="Testfixtur: fiendtlig innhold" Level="2">
+  <Info>
+    <Parent Key="cadd506a-4470-4f3d-9a66-3a4369bdc238">Artikler </Parent>
+    <Path>/Artikler/TestfixturFiendtligInnhold</Path>
+    <Trashed>false</Trashed>
+    <ContentType>artikkel</ContentType>
+    <CreateDate>2026-08-13T09:00:00</CreateDate>
+    <NodeName Default="Testfixtur: fiendtlig innhold" />
+    <SortOrder>902</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template />
+  </Info>
+  <Properties>
+    <tittel>
+      <Value><![CDATA[Testfixtur med en ekstremt lang tittel som bare fortsetter og fortsetter forbi enhver rimelig kolonnebredde for å se hva som skjer med ombrekking, avkorting og korthøyder i lister og på selve artikkelsiden]]></Value>
+    </tittel>
+    <ingress>
+      <Value><![CDATA[Emoji 🇳🇴👩🏽‍💻🧑‍🚀 · kombinerende tegn é vs é · norsk æøå ÆØÅ · nynorsk ikkje · samisk čŧšžđŋ · RTL العربية · nullbredde​​tegn · hardt mellomrom her · anførselstegn «» ”” · tankestrek – og —]]></Value>
+    </ingress>
+    <bakgrunn>
+      <Value><![CDATA[{
+  "label": "Brand 1",
+  "value": "#dfc2d4"
+}]]></Value>
+    </bakgrunn>
+    <slug>
+      <Value><![CDATA[testfixtur-fiendtlig-innhold]]></Value>
+    </slug>
+    <seoTittel>
+      <Value><![CDATA[Testfixtur med en ekstremt lang tittel som bare fortsetter og fortsetter forbi enhver rimelig kolonnebredde for å se hva som skjer med ombrekking, avkorting og korthøyder i lister og på selve artikkelsiden]]></Value>
+    </seoTittel>
+    <seoBeskrivelse>
+      <Value><![CDATA[Emoji 🇳🇴👩🏽‍💻🧑‍🚀 · kombinerende tegn é vs é · norsk æøå ÆØÅ · nynorsk ikkje · samisk čŧšžđŋ · RTL العربية · nullbredde​​tegn · hardt mellomrom her · anførselstegn «» ”” · tankestrek – og —]]></Value>
+    </seoBeskrivelse>
+    <innhold>
+      <Value><![CDATA[{
+  "contentData": [
+    {
+      "contentTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e",
+      "key": "7e57f1c0-0003-4000-8000-000000000001",
+      "values": [
+        {
+          "alias": "innhold",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Rå HTML som en redaktør kan lime inn fra Word eller Teams:</p><p><span style=\"caret-color: rgb(0,0,0); font-weight: 400;\">Avsnitt med inline-stiler.</span></p><script>alert('dette skal ikke kjøre')</script><iframe src=\"https://example.com\"></iframe><table><tr><td>Tabell</td><td>uten thead</td></tr></table><ul><li>Liste<ul><li>nøstet<ul><li>tre nivåer</li></ul></li></ul></li></ul><p>Tomt avsnitt følger.</p><p></p><p>&nbsp;</p>"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "c5ddaf44-3abe-41a7-8b47-e1b82c66d95e",
+      "key": "7e57f1c0-0003-4000-8000-000000000002",
+      "values": [
+        {
+          "alias": "innhold",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. Veldig langt avsnitt uten linjeskift. </p>"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "f6e6bb2f-ea53-4462-8a15-ea4382de55f0",
+      "key": "7e57f1c0-0003-4000-8000-000000000003",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Emoji 🇳🇴👩🏽‍💻🧑‍🚀 · kombinerende tegn é vs é · norsk æøå ÆØÅ · nynorsk ikkje · samisk čŧšžđŋ · RTL العربية · nullbredde​​tegn · hardt mellomrom her · anførselstegn «» ”” · tankestrek – og —"
+        },
+        {
+          "alias": "innhold",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Emoji 🇳🇴👩🏽‍💻🧑‍🚀 · kombinerende tegn é vs é · norsk æøå ÆØÅ · nynorsk ikkje · samisk čŧšžđŋ · RTL العربية · nullbredde​​tegn · hardt mellomrom her · anførselstegn «» ”” · tankestrek – og —</p>"
+          }
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "d8b6c846-e796-4e70-afd3-2ca356a0990b",
+      "key": "7e57f1c0-0003-4000-8000-000000000004",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "navn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "Emoji 🇳🇴👩🏽‍💻🧑‍🚀 · kombinerende tegn é vs é · norsk æøå ÆØÅ · nynorsk ikkje · samisk čŧšžđŋ · RTL العربية · nullbredde​​tegn · hardt mellomrom her · anførselstegn «» ”” · tankestrek – og —"
+        },
+        {
+          "alias": "stilling",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "virksomhet",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "epost",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "ikke-en-epost"
+        },
+        {
+          "alias": "telefon",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "+47 (0)22 00 00 00 ext. 1234"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "4b3cac2f-623b-46ac-a3d4-8caf0276fdf1",
+      "key": "7e57f1c0-0003-4000-8000-000000000005",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "tekst",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "blocks": {
+              "contentData": [],
+              "settingsData": [],
+              "expose": [],
+              "layout": {}
+            },
+            "markup": "<p>Fremheving uten tittel, uten bilde, med begge brytere på.</p>"
+          }
+        },
+        {
+          "alias": "kilde",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "visAnforselstegn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "1"
+        },
+        {
+          "alias": "visBakgrunn",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "contentTypeKey": "250deaaf-6798-41f2-a4c4-4e2a2fc23de2",
+      "key": "7e57f1c0-0003-4000-8000-000000000006",
+      "values": [
+        {
+          "alias": "tittel",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": ""
+        },
+        {
+          "alias": "steg",
+          "culture": null,
+          "editorAlias": null,
+          "segment": null,
+          "value": {
+            "contentData": [
+              {
+                "contentTypeKey": "60a48165-34ef-47b7-a43c-87f214ad29de",
+                "key": "7e57f1c0-0003-4000-8000-000000000061",
+                "values": [
+                  {
+                    "alias": "tittel",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": ""
+                  },
+                  {
+                    "alias": "beskrivelse",
+                    "culture": null,
+                    "editorAlias": null,
+                    "segment": null,
+                    "value": {
+                      "blocks": {
+                        "contentData": [],
+                        "settingsData": [],
+                        "expose": [],
+                        "layout": {}
+                      },
+                      "markup": "<p>Steg uten tittel.</p>"
+                    }
+                  }
+                ]
+              }
+            ],
+            "settingsData": [],
+            "expose": [
+              {
+                "contentKey": "7e57f1c0-0003-4000-8000-000000000061",
+                "culture": null,
+                "segment": null
+              }
+            ],
+            "layout": {
+              "Umbraco.BlockList": [
+                {
+                  "contentKey": "7e57f1c0-0003-4000-8000-000000000061",
+                  "contentUdi": null,
+                  "settingsKey": null,
+                  "settingsUdi": null
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "settingsData": [],
+  "expose": [
+    {
+      "contentKey": "7e57f1c0-0003-4000-8000-000000000001",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0003-4000-8000-000000000002",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0003-4000-8000-000000000003",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0003-4000-8000-000000000004",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0003-4000-8000-000000000005",
+      "culture": null,
+      "segment": null
+    },
+    {
+      "contentKey": "7e57f1c0-0003-4000-8000-000000000006",
+      "culture": null,
+      "segment": null
+    }
+  ],
+  "layout": {
+    "Umbraco.BlockList": [
+      {
+        "contentKey": "7e57f1c0-0003-4000-8000-000000000001",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0003-4000-8000-000000000002",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0003-4000-8000-000000000003",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0003-4000-8000-000000000004",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0003-4000-8000-000000000005",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      },
+      {
+        "contentKey": "7e57f1c0-0003-4000-8000-000000000006",
+        "contentUdi": null,
+        "settingsKey": null,
+        "settingsUdi": null
+      }
+    ]
+  }
+}]]></Value>
+    </innhold>
+  </Properties>
+</Content>

--- a/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-minimal.config
+++ b/apps/cms-umbraco/uSync-testinnhold/v17/Content/testfixtur-minimal.config
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="7e57f1c0-0002-4000-8000-000000000000" Alias="Testfixtur: minimal" Level="2">
+  <Info>
+    <Parent Key="cadd506a-4470-4f3d-9a66-3a4369bdc238">Artikler </Parent>
+    <Path>/Artikler/TestfixturMinimal</Path>
+    <Trashed>false</Trashed>
+    <ContentType>artikkel</ContentType>
+    <CreateDate>2026-08-13T09:00:00</CreateDate>
+    <NodeName Default="Testfixtur: minimal" />
+    <SortOrder>901</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template />
+  </Info>
+  <Properties>
+    <tittel>
+      <Value><![CDATA[Testfixtur: minimal]]></Value>
+    </tittel>
+    <ingress>
+      <Value><![CDATA[Bare påkrevde felt utfylt. Alt valgfritt står tomt, inkludert innhold, toppbilde, slug og alle SEO-felt.]]></Value>
+    </ingress>
+    <bakgrunn>
+      <Value><![CDATA[{
+  "label": "Brand 1",
+  "value": "#dfc2d4"
+}]]></Value>
+    </bakgrunn>
+  </Properties>
+</Content>

--- a/scripts/last-testfixturer-tt02.sh
+++ b/scripts/last-testfixturer-tt02.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Laster testfixturene i apps/cms-umbraco/uSync-testinnhold inn i tt02.
+#
+# Fixturene er artikler som presser skjemaet: alle blokktyper på én gang,
+# bare påkrevde felt, fiendtlige strenger, og brutte referanser. De ligger i
+# git nettopp fordi løse testnoder i et delt miljø råtner og blir feid vekk.
+#
+# Scriptet kopierer .config-filene inn i tt02-poddens uSync-mappe. Selve
+# importen gjøres i backoffice, som for all annen uSync-import.
+#
+# Bruk:
+#   scripts/last-testfixturer-tt02.sh              alle fixturer utenom brutte referanser
+#   scripts/last-testfixturer-tt02.sh --alle       ogsaa brutte referanser
+#   scripts/last-testfixturer-tt02.sh --sjekk      vis hva som ville blitt kopiert
+#
+# Krever kubectl med Altinn-VPN. Kjoerer aldri mot prod, se vakten under.
+
+set -euo pipefail
+
+TT02_CTX="${TT02_CTX:-dis-core-tt02-aks}"
+NS="${NS:-product-kinorgeportal}"
+POD="${POD:-deploy/umbraco}"
+CONTAINER="${CONTAINER:-umbraco}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT/apps/cms-umbraco/uSync-testinnhold/v17/Content"
+BRUTTE="testfixtur-brutte-referanser.config"
+
+ALLE=0; SJEKK=0
+for arg in "$@"; do
+  case "$arg" in
+    --alle)            ALLE=1 ;;
+    --sjekk|--dry-run) SJEKK=1 ;;
+    *) echo "Ukjent flagg: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# Fixturene skal aldri naa prod. Prod kan uansett ikke importere innhold
+# (Default-settet er eksport-only), men vi stoler ikke paa det alene.
+case "$TT02_CTX" in
+  *prod*) echo "Nekter aa kjoere mot en prod-kontekst ($TT02_CTX)." >&2; exit 1 ;;
+esac
+
+command -v kubectl >/dev/null || { echo "Fant ikke kubectl i PATH." >&2; exit 1; }
+[ -d "$SRC" ] || { echo "Fant ikke fixturmappa: $SRC" >&2; exit 1; }
+
+filer=()
+while IFS= read -r f; do
+  navn="$(basename "$f")"
+  if [ "$navn" = "$BRUTTE" ] && [ "$ALLE" -eq 0 ]; then continue; fi
+  filer+=("$f")
+done < <(find "$SRC" -name "*.config" | sort)
+
+[ "${#filer[@]}" -gt 0 ] || { echo "Ingen fixturer aa laste." >&2; exit 1; }
+
+echo "Maal:  $TT02_CTX  $NS/$POD:$CONTAINER"
+echo "Filer:"
+for f in "${filer[@]}"; do echo "  $(basename "$f")"; done
+if [ "$ALLE" -eq 0 ]; then
+  echo "  (hopper over $BRUTTE, bruk --alle for aa ta den med)"
+fi
+echo
+
+if [ "$SJEKK" -eq 1 ]; then echo "Sjekk-modus, ingenting kopiert."; exit 0; fi
+
+kubectl --context "$TT02_CTX" -n "$NS" get "$POD" -o name >/dev/null 2>&1 || {
+  echo "Naar ikke tt02 ($TT02_CTX, $NS/$POD). Er Altinn-VPN paa?" >&2; exit 1; }
+
+kubectl --context "$TT02_CTX" -n "$NS" exec "$POD" -c "$CONTAINER" -- \
+  mkdir -p /app/uSync/v17/Content
+
+for f in "${filer[@]}"; do
+  kubectl --context "$TT02_CTX" -n "$NS" exec -i "$POD" -c "$CONTAINER" -- \
+    sh -c "cat > /app/uSync/v17/Content/$(basename "$f")" < "$f"
+  echo "  kopiert $(basename "$f")"
+done
+
+echo
+echo "Ferdig. Neste steg: Import i tt02-backoffice (Settings -> uSync -> Import, sett Speiling, aldri Clean)."


### PR DESCRIPTION
Fire artikler som uSync Content-filer i `apps/cms-umbraco/uSync-testinnhold/`, lastet inn i tt02 med `scripts/last-testfixturer-tt02.sh`. Import gjøres i backoffice som for all annen uSync-import.

| Fixtur | Tester |
|---|---|
| alle-moduler | Hver av de 8 blokktypene `artikkel.innhold` tillater, i én artikkel |
| minimal | Bare påkrevde felt, alt valgfritt tomt |
| fiendtlig-innhold | Lang tittel, emoji, RTL, nullbredde-tegn, rå HTML fra Word/Teams, script- og iframe-tagger, nøstede lister, ugyldig e-post |
| brutte-referanser | Mediepeker og lenke til nøkler som ikke finnes |

Fixturene ligger i git fordi forrige generasjon lå løst i tt02: de mistet blokkene sine ved re-nøklingen 5. august uten at noen merket det, og ble slettet 13. august fordi de så ut som rot.

Brutte referanser lastes bare med `--alle`. Vi vet at én ødelagt property i en Block List kan gi HTTP 500 på hele Delivery API-responsen, ikke bare den ene noden, så den fixturen kan ta ned tt02s API til noden slettes.

Nøklene starter med `7e57f1c0` og kan ikke kollidere med ekte innhold. Scriptet nekter å kjøre mot en prod-kontekst, og prod kan uansett ikke importere innhold siden `Default`-settet er eksport-only.

Verifisert at filene lander bit-identisk i tt02-podden.