### PR TITLE
fix(frontend): veiledningens tekstspalte er 648px, skal være 680

### DIFF
--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -163,8 +163,11 @@ if (guideData) {
     line-height: var(--ds-body-lg-line-height);
   }
 
+  /* data-layout-block="content" gir border-box og padding-inline, så en naken
+     max-width: 680px ble en tekstspalte på 648. Legg til paddingen for å treffe
+     de 680 artikkel-, eksempel- og stegsidene bruker. */
   .article-page {
-    max-width: 680px;
+    max-width: calc(680px + 2 * var(--layout-content-padding));
     margin-inline: auto;
   }
 


### PR DESCRIPTION
`.article-page` på veiledningssiden er skrevet som `max-width: 680px`, men elementet har også `data-layout-block="content"`, som setter `box-sizing: border-box` og `padding-inline: 16px`. De 680 inkluderer da paddingen, og tekstspalten blir 648.

Målt på ki.norge.no i 1440px bredde:

| Side | Tekstspalte |
|---|---|
| Artikkel | 680 |
| Eksempel | 680 |
| Veiledning, stegside | 680 |
| Veiledning, guide | **648** |

Guide-siden er alene om å være smalere. Forfatteren skrev 680 og fikk 648.

Løst ved å legge paddingen inn i `max-width` i stedet for å hardkode 712, så tallet følger `--layout-content-padding` hvis det endres.

## Verifisert

Dev-server mot prod-CMS, målt i seks bredder.

| Viewport | Tekstspalte før | Etter |
|---|---|---|
| 1440 | 648 | 680 |
| 1200 | 648 | 680 |
| 1024 | 648 | 680 |
| 900 | 648 | 680 |
| 600 | 568 | 568 |
| 375 | 343 | 343 |

Under cirka 712px er containeren uansett begrenset av viewporten, så mobil er uendret. Artikkelsiden i samme bygg måler fortsatt 680, altså er de like nå.

149/149 enhetstester passerer.