### PR TITLE
fix(frontend): tittel og ingress på samme kant som brødteksten i veiledning

### DIFF
--- a/apps/frontend/src/pages/veiledning/[guide].astro
+++ b/apps/frontend/src/pages/veiledning/[guide].astro
@@ -125,7 +125,7 @@ if (guideData) {
   </Layout>
 ) : guideData && guideCtx ? (
   <Layout title={guideCtx.seoTitle} description={guideCtx.seoDesc} ogImage={guideData.seoBilde?.url} bodyColor="brand1">
-    <div class="guide-header">
+    <div class="guide-header" data-layout-block="content">
       <h1 class="ds-heading" data-size="xl">{guideData.tittel}</h1>
       {guideData.ingress && <p class="guide-ingress">{guideData.ingress}</p>}
     </div>
@@ -147,28 +147,25 @@ if (guideData) {
 
 <style>
 
+  /* Tittel, ingress og brødtekst deler spalte, slik artikkel- og
+     eksempelsidene gjør det. max-width teller med paddingen fra
+     data-layout-block="content", derfor calc og ikke naken 680. */
+  .guide-header,
+  .article-page {
+    max-width: calc(680px + 2 * var(--layout-content-padding));
+  }
+
   .guide-header {
     display: flex;
     flex-direction: column;
     gap: var(--ds-size-3);
     margin-block-end: var(--ds-size-8);
-    max-width: 1000px;
-    margin-inline: auto;
-    padding-inline: var(--ds-size-4);
   }
 
   .guide-ingress {
     margin: 0;
     font-size: var(--ds-body-lg-font-size);
     line-height: var(--ds-body-lg-line-height);
-  }
-
-  /* data-layout-block="content" gir border-box og padding-inline, så en naken
-     max-width: 680px ble en tekstspalte på 648. Legg til paddingen for å treffe
-     de 680 artikkel-, eksempel- og stegsidene bruker. */
-  .article-page {
-    max-width: calc(680px + 2 * var(--layout-content-padding));
-    margin-inline: auto;
   }
 
   .article-hero:has(.article-hero-image) {

--- a/apps/frontend/src/pages/veiledning/[guide]/[step].astro
+++ b/apps/frontend/src/pages/veiledning/[guide]/[step].astro
@@ -80,10 +80,14 @@ const steps = Array.from(stepMap.entries()).map(([num, data]) => ({
     margin-block-end: var(--ds-size-6);
   }
 
+  /* Brødsmule, tittel, piller og brødtekst deler spalte. Før lå de tre første
+     i 1050-containeren mens brødteksten var sentrert i 680, med 169px sprik. */
+  .step-page {
+    max-width: calc(680px + 2 * var(--layout-content-padding));
+  }
+
   .step-content {
-    max-width: 680px;
-    margin-inline: auto;
-    margin-block-start: var(--ds-size-18); 
+    margin-block-start: var(--ds-size-18);
 
     & :global(h2), & :global(h3) {
       font-family: var(--ds-font-family);


### PR DESCRIPTION
Veiledningssidene hadde overskriften i én ramme og brødteksten i en annen.

Guide-siden brukte en hardkodet `max-width: 1000px` på `.guide-header`, et tall som ikke finnes noe annet sted i kodebasen, mens brødteksten lå sentrert i 680. Stegsiden hadde samme problem med containeren på 1050 mot 680.

Målt på ki.norge.no i 1440px bredde:

| Side | Overskrift | Brødtekst | Sprik |
|---|---|---|---|
| Guide | v=220 | v=396 | 176px |
| Steg | v=211 | v=380 | 169px |

Begge sider bruker nå samme spalte til alt, slik artikkel- og eksempelsidene allerede gjør via `article-layout`. Der ligger tittel og brødtekst begge på 476.

## Verifisert

Dev-server mot prod-CMS. Venstrekant og bredde for hvert element.

Guide-siden:

| Viewport | Tittel | Ingress | Brødtekst | Stegvelger |
|---|---|---|---|---|
| 1440 | 380 / 680 | 380 / 680 | 380 / 680 | 380 / 680 |
| 1200 | 260 / 680 | 260 / 680 | 260 / 680 | 260 / 680 |
| 1024 | 172 / 680 | 172 / 680 | 172 / 680 | 172 / 680 |
| 900 | 110 / 680 | 110 / 680 | 110 / 680 | 110 / 680 |
| 375 | 16 / 343 | 16 / 343 | 16 / 343 | 16 / 343 |

Stegsiden får samme tall, inkludert brødsmule og pillerad.

149/149 enhetstester passerer.

## Merk

Pillene på stegsiden går fra én til to rader siden spalten er smalere. De skal uansett bygges om til en scrollbar rad.