### PR TITLE
feat(usync): varig uSync-mappe og innholdsimport ved boot i tt02

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2,8 +2,11 @@
 # Smoke test: hit every public frontend URL + critical Delivery API endpoints,
 # fail loud on non-2xx or empty body. Run after deploys, optionally in CI.
 #
-# Usage: bash scripts/smoke-test.sh [--prod | --local]
+# Usage: bash scripts/smoke-test.sh [--prod | --tt02 | --local]
 #   --prod (default): tests https://ki-norge-frontend... and the prod CMS
+#   --tt02:            tests ki.test.norge.no + tt02-CMS, krever Altinn-VPN.
+#                      Kjor denne etter en speiling: check_blocks fanger innhold
+#                      som har falt til Unsupported paa vei over.
 #   --local:           tests http://localhost:4321 + http://localhost:5000
 
 set -uo pipefail
@@ -13,6 +16,10 @@ MODE="${1:---prod}"
 if [ "$MODE" = "--local" ]; then
   FRONTEND="http://localhost:4321"
   CMS="http://localhost:5000"
+elif [ "$MODE" = "--tt02" ]; then
+  FRONTEND="https://ki.test.norge.no"
+  # Ingen proxy foran tt02, saa denne modusen gaar bare over Altinn-VPN.
+  CMS="https://kinorgeportal.tt02.dis-core.altinn.cloud"
 else
   FRONTEND="https://ki-norge-frontend-prod.digitaliseringsdirektoratet.workers.dev"
   # Proxy-hosten, ikke dis-core direkte: dis-core krever Altinn-VPN og er derfor

--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -64,6 +64,13 @@ spec:
           volumeMounts:
             - name: umbraco-data
               mountPath: /app/umbraco/Data
+            # uSync-mappa ligger ellers paa containerens skrivelag og forsvinner ved
+            # hver restart. Skjemaet taaler det (ContentTypes/DataTypes bakes inn i
+            # imaget og er tilbake ved boot), men innholdseksporten gjoer ikke det.
+            # Gjenbruker umbraco-data via subPath, saa ingen ny PVC trengs.
+            - name: umbraco-data
+              mountPath: /app/uSync/v17/Content
+              subPath: uSync-content
             - name: umbraco-media
               mountPath: /app/wwwroot/media
             - name: umbraco-logs

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -62,13 +62,16 @@ patches:
           name: USYNC_OWNS_SCHEMA
           value: "true"
       # Naar uSync eier skjemaet maa noe reconcilere det mot filene ved oppstart,
-      # slik composeren gjorde. Kun Settings-gruppa: innhold og media er
-      # eksport-only i settet, saa de hoppes over uansett.
+      # slik composeren gjorde. Content er med i tillegg fordi tt02 skal speile
+      # prod: innholdsmappa er varig (subPath i base-deploymentet), saa hver boot
+      # legger siste transporterte prod-snapshot tilbake. Bivirkning: det som
+      # redigeres i tt02-backoffice nullstilles ved neste restart. Skal tt02
+      # heller vaere et sted aa proeve ting, sett denne tilbake til Settings.
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: uSync__Settings__ImportAtStartup
-          value: Settings
+          value: Settings,Content
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
`/app/uSync` lå på containerens skrivelag og forsvant ved hver restart. Skjemaet tålte det, siden `ContentTypes` og `DataTypes` bakes inn i imaget og er tilbake ved boot, men innholdseksporten gjorde ikke det. Derfor måtte en speiling gjøres om igjen fra bunnen hver gang en pod startet.

**Persistens uten ny infrastruktur.** `umbraco-data` monteres på nytt med `subPath` i base-deploymentet. Samme claim som deploymentet allerede bruker, så ingen ny PVC, storage-konto eller blob-provider. Bare innholdsmappa blir varig; skjemaet fortsetter å komme fra imaget.

**tt02 importerer Content ved oppstart** i tillegg til Settings. Med varig innholdsmappe legger hver boot siste transporterte prod-snapshot tilbake. Bivirkning er at redigering i tt02-backoffice nullstilles ved restart. Det er én ordendring å reversere, og avveiningen står som kommentar der verdien settes.

**`smoke-test.sh --tt02`** kjører de samme sjekkene mot ki.test.norge.no og tt02-CMS-et, så `check_blocks` kan brukes som etterkontroll av en speiling. Krever Altinn-VPN, siden tt02 ikke har noen offentlig proxy.

`kubectl kustomize` rendrer riktig for begge miljø: mounten er med i begge, `ImportAtStartup` er `Settings` i prod og `Settings,Content` i tt02.

Kjørt mot tt02, alle 15 sjekker passerer:

```
PASS  Artikkelblokker har contentType  (26 blokker, alle med contentType)
PASS  Eksempelblokker har contentType  (28 blokker, alle med contentType)
```